### PR TITLE
fix(android): apply suggested media folders directly

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
@@ -71,8 +71,8 @@ internal class AndroidFileSyncEngine(context: Context) {
         remoteRootPath: String,
         configuration: FileSyncConfiguration,
     ): FileSyncCenterActionResult = synchronized(ENGINE_LOCK) {
-        // Constructing the adapter verifies that the durable read/write grant still exists.
-        AndroidFileSyncLocalTree(appContext.contentResolver, localRoot.localRootId)
+        // Constructing the adapter verifies that its persisted SAF grant or detected media root is usable.
+        createAndroidFileSyncLocalTree(appContext.contentResolver, localRoot.localRootId)
         val normalizedRemote = normalizeRemoteRoot(remoteRootPath)
         val accountId = NextcloudDocumentIds.accountKey(session)
         val current = store.load()
@@ -132,7 +132,10 @@ internal class AndroidFileSyncEngine(context: Context) {
                     localDisplayNames = current.localDisplayNames - pairId,
                 ),
             )
-            if (remaining.pairs.none { it.localRootId == pair.localRootId }) {
+            if (
+                pair.localRootId.startsWith("content://") &&
+                remaining.pairs.none { it.localRootId == pair.localRootId }
+            ) {
                 runCatching {
                     appContext.contentResolver.releasePersistableUriPermission(
                         Uri.parse(pair.localRootId),
@@ -166,7 +169,7 @@ internal class AndroidFileSyncEngine(context: Context) {
             .asSequence()
             .filter { it.kind == SyncEntryKind.File && it.contentHash != null }
             .mapTo(mutableSetOf()) { it.relativePath }
-        val local = AndroidFileSyncLocalTree(
+        val local = createAndroidFileSyncLocalTree(
             appContext.contentResolver,
             initialPair.localRootId,
             contentHashPaths,

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncLocalTree.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncLocalTree.kt
@@ -18,17 +18,26 @@ internal data class AndroidLocalSyncDocument(
     val displayName: String,
 )
 
+internal interface AndroidFileSyncLocalTree {
+    fun scan(): List<AndroidLocalSyncDocument>
+    fun stageForUpload(path: String, destination: File, maximumBytes: Long): LocalSyncEntry
+    fun createDirectory(path: String, expectedLocalRevision: String?)
+    fun writeFile(path: String, source: File, expectedLocalRevision: String?)
+    fun delete(path: String, expectedLocalRevision: String)
+    fun resolve(path: String): AndroidLocalSyncDocument?
+}
+
 /**
  * Revision-guarded adapter over one persisted Storage Access Framework tree.
  *
  * Downloads are staged as siblings. Existing content is renamed to a recovery backup before the
  * staged generation takes its name, so interruption never silently truncates the user's file.
  */
-internal class AndroidFileSyncLocalTree(
+internal class AndroidSafFileSyncLocalTree(
     private val resolver: ContentResolver,
     rootId: String,
     private val contentHashPaths: Set<String> = emptySet(),
-) {
+) : AndroidFileSyncLocalTree {
     private val treeUri = Uri.parse(rootId)
     private val rootDocumentId = DocumentsContract.getTreeDocumentId(treeUri)
     private val rootUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, rootDocumentId)
@@ -42,7 +51,7 @@ internal class AndroidFileSyncLocalTree(
         ) { "Access to the selected local folder has expired. Select it again." }
     }
 
-    fun scan(): List<AndroidLocalSyncDocument> {
+    override fun scan(): List<AndroidLocalSyncDocument> {
         val result = ArrayList<AndroidLocalSyncDocument>()
         val pending = ArrayDeque<Pair<String, Uri>>()
         pending += "" to rootUri
@@ -60,7 +69,7 @@ internal class AndroidFileSyncLocalTree(
         return result.sortedBy { it.entry.relativePath }
     }
 
-    fun stageForUpload(path: String, destination: File, maximumBytes: Long): LocalSyncEntry {
+    override fun stageForUpload(path: String, destination: File, maximumBytes: Long): LocalSyncEntry {
         val document = requireNotNull(resolve(path)) { "The local file no longer exists." }
         require(document.entry.kind == SyncEntryKind.File) { "Only files can be uploaded as file content." }
         require((document.entry.size ?: 0L) <= maximumBytes) { "The local file exceeds the sync size limit." }
@@ -86,7 +95,7 @@ internal class AndroidFileSyncLocalTree(
         return after.entry
     }
 
-    fun createDirectory(path: String, expectedLocalRevision: String?) {
+    override fun createDirectory(path: String, expectedLocalRevision: String?) {
         val existing = resolve(path)
         if (expectedLocalRevision == null) {
             require(existing == null) { "The local folder appeared after the sync scan." }
@@ -107,7 +116,7 @@ internal class AndroidFileSyncLocalTree(
         requireNotNull(created) { "The local folder could not be created." }
     }
 
-    fun writeFile(path: String, source: File, expectedLocalRevision: String?) {
+    override fun writeFile(path: String, source: File, expectedLocalRevision: String?) {
         require(source.isFile)
         val current = resolve(path)
         if (expectedLocalRevision == null) {
@@ -155,7 +164,7 @@ internal class AndroidFileSyncLocalTree(
         }
     }
 
-    fun delete(path: String, expectedLocalRevision: String) {
+    override fun delete(path: String, expectedLocalRevision: String) {
         val current = requireNotNull(resolve(path)) { "The local item was already removed." }
         require(current.entry.revision == expectedLocalRevision) {
             "The local item changed after the sync scan."
@@ -165,7 +174,7 @@ internal class AndroidFileSyncLocalTree(
         }
     }
 
-    fun resolve(path: String): AndroidLocalSyncDocument? {
+    override fun resolve(path: String): AndroidLocalSyncDocument? {
         if (path.isBlank()) return null
         var parentPath = ""
         var parentUri = rootUri

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
@@ -1,0 +1,250 @@
+package dev.obiente.nextcloudnative
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.os.Environment
+import dev.obiente.nextcloudnative.app.LocalSyncEntry
+import dev.obiente.nextcloudnative.app.SyncEntryKind
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.util.UUID
+
+internal fun createAndroidFileSyncLocalTree(
+    resolver: ContentResolver,
+    rootId: String,
+    contentHashPaths: Set<String> = emptySet(),
+): AndroidFileSyncLocalTree =
+    if (rootId.startsWith(MEDIA_STORE_SYNC_ROOT_PREFIX)) {
+        AndroidMediaStoreSyncLocalTree(
+            root = resolveMediaStoreSyncRoot(rootId, Environment.getExternalStorageDirectory()),
+            contentHashPaths = contentHashPaths,
+        )
+    } else {
+        AndroidSafFileSyncLocalTree(resolver, rootId, contentHashPaths)
+    }
+
+internal fun resolveMediaStoreSyncRoot(rootId: String, externalStorageRoot: File): File {
+    require(rootId.startsWith(MEDIA_STORE_SYNC_ROOT_PREFIX)) {
+        "The local sync root is not a detected MediaStore folder."
+    }
+    val relativePath = normalizeMediaStoreRelativePath(rootId.removePrefix(MEDIA_STORE_SYNC_ROOT_PREFIX))
+    val storageRoot = externalStorageRoot.canonicalFile
+    val folder = File(storageRoot, relativePath).canonicalFile
+    require(folder.toPath().startsWith(storageRoot.toPath()) && folder != storageRoot) {
+        "The detected media folder is outside shared storage."
+    }
+    require(folder.isDirectory) { "The detected media folder no longer exists." }
+    require(folder.canRead()) { "The detected media folder is not readable." }
+    return folder
+}
+
+/**
+ * Direct shared-storage adapter for folders already discovered through MediaStore.
+ *
+ * It avoids a redundant SAF browser while constraining every root to primary shared storage.
+ */
+internal class AndroidMediaStoreSyncLocalTree(
+    private val root: File,
+    private val contentHashPaths: Set<String> = emptySet(),
+) : AndroidFileSyncLocalTree {
+    init {
+        require(root.isDirectory && root.canRead()) { "The detected media folder is unavailable." }
+    }
+
+    override fun scan(): List<AndroidLocalSyncDocument> {
+        val result = ArrayList<AndroidLocalSyncDocument>()
+        val pending = ArrayDeque<Pair<String, File>>()
+        pending += "" to root
+        while (pending.isNotEmpty()) {
+            val (parentPath, parent) = pending.removeFirst()
+            require(parentPath.count { it == '/' } < MAX_DEPTH) { "The local folder is nested too deeply." }
+            val children = parent.listFiles()
+                ?.asSequence()
+                ?.filter { it.name.isSafeLocalName() }
+                ?.sortedBy { it.name.lowercase() }
+                ?.toList()
+                .orEmpty()
+            for (child in children) {
+                require(result.size < MAX_ENTRIES) { "The local folder contains too many entries." }
+                val path = if (parentPath.isBlank()) child.name else "$parentPath/${child.name}"
+                val document = child.toSyncDocument(path)
+                result += document
+                if (document.entry.kind == SyncEntryKind.Directory) pending += path to child
+            }
+        }
+        return result.sortedBy { it.entry.relativePath }
+    }
+
+    override fun stageForUpload(path: String, destination: File, maximumBytes: Long): LocalSyncEntry {
+        val before = requireNotNull(resolve(path)) { "The local file no longer exists." }
+        require(before.entry.kind == SyncEntryKind.File) { "Only files can be uploaded as file content." }
+        require((before.entry.size ?: 0L) <= maximumBytes) { "The local file exceeds the sync size limit." }
+        FileInputStream(before.uri.toFile()).use { input ->
+            FileOutputStream(destination).use { output ->
+                var copied = 0L
+                val buffer = ByteArray(BUFFER_BYTES)
+                while (true) {
+                    val count = input.read(buffer)
+                    if (count < 0) break
+                    copied += count
+                    require(copied <= maximumBytes) { "The local file exceeds the sync size limit." }
+                    output.write(buffer, 0, count)
+                }
+                output.fd.sync()
+            }
+        }
+        val after = requireNotNull(resolve(path)) { "The local file disappeared while it was read." }
+        require(after.entry.revision == before.entry.revision) {
+            "The local file changed while it was being prepared for upload."
+        }
+        return after.entry
+    }
+
+    override fun createDirectory(path: String, expectedLocalRevision: String?) {
+        val existing = resolve(path)
+        if (expectedLocalRevision != null) {
+            require(existing?.entry?.revision == expectedLocalRevision) {
+                "The local folder changed after the sync scan."
+            }
+            require(existing.entry.kind == SyncEntryKind.Directory)
+            return
+        }
+        require(existing == null) { "The local folder appeared after the sync scan." }
+        val target = safeFile(path)
+        require(target.mkdirs()) { "The local folder could not be created." }
+    }
+
+    override fun writeFile(path: String, source: File, expectedLocalRevision: String?) {
+        require(source.isFile)
+        val current = resolve(path)
+        if (expectedLocalRevision == null) {
+            require(current == null) { "The local file appeared after the sync scan." }
+        } else {
+            require(current?.entry?.revision == expectedLocalRevision) {
+                "The local file changed after the sync scan."
+            }
+            require(current.entry.kind == SyncEntryKind.File) { "The local item changed type." }
+        }
+        val target = safeFile(path)
+        val parent = requireNotNull(target.parentFile)
+        require(parent.isDirectory || parent.mkdirs()) { "A local parent folder could not be created." }
+        val token = UUID.randomUUID().toString()
+        val staged = File(parent, ".${target.name}.nextcloud-native-download-$token")
+        val backup = File(parent, ".${target.name}.nextcloud-native-backup-$token")
+        try {
+            FileInputStream(source).use { input ->
+                FileOutputStream(staged).use { output ->
+                    input.copyTo(output, BUFFER_BYTES)
+                    output.fd.sync()
+                }
+            }
+            if (target.exists()) {
+                require(target.renameTo(backup)) {
+                    "The existing local file could not be protected before replacement."
+                }
+            }
+            require(staged.renameTo(target)) { "The staged local file could not be published." }
+            if (backup.exists()) {
+                require(backup.delete()) { "The replaced local file could not be cleaned up." }
+            }
+        } catch (failure: Throwable) {
+            staged.delete()
+            if (backup.exists() && !target.exists()) backup.renameTo(target)
+            throw failure
+        }
+    }
+
+    override fun delete(path: String, expectedLocalRevision: String) {
+        val current = requireNotNull(resolve(path)) { "The local item was already removed." }
+        require(current.entry.revision == expectedLocalRevision) {
+            "The local item changed after the sync scan."
+        }
+        require(current.uri.toFile().deleteRecursively()) { "The local item could not be removed." }
+    }
+
+    override fun resolve(path: String): AndroidLocalSyncDocument? {
+        if (path.isBlank()) return null
+        val normalized = normalizeRelativeSyncPath(path)
+        val file = safeFile(normalized)
+        if (!file.exists()) return null
+        return file.toSyncDocument(normalized)
+    }
+
+    private fun safeFile(path: String): File {
+        val normalized = normalizeRelativeSyncPath(path)
+        val canonicalRoot = root.canonicalFile
+        val file = File(canonicalRoot, normalized).canonicalFile
+        require(file.toPath().startsWith(canonicalRoot.toPath()) && file != canonicalRoot) {
+            "The local sync path escapes its root."
+        }
+        return file
+    }
+
+    private fun File.toSyncDocument(relativePath: String): AndroidLocalSyncDocument {
+        val kind = if (isDirectory) SyncEntryKind.Directory else SyncEntryKind.File
+        val size = if (kind == SyncEntryKind.File) length().coerceAtLeast(0L) else null
+        return AndroidLocalSyncDocument(
+            entry = LocalSyncEntry(
+                relativePath = relativePath,
+                kind = kind,
+                revision = fileRevision(relativePath, kind, lastModified(), size),
+                size = size,
+                contentHash = if (
+                    kind == SyncEntryKind.File &&
+                    relativePath in contentHashPaths &&
+                    size != null &&
+                    size <= ANDROID_SYNC_CONTENT_IDENTITY_MAX_BYTES
+                ) {
+                    runCatching {
+                        inputStream().use { input ->
+                            sha256SyncContentHash(
+                                input,
+                                expectedBytes = size,
+                                maximumBytes = ANDROID_SYNC_CONTENT_IDENTITY_MAX_BYTES,
+                            )
+                        }
+                    }.getOrNull()
+                } else {
+                    null
+                },
+            ),
+            uri = Uri.fromFile(this),
+            displayName = name,
+        )
+    }
+
+    private fun normalizeRelativeSyncPath(path: String): String {
+        val segments = path.trim('/').split('/')
+        require(segments.isNotEmpty() && segments.size <= MAX_DEPTH)
+        require(segments.all { it.isSafeLocalName() }) { "The local sync path is invalid." }
+        return segments.joinToString("/")
+    }
+
+    private fun String.isSafeLocalName(): Boolean =
+        isNotBlank() &&
+            this !in setOf(".", "..") &&
+            '/' !in this &&
+            '\\' !in this &&
+            none(Char::isISOControl)
+
+    private fun fileRevision(
+        relativePath: String,
+        kind: SyncEntryKind,
+        modified: Long,
+        size: Long?,
+    ): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest("$relativePath\u0000$kind\u0000$modified\u0000${size ?: -1L}".encodeToByteArray())
+        return "file-" + digest.joinToString("") { "%02x".format(it) }
+    }
+
+    private fun Uri.toFile(): File = File(requireNotNull(path))
+
+    private companion object {
+        const val MAX_ENTRIES = 20_000
+        const val MAX_DEPTH = 64
+        const val BUFFER_BYTES = 64 * 1024
+    }
+}

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetector.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetector.kt
@@ -11,8 +11,6 @@ import dev.obiente.nextcloudnative.app.MediaSyncFolderDiscoverySupport
 import dev.obiente.nextcloudnative.app.MediaSyncFolderKind
 import dev.obiente.nextcloudnative.app.MediaSyncFolderSuggestion
 import java.io.File
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 internal data class DetectedMediaFolderItem(
     val relativePath: String,
@@ -102,7 +100,7 @@ internal fun buildMediaSyncFolderSuggestions(
             val kind = classifyMediaSyncFolder(relativePath, imageCount, videoCount)
             val remoteCategory = if (kind == MediaSyncFolderKind.Videos) "Videos" else "Photos"
             MediaSyncFolderSuggestion(
-                localRootHint = externalStorageTreeHint(relativePath),
+                localRootHint = mediaStoreSyncRootId(relativePath),
                 displayName = displayName,
                 relativePath = relativePath,
                 kind = kind,
@@ -143,11 +141,20 @@ private fun MediaSyncFolderKind.sortPriority(): Int = when (this) {
     MediaSyncFolderKind.Videos -> 4
 }
 
-private fun externalStorageTreeHint(relativePath: String): String {
-    val documentId = "primary:$relativePath"
-    val encoded = URLEncoder.encode(documentId, StandardCharsets.UTF_8.name()).replace("+", "%20")
-    return "content://$EXTERNAL_STORAGE_AUTHORITY/tree/$encoded"
+internal fun mediaStoreSyncRootId(relativePath: String): String =
+    MEDIA_STORE_SYNC_ROOT_PREFIX + normalizeMediaStoreRelativePath(relativePath)
+
+internal fun normalizeMediaStoreRelativePath(relativePath: String): String {
+    val segments = relativePath.trim('/').split('/')
+    require(segments.isNotEmpty())
+    require(segments.all { segment ->
+        segment.isNotBlank() &&
+            segment !in setOf(".", "..") &&
+            '\\' !in segment &&
+            segment.none(Char::isISOControl)
+    }) { "The detected media folder path is invalid." }
+    return segments.joinToString("/")
 }
 
-private const val EXTERNAL_STORAGE_AUTHORITY = "com.android.externalstorage.documents"
+internal const val MEDIA_STORE_SYNC_ROOT_PREFIX = "media-store://primary/"
 private const val MAX_MEDIA_FOLDER_SUGGESTIONS = 24

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetectorTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetectorTest.kt
@@ -1,9 +1,10 @@
 package dev.obiente.nextcloudnative
 
 import dev.obiente.nextcloudnative.app.MediaSyncFolderKind
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class AndroidMediaSyncFolderDetectorTest {
     @Test
@@ -23,7 +24,8 @@ class AndroidMediaSyncFolderDetectorTest {
         assertEquals(1, suggestions[0].imageCount)
         assertEquals(1, suggestions[0].videoCount)
         assertEquals("Photos/Camera", suggestions[0].suggestedRemoteRootPath)
-        assertTrue(suggestions[0].localRootHint.endsWith("primary%3ADCIM%2FCamera"))
+        assertEquals("media-store://primary/DCIM/Camera", suggestions[0].localRootHint)
+        assertEquals("Camera", suggestions[0].localRoot.displayName)
     }
 
     @Test
@@ -34,5 +36,20 @@ class AndroidMediaSyncFolderDetectorTest {
 
         assertEquals(MediaSyncFolderKind.Videos, suggestion.kind)
         assertEquals("Videos/Clips", suggestion.suggestedRemoteRootPath)
+    }
+
+    @Test
+    fun mediaStoreRootResolutionStaysInsideSharedStorage() {
+        val storage = Files.createTempDirectory("media-root-").toFile()
+        val camera = storage.resolve("DCIM/Camera")
+        camera.mkdirs()
+
+        assertEquals(
+            camera.canonicalFile,
+            resolveMediaStoreSyncRoot("media-store://primary/DCIM/Camera", storage),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            resolveMediaStoreSyncRoot("media-store://primary/DCIM/../Secrets", storage)
+        }
     }
 }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
@@ -232,16 +232,8 @@ internal fun FileOfflineCenterScreen(
                         },
                         onOpenMediaSuggestion = { suggestion ->
                             if (syncBusyPairId == null) {
-                                scope.launch {
-                                    runCatching {
-                                        services.chooseFileSyncLocalRoot(suggestion.localRootHint)
-                                    }.onSuccess { selected ->
-                                        pendingMediaSuggestion = suggestion
-                                        pendingLocalRoot = selected
-                                    }.onFailure { failure ->
-                                        actionMessage = failure.message ?: "Could not select this media folder."
-                                    }
-                                }
+                                pendingMediaSuggestion = suggestion
+                                pendingLocalRoot = suggestion.localRoot
                             }
                         },
                         onRequestMediaPermission = {
@@ -553,7 +545,7 @@ private fun MediaFolderSuggestions(
             } else {
                 Text("Suggested media folders", style = MaterialTheme.typography.labelLarge)
                 Text(
-                    "Choose a detected folder to prefill a safe upload-only sync. Android will ask you to confirm access.",
+                    "Choose a detected folder to review a prefilled, upload-only sync.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -752,7 +744,7 @@ private fun AddFolderSyncDialog(
                 modifier = Modifier.heightIn(max = 560.dp).verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
             ) {
-                Text("Local folder: ${localRoot.displayName}")
+                Text("Local folder: ${mediaSuggestion?.relativePath ?: localRoot.displayName}")
                 OutlinedTextField(
                     value = remotePath,
                     onValueChange = { remotePath = it },

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt
@@ -36,10 +36,10 @@ enum class MediaSyncFolderKind {
 }
 
 /**
- * A platform-discovered local media folder that can seed the native folder picker.
+ * A platform-discovered local media folder that can be proposed without another folder browser.
  *
- * [localRootHint] is opaque outside the platform implementation. It is not a persisted grant and
- * must never be used for sync until the user confirms it in the system folder picker.
+ * [localRootHint] is an opaque platform-owned sync root. Common code may pass it back to the
+ * platform, but must never interpret it as a path.
  */
 data class MediaSyncFolderSuggestion(
     val localRootHint: String,
@@ -57,6 +57,9 @@ data class MediaSyncFolderSuggestion(
         require(imageCount >= 0 && videoCount >= 0 && imageCount + videoCount > 0)
         requireValidSyncPath(suggestedRemoteRootPath)
     }
+
+    val localRoot: FileSyncLocalRoot
+        get() = FileSyncLocalRoot(localRootHint, displayName)
 }
 
 data class MediaSyncFolderDiscovery(

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenterTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenterTest.kt
@@ -5,6 +5,24 @@ import kotlin.test.assertEquals
 
 class FileSyncCenterTest {
     @Test
+    fun `media suggestion exposes its detected root directly`() {
+        val suggestion = MediaSyncFolderSuggestion(
+            localRootHint = "media-store://primary/DCIM/Camera",
+            displayName = "Camera",
+            relativePath = "DCIM/Camera",
+            kind = MediaSyncFolderKind.Camera,
+            imageCount = 4,
+            videoCount = 1,
+            suggestedRemoteRootPath = "Photos/Camera",
+        )
+
+        assertEquals(
+            FileSyncLocalRoot("media-store://primary/DCIM/Camera", "Camera"),
+            suggestion.localRoot,
+        )
+    }
+
+    @Test
     fun `summary exposes actionable work counts without leaking the root grant`() {
         val pair = FileSyncPair(
             id = "pair",


### PR DESCRIPTION
Closes #167

## What changed
- open a prefilled in-app sync proposal directly from each detected MediaStore folder
- keep Android’s document-tree picker exclusively for manual folder selection
- add a validated shared-storage adapter so detected roots remain usable by scheduled sync without a redundant SAF prompt
- show the exact detected path and suggested Nextcloud destination before confirmation

## Validation
- `./gradlew --no-daemon :contractAcquisition:test :androidApp:testDebugUnitTest :ui:desktopTest :androidApp:assembleDebug`
- repository hygiene check
- physical Android validation for suggested-folder and manual-folder flows
- no Android runtime crash after entering and leaving either flow