### PR TITLE
chore(deps): constrain incompatible updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # These releases require compileSdk 37 and Android Gradle Plugin 9.1.
+      # Remove the ceilings when the Android toolchain is upgraded together.
+      - dependency-name: "com.mikepenz:multiplatform-markdown-renderer"
+        versions: ["[0.43,0.44)"]
+      - dependency-name: "com.mikepenz:multiplatform-markdown-renderer-m3"
+        versions: ["[0.43,0.44)"]
+      - dependency-name: "org.jetbrains.compose.material3:material3"
+        versions: ["[1.12.0-alpha01,1.13)"]
     open-pull-requests-limit: 5
   - package-ecosystem: cargo
     directory: /


### PR DESCRIPTION
## Summary

- constrain the markdown renderer 0.43 line while it requires compile SDK 37 and Android Gradle Plugin 9.1
- constrain the Compose Material 3 1.12 line for the same toolchain incompatibility
- keep Dependabot enabled for all other Gradle, Cargo, and GitHub Actions updates

## Why

Dependabot opened three updates that cannot build with the repository's supported compile SDK 36 and Android Gradle Plugin 8.13.2 toolchain. These narrow Maven ranges prevent repeated red pull requests without hiding future update lines after the coordinated Android toolchain upgrade.

## Validation

- parsed `.github/dependabot.yml` as YAML
- `bash tools/check-repository.sh`
- `git diff --check`

Relates to #103.