### PR TITLE
feat(media): persist transfer ledger with SQLite

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedger.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedger.kt
@@ -1,0 +1,10 @@
+package dev.obiente.nextcloudnative
+
+import android.content.Context
+import dev.obiente.nextcloudnative.app.MediaBackupLedgerStore
+import java.io.File
+
+internal fun createAndroidMediaBackupLedgerStore(context: Context): MediaBackupLedgerStore =
+    MediaBackupLedgerStore(
+        File(context.applicationContext.noBackupFilesDir, "media-backup-ledger.db").absolutePath,
+    )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ json = "20250517"
 media3 = "1.10.1"
 javafx = "21.0.12"
 jse = "1.1.0"
+sqlite = "2.7.0"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
@@ -31,6 +32,7 @@ jse-spi-vorbis = { module = "io.github.jseproject:jse-spi-vorbis", version.ref =
 jse-spi-opus = { module = "io.github.jseproject:jse-spi-opus", version.ref = "jse" }
 jse-spi-mp3 = { module = "io.github.jseproject:jse-spi-mp3", version.ref = "jse" }
 jse-spi-aac = { module = "io.github.jseproject:jse-spi-aac", version.ref = "jse" }
+androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -68,6 +68,7 @@ kotlin {
             implementation("com.fleeksoft.ksoup:ksoup:0.2.6")
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.androidx.sqlite.bundled)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedger.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedger.kt
@@ -43,6 +43,76 @@ data class MediaBackupReceipt(
     }
 }
 
+enum class MediaBackupTransferState {
+    Pending,
+    Uploading,
+    Failed,
+    Succeeded,
+}
+
+data class MediaBackupLedgerRecord(
+    val accountId: String,
+    val local: LocalMediaObject?,
+    val receipt: MediaBackupReceipt?,
+    val transferState: MediaBackupTransferState,
+    val attemptCount: Int,
+    val updatedAtEpochMillis: Long,
+    val failureMessage: String? = null,
+) {
+    init {
+        require(accountId.isSafeMediaLedgerText(256))
+        require(local != null || receipt != null)
+        require(local == null || receipt == null || local.key == receipt.localKey)
+        require(attemptCount in 0..MAX_MEDIA_BACKUP_ATTEMPTS)
+        require(updatedAtEpochMillis >= 0L)
+        require(failureMessage == null || failureMessage.isSafeMediaLedgerText(1_024))
+        require((transferState == MediaBackupTransferState.Failed) == (failureMessage != null))
+        require(transferState != MediaBackupTransferState.Uploading || local != null)
+        require(transferState != MediaBackupTransferState.Pending || local != null)
+        require(
+            transferState != MediaBackupTransferState.Succeeded ||
+                receipt != null && (local == null || receipt.matches(local)),
+        )
+    }
+
+    val localKey: String
+        get() = local?.key ?: requireNotNull(receipt).localKey
+}
+
+data class MediaBackupLedgerCursor(
+    val updatedAtEpochMillis: Long,
+    val localKey: String,
+) {
+    init {
+        require(updatedAtEpochMillis >= 0L)
+        require(localKey.isSafeMediaLedgerText(2_048))
+    }
+}
+
+data class MediaBackupLedgerPage(
+    val records: List<MediaBackupLedgerRecord>,
+    val nextCursor: MediaBackupLedgerCursor?,
+) {
+    init {
+        require(records.size <= MAX_MEDIA_BACKUP_LEDGER_PAGE_SIZE)
+        require(records.map { it.accountId to it.localKey }.distinct().size == records.size)
+    }
+}
+
+data class MediaBackupLedgerSummary(
+    val pending: Int,
+    val uploading: Int,
+    val failed: Int,
+    val succeeded: Int,
+) {
+    init {
+        require(listOf(pending, uploading, failed, succeeded).all { it >= 0 })
+    }
+
+    val total: Int
+        get() = pending + uploading + failed + succeeded
+}
+
 enum class MediaBackupStatus {
     Pending,
     Uploading,
@@ -93,8 +163,12 @@ fun mediaReclaimEligibility(
     return MediaReclaimEligibility.Eligible(local.size)
 }
 
-private fun MediaBackupReceipt.matches(local: LocalMediaObject): Boolean =
+internal fun MediaBackupReceipt.matches(local: LocalMediaObject): Boolean =
     localKey == local.key && localRevision == local.revision && localSize == local.size
 
 private fun String.isSafeMediaLedgerText(maxLength: Int): Boolean =
     isNotBlank() && length <= maxLength && none(Char::isISOControl)
+
+internal const val MAX_MEDIA_BACKUP_LEDGER_RECORDS_PER_ACCOUNT = 25_000
+internal const val MAX_MEDIA_BACKUP_LEDGER_PAGE_SIZE = 200
+private const val MAX_MEDIA_BACKUP_ATTEMPTS = 1_000

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerStore.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerStore.kt
@@ -1,0 +1,373 @@
+package dev.obiente.nextcloudnative.app
+
+import androidx.sqlite.SQLiteConnection
+import androidx.sqlite.SQLiteStatement
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class MediaBackupLedgerStoreException(message: String, cause: Throwable? = null) :
+    IllegalStateException(message, cause)
+
+/**
+ * Indexed, transactional media transfer ledger shared by Android and desktop.
+ *
+ * A single connection is guarded by [mutex]. The bundled driver keeps SQLite behavior consistent
+ * across supported targets. Pages use a stable `(updated_at, local_key)` cursor so the UI never
+ * needs to materialize a complete upload history.
+ */
+class MediaBackupLedgerStore internal constructor(
+    private val connection: SQLiteConnection,
+    private val maxRecordsPerAccount: Int = MAX_MEDIA_BACKUP_LEDGER_RECORDS_PER_ACCOUNT,
+) {
+    private val mutex = Mutex()
+
+    constructor(databasePath: String) : this(BundledSQLiteDriver().open(databasePath))
+
+    init {
+        require(maxRecordsPerAccount in 1..MAX_MEDIA_BACKUP_LEDGER_RECORDS_PER_ACCOUNT)
+        try {
+            initializeSchema()
+        } catch (failure: Throwable) {
+            connection.close()
+            throw if (failure is MediaBackupLedgerStoreException) {
+                failure
+            } else {
+                MediaBackupLedgerStoreException("Could not open the media backup ledger.", failure)
+            }
+        }
+    }
+
+    suspend fun upsert(record: MediaBackupLedgerRecord) = mutex.withLock {
+        transaction {
+            connection.prepare(UPSERT_RECORD).use { statement ->
+                statement.bindRecord(record)
+                check(!statement.step()) { "Media ledger upsert returned an unexpected row." }
+            }
+            pruneCompletedHistory(record.accountId)
+            check(countRecords(record.accountId) <= maxRecordsPerAccount) {
+                "The media ledger contains too many unfinished transfers for this account."
+            }
+        }
+    }
+
+    suspend fun load(
+        accountId: String,
+        localKey: String,
+    ): MediaBackupLedgerRecord? = mutex.withLock {
+        requireAccountId(accountId)
+        requireLocalKey(localKey)
+        connection.prepare("$SELECT_COLUMNS WHERE account_id = ? AND local_key = ?").use { statement ->
+            statement.bindText(1, accountId)
+            statement.bindText(2, localKey)
+            if (statement.step()) statement.readRecord() else null
+        }
+    }
+
+    suspend fun page(
+        accountId: String,
+        transferState: MediaBackupTransferState? = null,
+        after: MediaBackupLedgerCursor? = null,
+        limit: Int = 50,
+    ): MediaBackupLedgerPage = mutex.withLock {
+        requireAccountId(accountId)
+        require(limit in 1..MAX_MEDIA_BACKUP_LEDGER_PAGE_SIZE)
+        val predicates = buildList {
+            add("account_id = ?")
+            if (transferState != null) add("transfer_state = ?")
+            if (after != null) {
+                add("(updated_at < ? OR (updated_at = ? AND local_key < ?))")
+            }
+        }
+        val sql = buildString {
+            append(SELECT_COLUMNS)
+            append(" WHERE ")
+            append(predicates.joinToString(" AND "))
+            append(" ORDER BY updated_at DESC, local_key DESC LIMIT ?")
+        }
+        val rows = connection.prepare(sql).use { statement ->
+            var index = 1
+            statement.bindText(index++, accountId)
+            transferState?.let { statement.bindText(index++, it.name) }
+            after?.let { cursor ->
+                statement.bindLong(index++, cursor.updatedAtEpochMillis)
+                statement.bindLong(index++, cursor.updatedAtEpochMillis)
+                statement.bindText(index++, cursor.localKey)
+            }
+            statement.bindLong(index, (limit + 1).toLong())
+            buildList {
+                while (statement.step()) add(statement.readRecord())
+            }
+        }
+        val visible = rows.take(limit)
+        MediaBackupLedgerPage(
+            records = visible,
+            nextCursor = if (rows.size > limit) {
+                visible.last().let { MediaBackupLedgerCursor(it.updatedAtEpochMillis, it.localKey) }
+            } else {
+                null
+            },
+        )
+    }
+
+    suspend fun summary(accountId: String): MediaBackupLedgerSummary = mutex.withLock {
+        requireAccountId(accountId)
+        val counts = mutableMapOf<MediaBackupTransferState, Int>()
+        connection.prepare(
+            "SELECT transfer_state, COUNT(*) FROM media_backup_ledger " +
+                "WHERE account_id = ? GROUP BY transfer_state",
+        ).use { statement ->
+            statement.bindText(1, accountId)
+            while (statement.step()) {
+                val state = enumValueOf<MediaBackupTransferState>(statement.getText(0))
+                val count = statement.getLong(1)
+                check(count in 0..Int.MAX_VALUE.toLong())
+                counts[state] = count.toInt()
+            }
+        }
+        MediaBackupLedgerSummary(
+            pending = counts[MediaBackupTransferState.Pending] ?: 0,
+            uploading = counts[MediaBackupTransferState.Uploading] ?: 0,
+            failed = counts[MediaBackupTransferState.Failed] ?: 0,
+            succeeded = counts[MediaBackupTransferState.Succeeded] ?: 0,
+        )
+    }
+
+    suspend fun deleteAccount(accountId: String) = mutex.withLock {
+        requireAccountId(accountId)
+        transaction {
+            connection.prepare("DELETE FROM media_backup_ledger WHERE account_id = ?").use { statement ->
+                statement.bindText(1, accountId)
+                check(!statement.step())
+            }
+        }
+    }
+
+    suspend fun close() = mutex.withLock {
+        connection.close()
+    }
+
+    private fun initializeSchema() {
+        connection.prepare("PRAGMA journal_mode = WAL").use(SQLiteStatement::step)
+        connection.execSQL("PRAGMA synchronous = FULL")
+        connection.execSQL("PRAGMA foreign_keys = ON")
+        val version = connection.prepare("PRAGMA user_version").use { statement ->
+            check(statement.step())
+            statement.getLong(0).toInt()
+        }
+        when (version) {
+            0 -> transaction {
+                connection.execSQL(CREATE_TABLE)
+                connection.execSQL(CREATE_ACCOUNT_STATE_INDEX)
+                connection.execSQL(CREATE_ACCOUNT_UPDATED_INDEX)
+                connection.execSQL("PRAGMA user_version = $SCHEMA_VERSION")
+            }
+            SCHEMA_VERSION -> Unit
+            else -> throw MediaBackupLedgerStoreException(
+                "Media backup ledger schema version $version is unsupported.",
+            )
+        }
+        transaction {
+            connection.execSQL(
+                "UPDATE media_backup_ledger SET transfer_state = 'Pending', failure_message = NULL " +
+                    "WHERE transfer_state = 'Uploading'",
+            )
+        }
+    }
+
+    private fun pruneCompletedHistory(accountId: String) {
+        val excess = countRecords(accountId) - maxRecordsPerAccount
+        if (excess <= 0) return
+        connection.prepare(
+            """
+            DELETE FROM media_backup_ledger
+            WHERE account_id = ? AND local_key IN (
+                SELECT local_key
+                FROM media_backup_ledger
+                WHERE account_id = ? AND transfer_state = 'Succeeded'
+                ORDER BY updated_at ASC, local_key ASC
+                LIMIT ?
+            )
+            """.trimIndent(),
+        ).use { statement ->
+            statement.bindText(1, accountId)
+            statement.bindText(2, accountId)
+            statement.bindLong(3, excess.toLong())
+            check(!statement.step())
+        }
+    }
+
+    private fun countRecords(accountId: String): Int =
+        connection.prepare(
+            "SELECT COUNT(*) FROM media_backup_ledger WHERE account_id = ?",
+        ).use { statement ->
+            statement.bindText(1, accountId)
+            check(statement.step())
+            val count = statement.getLong(0)
+            check(count in 0..Int.MAX_VALUE.toLong())
+            count.toInt()
+        }
+
+    private inline fun <T> transaction(block: () -> T): T {
+        connection.execSQL("BEGIN IMMEDIATE TRANSACTION")
+        return try {
+            block().also { connection.execSQL("COMMIT") }
+        } catch (failure: Throwable) {
+            runCatching { connection.execSQL("ROLLBACK") }
+            throw failure
+        }
+    }
+
+    private fun SQLiteStatement.bindRecord(record: MediaBackupLedgerRecord) {
+        bindText(1, record.accountId)
+        bindText(2, record.localKey)
+        bindNullableText(3, record.local?.displayName)
+        bindNullableLong(4, record.local?.size)
+        bindNullableText(5, record.local?.revision)
+        bindNullableText(6, record.receipt?.localRevision)
+        bindNullableLong(7, record.receipt?.localSize)
+        bindNullableText(8, record.receipt?.remotePath)
+        bindNullableText(9, record.receipt?.remoteEtag)
+        bindNullableLong(10, record.receipt?.verifiedAtEpochMillis)
+        bindText(11, record.transferState.name)
+        bindLong(12, record.attemptCount.toLong())
+        bindLong(13, record.updatedAtEpochMillis)
+        bindNullableText(14, record.failureMessage)
+    }
+
+    private fun SQLiteStatement.readRecord(): MediaBackupLedgerRecord {
+        val accountId = getText(0)
+        val localKey = getText(1)
+        val local = if (isNull(2)) {
+            check(isNull(3) && isNull(4))
+            null
+        } else {
+            LocalMediaObject(
+                key = localKey,
+                displayName = getText(2),
+                size = getLong(3),
+                revision = getText(4),
+            )
+        }
+        val receipt = if (isNull(7)) {
+            check(isNull(5) && isNull(6) && isNull(8) && isNull(9))
+            null
+        } else {
+            MediaBackupReceipt(
+                localKey = localKey,
+                localRevision = getText(5),
+                localSize = getLong(6),
+                remotePath = getText(7),
+                remoteEtag = getText(8),
+                verifiedAtEpochMillis = getLong(9),
+            )
+        }
+        val attemptCount = getLong(11)
+        check(attemptCount in 0..Int.MAX_VALUE.toLong())
+        return MediaBackupLedgerRecord(
+            accountId = accountId,
+            local = local,
+            receipt = receipt,
+            transferState = enumValueOf(getText(10)),
+            attemptCount = attemptCount.toInt(),
+            updatedAtEpochMillis = getLong(12),
+            failureMessage = nullableText(13),
+        )
+    }
+
+    private fun SQLiteStatement.bindNullableText(index: Int, value: String?) {
+        if (value == null) bindNull(index) else bindText(index, value)
+    }
+
+    private fun SQLiteStatement.bindNullableLong(index: Int, value: Long?) {
+        if (value == null) bindNull(index) else bindLong(index, value)
+    }
+
+    private fun SQLiteStatement.nullableText(index: Int): String? =
+        if (isNull(index)) null else getText(index)
+
+    private fun requireAccountId(accountId: String) {
+        require(accountId.isNotBlank() && accountId.length <= 256 && accountId.none(Char::isISOControl))
+    }
+
+    private fun requireLocalKey(localKey: String) {
+        require(localKey.isNotBlank() && localKey.length <= 2_048 && localKey.none(Char::isISOControl))
+    }
+
+    private companion object {
+        const val SCHEMA_VERSION = 1
+
+        const val SELECT_COLUMNS =
+            "SELECT account_id, local_key, local_display_name, local_size, local_revision, " +
+                "receipt_local_revision, receipt_local_size, remote_path, remote_etag, verified_at, " +
+                "transfer_state, attempt_count, updated_at, failure_message FROM media_backup_ledger"
+
+        val CREATE_TABLE =
+            """
+            CREATE TABLE media_backup_ledger (
+                account_id TEXT NOT NULL,
+                local_key TEXT NOT NULL,
+                local_display_name TEXT,
+                local_size INTEGER,
+                local_revision TEXT,
+                receipt_local_revision TEXT,
+                receipt_local_size INTEGER,
+                remote_path TEXT,
+                remote_etag TEXT,
+                verified_at INTEGER,
+                transfer_state TEXT NOT NULL CHECK (
+                    transfer_state IN ('Pending', 'Uploading', 'Failed', 'Succeeded')
+                ),
+                attempt_count INTEGER NOT NULL CHECK (attempt_count >= 0),
+                updated_at INTEGER NOT NULL CHECK (updated_at >= 0),
+                failure_message TEXT,
+                PRIMARY KEY (account_id, local_key),
+                CHECK (
+                    (local_display_name IS NULL AND local_size IS NULL AND local_revision IS NULL)
+                    OR
+                    (local_display_name IS NOT NULL AND local_size IS NOT NULL AND local_revision IS NOT NULL)
+                ),
+                CHECK (
+                    (remote_path IS NULL AND receipt_local_revision IS NULL AND receipt_local_size IS NULL
+                        AND remote_etag IS NULL AND verified_at IS NULL)
+                    OR
+                    (remote_path IS NOT NULL AND receipt_local_revision IS NOT NULL
+                        AND receipt_local_size IS NOT NULL AND remote_etag IS NOT NULL
+                        AND verified_at IS NOT NULL)
+                ),
+                CHECK ((transfer_state = 'Failed') = (failure_message IS NOT NULL))
+            )
+            """.trimIndent()
+
+        const val CREATE_ACCOUNT_STATE_INDEX =
+            "CREATE INDEX media_backup_account_state_updated " +
+                "ON media_backup_ledger(account_id, transfer_state, updated_at DESC, local_key DESC)"
+
+        const val CREATE_ACCOUNT_UPDATED_INDEX =
+            "CREATE INDEX media_backup_account_updated " +
+                "ON media_backup_ledger(account_id, updated_at DESC, local_key DESC)"
+
+        val UPSERT_RECORD =
+            """
+            INSERT INTO media_backup_ledger (
+                account_id, local_key, local_display_name, local_size, local_revision,
+                receipt_local_revision, receipt_local_size, remote_path, remote_etag, verified_at,
+                transfer_state, attempt_count, updated_at, failure_message
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(account_id, local_key) DO UPDATE SET
+                local_display_name = excluded.local_display_name,
+                local_size = excluded.local_size,
+                local_revision = excluded.local_revision,
+                receipt_local_revision = excluded.receipt_local_revision,
+                receipt_local_size = excluded.receipt_local_size,
+                remote_path = excluded.remote_path,
+                remote_etag = excluded.remote_etag,
+                verified_at = excluded.verified_at,
+                transfer_state = excluded.transfer_state,
+                attempt_count = excluded.attempt_count,
+                updated_at = excluded.updated_at,
+                failure_message = excluded.failure_message
+            """.trimIndent()
+    }
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerTest.kt
@@ -1,10 +1,15 @@
 package dev.obiente.nextcloudnative.app
 
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import androidx.sqlite.execSQL
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 
 class MediaBackupLedgerTest {
+    private val accountId = "0123456789abcdef0123456789abcdef"
     private val local = LocalMediaObject(
         key = "external:42",
         displayName = "IMG_0042.jpg",
@@ -40,5 +45,138 @@ class MediaBackupLedgerTest {
     fun removedLocalOriginalRemainsRepresentedAsCloudOnly() {
         assertEquals(MediaBackupStatus.CloudOnly, resolveMediaBackupStatus(null, receipt))
         assertEquals(MediaReclaimEligibility.AlreadyCloudOnly, mediaReclaimEligibility(null, receipt))
+    }
+
+    @Test
+    fun sqliteLedgerRecoversInterruptedUploadAsPending() = runBlocking {
+        val connection = BundledSQLiteDriver().open(":memory:")
+        val firstProcess = MediaBackupLedgerStore(connection)
+        firstProcess.upsert(
+            MediaBackupLedgerRecord(
+                accountId = accountId,
+                local = local,
+                receipt = null,
+                transferState = MediaBackupTransferState.Uploading,
+                attemptCount = 1,
+                updatedAtEpochMillis = 2_000,
+            ),
+        )
+
+        val reopened = MediaBackupLedgerStore(connection)
+        val recovered = reopened.load(accountId, local.key)
+
+        assertEquals(MediaBackupTransferState.Pending, recovered?.transferState)
+        assertEquals(1, recovered?.attemptCount)
+        reopened.close()
+    }
+
+    @Test
+    fun indexedPagesRemainAccountScopedAndStable() = runBlocking {
+        val otherAccount = "fedcba9876543210fedcba9876543210"
+        val store = MediaBackupLedgerStore(BundledSQLiteDriver().open(":memory:"))
+        repeat(5) { index ->
+            store.upsert(
+                pendingRecord(
+                    accountId = accountId,
+                    key = "external:$index",
+                    updatedAt = 1_000L - index,
+                ),
+            )
+        }
+        store.upsert(pendingRecord(otherAccount, "external:other", 2_000))
+
+        val firstPage = store.page(accountId, limit = 2)
+        val secondPage = store.page(accountId, after = firstPage.nextCursor, limit = 2)
+
+        assertEquals(listOf("external:0", "external:1"), firstPage.records.map { it.localKey })
+        assertEquals(listOf("external:2", "external:3"), secondPage.records.map { it.localKey })
+        assertEquals(5, store.summary(accountId).pending)
+        assertEquals(1, store.summary(otherAccount).pending)
+        store.close()
+    }
+
+    @Test
+    fun completedHistoryIsPrunedBeforeUnfinishedWork() = runBlocking {
+        val store = MediaBackupLedgerStore(
+            connection = BundledSQLiteDriver().open(":memory:"),
+            maxRecordsPerAccount = 2,
+        )
+        store.upsert(succeededRecord("external:old", 1_000))
+        store.upsert(succeededRecord("external:new", 2_000))
+        store.upsert(pendingRecord(accountId, "external:pending", 3_000))
+
+        assertEquals(null, store.load(accountId, "external:old"))
+        assertEquals(2, store.summary(accountId).total)
+        store.close()
+    }
+
+    @Test
+    fun unfinishedOverflowRollsBackAndFutureSchemaIsRejected() = runBlocking {
+        val connection = BundledSQLiteDriver().open(":memory:")
+        val store = MediaBackupLedgerStore(connection, maxRecordsPerAccount = 2)
+        store.upsert(pendingRecord(accountId, "external:1", 1_000))
+        store.upsert(pendingRecord(accountId, "external:2", 2_000))
+
+        assertFailsWith<IllegalStateException> {
+            store.upsert(pendingRecord(accountId, "external:3", 3_000))
+        }
+        assertEquals(2, store.summary(accountId).total)
+        store.close()
+
+        val future = BundledSQLiteDriver().open(":memory:")
+        future.execSQL("PRAGMA user_version = 2")
+        assertFailsWith<MediaBackupLedgerStoreException> {
+            MediaBackupLedgerStore(future)
+        }
+        Unit
+    }
+
+    @Test
+    fun corruptRowsAreRejectedInsteadOfSilentlyCoerced() = runBlocking {
+        val connection = BundledSQLiteDriver().open(":memory:")
+        val store = MediaBackupLedgerStore(connection)
+        store.upsert(pendingRecord(accountId, local.key, 1_000))
+        connection.execSQL("PRAGMA ignore_check_constraints = ON")
+        connection.prepare(
+            "UPDATE media_backup_ledger SET transfer_state = 'Unknown' WHERE account_id = ?",
+        ).use { statement ->
+            statement.bindText(1, accountId)
+            check(!statement.step())
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            store.load(accountId, local.key)
+        }
+        store.close()
+    }
+
+    private fun pendingRecord(
+        accountId: String,
+        key: String,
+        updatedAt: Long,
+    ) = MediaBackupLedgerRecord(
+        accountId = accountId,
+        local = local.copy(key = key, displayName = "$key.jpg"),
+        receipt = null,
+        transferState = MediaBackupTransferState.Pending,
+        attemptCount = 0,
+        updatedAtEpochMillis = updatedAt,
+    )
+
+    private fun succeededRecord(key: String, updatedAt: Long): MediaBackupLedgerRecord {
+        val objectAtKey = local.copy(key = key, displayName = "$key.jpg")
+        return MediaBackupLedgerRecord(
+            accountId = accountId,
+            local = objectAtKey,
+            receipt = receipt.copy(
+                localKey = key,
+                localRevision = objectAtKey.revision,
+                localSize = objectAtKey.size,
+                remotePath = "Photos/Camera/$key.jpg",
+            ),
+            transferState = MediaBackupTransferState.Succeeded,
+            attemptCount = 1,
+            updatedAtEpochMillis = updatedAt,
+        )
     }
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerPersistenceTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerPersistenceTest.kt
@@ -1,0 +1,72 @@
+package dev.obiente.nextcloudnative.app
+
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MediaBackupLedgerPersistenceTest {
+    @Test
+    fun fileBackedLedgerSurvivesCloseAndRecoversActiveWork() = runBlocking {
+        val directory = Files.createTempDirectory("media-ledger-")
+        val databasePath = directory.resolve("ledger.db").toString()
+        val accountId = "0123456789abcdef0123456789abcdef"
+        val local = LocalMediaObject(
+            key = "external:42",
+            displayName = "IMG_0042.jpg",
+            size = 4_096,
+            revision = "generation:9",
+        )
+        val completedLocal = local.copy(
+            key = "external:43",
+            displayName = "IMG_0043.jpg",
+            revision = "generation:10",
+        )
+        val completedReceipt = MediaBackupReceipt(
+            localKey = completedLocal.key,
+            localRevision = completedLocal.revision,
+            localSize = completedLocal.size,
+            remotePath = "Photos/Camera/IMG_0043.jpg",
+            remoteEtag = "\"remote-43\"",
+            verifiedAtEpochMillis = 1_500,
+        )
+        MediaBackupLedgerStore(databasePath).also { store ->
+            store.upsert(
+                MediaBackupLedgerRecord(
+                    accountId = accountId,
+                    local = local,
+                    receipt = null,
+                    transferState = MediaBackupTransferState.Uploading,
+                    attemptCount = 1,
+                    updatedAtEpochMillis = 1_000,
+                ),
+            )
+            store.upsert(
+                MediaBackupLedgerRecord(
+                    accountId = accountId,
+                    local = completedLocal,
+                    receipt = completedReceipt,
+                    transferState = MediaBackupTransferState.Succeeded,
+                    attemptCount = 1,
+                    updatedAtEpochMillis = 1_500,
+                ),
+            )
+            store.close()
+        }
+
+        BundledSQLiteDriver().open(databasePath).use { connection ->
+            connection.prepare("PRAGMA journal_mode").use { statement ->
+                check(statement.step())
+                assertEquals("wal", statement.getText(0).lowercase())
+            }
+        }
+        val reopened = MediaBackupLedgerStore(databasePath)
+
+        assertEquals(MediaBackupTransferState.Pending, reopened.load(accountId, local.key)?.transferState)
+        assertEquals(completedReceipt, reopened.load(accountId, completedLocal.key)?.receipt)
+        reopened.close()
+        directory.toFile().deleteRecursively()
+        Unit
+    }
+}


### PR DESCRIPTION
Closes #63

## What changed
- add an account-scoped, versioned SQLite transfer ledger backed by the bundled KMP driver
- persist exact local revisions, remote ETags, transfer state, attempts, and failure details transactionally
- recover interrupted uploads as pending and bound history by pruning completed records first
- expose stable keyset pagination and account summaries for the transfer center
- store Android device-local ledger data outside automatic app backup

## Verification
- repository hygiene checks
- contract acquisition tests
- Android unit tests
- desktop tests, including file-backed reopen, WAL mode, strict decode, isolation, pruning, rollback, and pagination
- Android debug assembly