### PR TITLE
feat(media): show device backup status

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
@@ -29,6 +29,8 @@ import dev.obiente.nextcloudnative.app.scanFileSyncPair
 import dev.obiente.nextcloudnative.app.toCenterSummary
 import java.io.File
 import java.util.UUID
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Foreground execution engine for SAF-backed sync pairs.
@@ -45,7 +47,10 @@ internal class AndroidFileSyncEngine(context: Context) {
     }
     private val stagingRoot = File(appContext.cacheDir, "file-sync-staging")
 
-    fun loadCenter(session: NextcloudSession, userId: String): FileSyncCenterSnapshot = synchronized(ENGINE_LOCK) {
+    suspend fun loadCenter(
+        session: NextcloudSession,
+        userId: String,
+    ): FileSyncCenterSnapshot = ENGINE_LOCK.withLock {
         val accountId = NextcloudDocumentIds.accountKey(session)
         val persisted = store.load()
         persisted.coordinator.pairs
@@ -64,13 +69,13 @@ internal class AndroidFileSyncEngine(context: Context) {
         )
     }
 
-    fun addPair(
+    suspend fun addPair(
         session: NextcloudSession,
         userId: String,
         localRoot: FileSyncLocalRoot,
         remoteRootPath: String,
         configuration: FileSyncConfiguration,
-    ): FileSyncCenterActionResult = synchronized(ENGINE_LOCK) {
+    ): FileSyncCenterActionResult = ENGINE_LOCK.withLock {
         // Constructing the adapter verifies that its persisted SAF grant or detected media root is usable.
         createAndroidFileSyncLocalTree(appContext.contentResolver, localRoot.localRootId)
         val normalizedRemote = normalizeRemoteRoot(remoteRootPath)
@@ -82,7 +87,9 @@ internal class AndroidFileSyncEngine(context: Context) {
                     it.remoteRootPath == normalizedRemote
             }
         ) {
-            return FileSyncCenterActionResult.Rejected("That local and Nextcloud folder pair already exists.")
+            return@withLock FileSyncCenterActionResult.Rejected(
+                "That local and Nextcloud folder pair already exists.",
+            )
         }
         val pair = FileSyncPair(
             id = UUID.randomUUID().toString(),
@@ -117,13 +124,17 @@ internal class AndroidFileSyncEngine(context: Context) {
         }
     }
 
-    fun removePair(session: NextcloudSession, pairId: String): FileSyncCenterActionResult =
-        synchronized(ENGINE_LOCK) {
+    suspend fun removePair(session: NextcloudSession, pairId: String): FileSyncCenterActionResult =
+        ENGINE_LOCK.withLock {
             val current = store.load()
             val pair = current.coordinator.pairs.firstOrNull { it.id == pairId }
-                ?: return FileSyncCenterActionResult.Rejected("The folder sync pair no longer exists.")
+                ?: return@withLock FileSyncCenterActionResult.Rejected(
+                    "The folder sync pair no longer exists.",
+                )
             if (pair.accountId != NextcloudDocumentIds.accountKey(session)) {
-                return FileSyncCenterActionResult.Rejected("This folder sync pair belongs to another account.")
+                return@withLock FileSyncCenterActionResult.Rejected(
+                    "This folder sync pair belongs to another account.",
+                )
             }
             val remaining = removeFileSyncPair(current.coordinator, pairId)
             store.save(
@@ -147,17 +158,26 @@ internal class AndroidFileSyncEngine(context: Context) {
             FileSyncCenterActionResult.Completed("Folder sync pair removed. No local or server files were deleted.")
         }
 
-    fun runPair(
+    suspend fun runPair(
         session: NextcloudSession,
         userId: String,
         pairId: String,
-    ): FileSyncCenterActionResult = synchronized(ENGINE_LOCK) {
+    ): FileSyncCenterActionResult = ENGINE_LOCK.withLock {
+        runPairLocked(session, userId, pairId)
+    }
+
+    private suspend fun runPairLocked(
+        session: NextcloudSession,
+        userId: String,
+        pairId: String,
+    ): FileSyncCenterActionResult {
         var persisted = store.load()
         val initialPair = persisted.coordinator.pairs.firstOrNull { it.id == pairId }
             ?: return FileSyncCenterActionResult.Rejected("The folder sync pair no longer exists.")
         if (initialPair.accountId != NextcloudDocumentIds.accountKey(session)) {
             return FileSyncCenterActionResult.Rejected("This folder sync pair belongs to another account.")
         }
+        return withAndroidMediaBackupLedger(appContext, initialPair) { mediaLedger ->
         val remote = AndroidFileSyncRemoteTree(
             session,
             userId,
@@ -232,8 +252,18 @@ internal class AndroidFileSyncEngine(context: Context) {
                         work.id,
                     ),
                 )
-            }
+        }
         store.save(persisted)
+        mediaLedger?.recordVerifiedBaselines(
+            baselines = persisted.coordinator.pairs.first { it.id == pairId }.baselines,
+            localEntries = localEntries,
+            remoteEntries = remoteEntries,
+            nowEpochMillis = System.currentTimeMillis(),
+        )
+        mediaLedger?.recordPlanned(
+            persisted.coordinator.pairs.first { it.id == pairId }.workItems,
+            System.currentTimeMillis(),
+        )
 
         var completed = 0
         while (true) {
@@ -245,9 +275,17 @@ internal class AndroidFileSyncEngine(context: Context) {
             persisted = persisted.copy(coordinator = claim.state)
             store.save(persisted)
             val command = claim.command ?: break
-            runCatching {
+            val claimedWork = persisted.coordinator.pairs
+                .first { it.id == pairId }
+                .workItems
+                .first { it.id == command.workId }
+            mediaLedger?.recordPlanned(listOf(claimedWork), System.currentTimeMillis())
+            val execution = runCatching {
                 execute(command, persisted.coordinator, local, remote)
-            }.onSuccess { success ->
+            }
+            val failure = execution.exceptionOrNull()
+            if (failure == null) {
+                val success = execution.getOrThrow()
                 persisted = persisted.copy(
                     coordinator = completeFileSyncOperation(
                         persisted.coordinator,
@@ -257,7 +295,20 @@ internal class AndroidFileSyncEngine(context: Context) {
                     ),
                 )
                 completed += 1
-            }.onFailure { failure ->
+                store.save(persisted)
+                if (claimedWork.operation is FileSyncOperation.Upload) {
+                    val baseline = success.synchronizedBaselines.single {
+                        it.relativePath == claimedWork.relativePath
+                    }
+                    val verifiedLocal = requireNotNull(local.resolve(claimedWork.relativePath)).entry
+                    mediaLedger?.recordSucceeded(
+                        work = claimedWork,
+                        local = verifiedLocal,
+                        baseline = baseline,
+                        nowEpochMillis = System.currentTimeMillis(),
+                    )
+                }
+            } else {
                 persisted = persisted.copy(
                     coordinator = failFileSyncOperation(
                         persisted.coordinator,
@@ -266,8 +317,13 @@ internal class AndroidFileSyncEngine(context: Context) {
                         safeFailureMessage(failure, "The sync operation failed."),
                     ),
                 )
+                store.save(persisted)
+                val failedWork = persisted.coordinator.pairs
+                    .first { it.id == pairId }
+                    .workItems
+                    .first { it.id == command.workId }
+                mediaLedger?.recordPlanned(listOf(failedWork), System.currentTimeMillis())
             }
-            store.save(persisted)
         }
         val pair = persisted.coordinator.pairs.first { it.id == pairId }
         val conflicts = pair.workItems.count { it.state == FileSyncExecutionState.AwaitingDecision }
@@ -281,25 +337,30 @@ internal class AndroidFileSyncEngine(context: Context) {
         }
         if (failures > 0) FileSyncCenterActionResult.Rejected(message)
         else FileSyncCenterActionResult.Completed(message)
+        }
     }
 
-    fun resolveConflictAndRun(
+    suspend fun resolveConflictAndRun(
         session: NextcloudSession,
         userId: String,
         pairId: String,
         workId: Long,
         choice: FileSyncDecisionChoice,
-    ): FileSyncCenterActionResult = synchronized(ENGINE_LOCK) {
+    ): FileSyncCenterActionResult = ENGINE_LOCK.withLock {
         val current = store.load()
         val pair = current.coordinator.pairs.firstOrNull { it.id == pairId }
-            ?: return FileSyncCenterActionResult.Rejected("The folder sync pair no longer exists.")
+            ?: return@withLock FileSyncCenterActionResult.Rejected(
+                "The folder sync pair no longer exists.",
+            )
         if (pair.accountId != NextcloudDocumentIds.accountKey(session)) {
-            return FileSyncCenterActionResult.Rejected("This folder sync pair belongs to another account.")
+            return@withLock FileSyncCenterActionResult.Rejected(
+                "This folder sync pair belongs to another account.",
+            )
         }
         val resolved = runCatching {
             resolveFileSyncDecision(current.coordinator, pairId, workId, choice)
         }.getOrElse { failure ->
-            return FileSyncCenterActionResult.Rejected(
+            return@withLock FileSyncCenterActionResult.Rejected(
                 safeFailureMessage(
                     failure,
                     "That conflict decision is no longer valid. Scan again.",
@@ -307,7 +368,7 @@ internal class AndroidFileSyncEngine(context: Context) {
             )
         }
         store.save(current.copy(coordinator = resolved))
-        runPair(session, userId, pairId)
+        runPairLocked(session, userId, pairId)
     }
 
     private fun execute(
@@ -468,6 +529,6 @@ internal class AndroidFileSyncEngine(context: Context) {
 
     private companion object {
         const val MAX_SYNC_FILE_BYTES = 8L * 1024L * 1024L * 1024L
-        val ENGINE_LOCK = Any()
+        val ENGINE_LOCK = Mutex()
     }
 }

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedger.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedger.kt
@@ -4,7 +4,14 @@ import android.content.Context
 import dev.obiente.nextcloudnative.app.MediaBackupLedgerStore
 import java.io.File
 
-internal fun createAndroidMediaBackupLedgerStore(context: Context): MediaBackupLedgerStore =
+internal fun createAndroidMediaBackupLedgerStore(
+    context: Context,
+    recoverInterruptedTransfers: Boolean = true,
+): MediaBackupLedgerStore =
     MediaBackupLedgerStore(
-        File(context.applicationContext.noBackupFilesDir, "media-backup-ledger.db").absolutePath,
+        databasePath = File(
+            context.applicationContext.noBackupFilesDir,
+            "media-backup-ledger.db",
+        ).absolutePath,
+        recoverInterruptedTransfers = recoverInterruptedTransfers,
     )

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedgerBridge.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedgerBridge.kt
@@ -1,0 +1,383 @@
+package dev.obiente.nextcloudnative
+
+import android.content.Context
+import dev.obiente.nextcloudnative.app.FileSyncBaseline
+import dev.obiente.nextcloudnative.app.FileSyncDirection
+import dev.obiente.nextcloudnative.app.FileSyncExecutionState
+import dev.obiente.nextcloudnative.app.FileSyncOperation
+import dev.obiente.nextcloudnative.app.FileSyncPair
+import dev.obiente.nextcloudnative.app.FileSyncWorkItem
+import dev.obiente.nextcloudnative.app.LocalMediaObject
+import dev.obiente.nextcloudnative.app.RemoteSyncEntry
+import dev.obiente.nextcloudnative.app.LocalSyncEntry
+import dev.obiente.nextcloudnative.app.MAX_MEDIA_BACKUP_LEDGER_QUERY_KEYS
+import dev.obiente.nextcloudnative.app.MAX_MEDIA_BACKUP_LEDGER_WRITE_BATCH
+import dev.obiente.nextcloudnative.app.MediaBackupLedgerRecord
+import dev.obiente.nextcloudnative.app.MediaBackupLedgerStore
+import dev.obiente.nextcloudnative.app.MediaBackupReceipt
+import dev.obiente.nextcloudnative.app.MediaBackupTransferState
+import dev.obiente.nextcloudnative.app.SyncEntryKind
+import java.security.MessageDigest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * Mirrors upload-only MediaStore sync work into the indexed media ledger.
+ *
+ * The folder-sync coordinator remains responsible for execution and revision guards. This bridge
+ * gives native media UI a compact account-scoped projection without loading the coordinator's
+ * complete work graph.
+ */
+internal class AndroidMediaBackupLedgerBridge(
+    private val pair: FileSyncPair,
+    private val store: MediaBackupLedgerStore,
+) {
+    suspend fun recordVerifiedBaselines(
+        baselines: Collection<FileSyncBaseline>,
+        localEntries: Collection<LocalSyncEntry>,
+        remoteEntries: Collection<RemoteSyncEntry>,
+        nowEpochMillis: Long,
+    ): Boolean = project {
+        val baselineByPath = baselines.associateBy(FileSyncBaseline::relativePath)
+        val localPaths = localEntries.mapTo(mutableSetOf(), LocalSyncEntry::relativePath)
+        val remoteByPath = remoteEntries.associateBy(RemoteSyncEntry::relativePath)
+        val verified = localEntries.filter { local ->
+            local.kind == SyncEntryKind.File &&
+                baselineByPath[local.relativePath]?.localRevision == local.revision
+        }
+        verified.chunked(MAX_MEDIA_BACKUP_LEDGER_QUERY_KEYS).forEach { chunk ->
+            val keys = chunk.associateWith { localKey(it.relativePath) }
+            val existing = store.loadMany(pair.accountId, keys.values)
+            val records = chunk.mapNotNull { local ->
+                val key = requireNotNull(keys[local])
+                val baseline = requireNotNull(baselineByPath[local.relativePath])
+                mediaBackupVerifiedRecord(
+                    pair = pair,
+                    local = local,
+                    baseline = baseline,
+                    existing = existing[key],
+                    nowEpochMillis = nowEpochMillis,
+                )
+            }
+            for (batch in records.chunked(MAX_MEDIA_BACKUP_LEDGER_WRITE_BATCH)) {
+                store.upsertAll(batch)
+            }
+        }
+        val cloudOnly = baselines.filter { baseline ->
+            baseline.kind == SyncEntryKind.File &&
+                baseline.relativePath !in localPaths &&
+                remoteByPath[baseline.relativePath]?.let { remote ->
+                    remote.kind == SyncEntryKind.File && remote.etag == baseline.remoteEtag
+                } == true
+        }
+        cloudOnly.chunked(MAX_MEDIA_BACKUP_LEDGER_QUERY_KEYS).forEach { chunk ->
+            val keys = chunk.associateWith { baseline -> localKey(baseline.relativePath) }
+            val existing = store.loadMany(pair.accountId, keys.values)
+            val records = chunk.mapNotNull { baseline ->
+                mediaBackupCloudOnlyRecord(
+                    pair = pair,
+                    baseline = baseline,
+                    remote = requireNotNull(remoteByPath[baseline.relativePath]),
+                    existing = existing[keys[baseline]],
+                    nowEpochMillis = nowEpochMillis,
+                )
+            }
+            for (batch in records.chunked(MAX_MEDIA_BACKUP_LEDGER_WRITE_BATCH)) {
+                store.upsertAll(batch)
+            }
+        }
+    }
+
+    suspend fun recordPlanned(
+        workItems: Collection<FileSyncWorkItem>,
+        nowEpochMillis: Long,
+    ): Boolean = project {
+        val uploads = workItems.filter { work ->
+            work.operation is FileSyncOperation.Upload &&
+                work.observedLocal?.kind == SyncEntryKind.File &&
+                work.state in setOf(
+                    FileSyncExecutionState.Ready,
+                    FileSyncExecutionState.Running,
+                    FileSyncExecutionState.Failed,
+                )
+        }
+        uploads.chunked(MAX_MEDIA_BACKUP_LEDGER_QUERY_KEYS).forEach { chunk ->
+            val keys = chunk.associateWith { localKey(it.relativePath) }
+            val existing = store.loadMany(pair.accountId, keys.values)
+            val records = chunk.map { work ->
+                mediaBackupLedgerRecordForWork(
+                    pair = pair,
+                    work = work,
+                    existing = existing[keys[work]],
+                    nowEpochMillis = nowEpochMillis,
+                )
+            }
+            for (batch in records.chunked(MAX_MEDIA_BACKUP_LEDGER_WRITE_BATCH)) {
+                store.upsertAll(batch)
+            }
+        }
+    }
+
+    suspend fun recordSucceeded(
+        work: FileSyncWorkItem,
+        local: LocalSyncEntry,
+        baseline: FileSyncBaseline,
+        nowEpochMillis: Long,
+    ): Boolean = project {
+        require(work.operation is FileSyncOperation.Upload)
+        require(local.kind == SyncEntryKind.File && local.relativePath == work.relativePath)
+        require(baseline.relativePath == work.relativePath)
+        store.upsert(
+            mediaBackupSucceededRecord(pair, work, local, baseline, nowEpochMillis),
+        )
+    }
+
+    suspend fun close(): Boolean = runMediaBackupProjection {
+        store.close()
+    }
+
+    private suspend fun project(block: suspend () -> Unit): Boolean {
+        val updated = runMediaBackupProjection(block)
+        if (updated) MediaBackupStatusUpdates.changes.tryEmit(pair.accountId)
+        return updated
+    }
+
+    private fun localKey(relativePath: String): String =
+        mediaBackupLocalKey(pair.localRootId, relativePath)
+
+    companion object {
+        fun open(context: Context, pair: FileSyncPair): AndroidMediaBackupLedgerBridge? =
+            if (
+                pair.localRootId.startsWith(MEDIA_STORE_SYNC_ROOT_PREFIX) &&
+                pair.configuration.direction == FileSyncDirection.UploadOnly
+            ) {
+                AndroidMediaBackupLedgerBridge(
+                    pair = pair,
+                    store = createAndroidMediaBackupLedgerStore(context.applicationContext),
+                )
+            } else {
+                null
+            }
+    }
+}
+
+internal fun mediaBackupLedgerRecordForWork(
+    pair: FileSyncPair,
+    work: FileSyncWorkItem,
+    existing: MediaBackupLedgerRecord?,
+    nowEpochMillis: Long,
+): MediaBackupLedgerRecord {
+        require(work.operation is FileSyncOperation.Upload)
+        val localEntry = requireNotNull(work.observedLocal)
+        require(localEntry.kind == SyncEntryKind.File)
+        val key = mediaBackupLocalKey(pair.localRootId, work.relativePath)
+        val localObject = localEntry.toMediaBackupLocalObject(key)
+        val path = pair.mediaBackupRemotePath(work.relativePath)
+        val baseline = work.observedBaseline
+        val validExistingReceipt = existing?.receipt?.takeIf { receipt ->
+            receipt.remotePath == path &&
+                baseline != null &&
+                receipt.localRevision == baseline.localRevision &&
+                receipt.remoteEtag == baseline.remoteEtag &&
+                work.observedRemote?.etag == baseline.remoteEtag
+        }
+        val receipt = when {
+            baseline != null &&
+                baseline.localRevision == localEntry.revision &&
+                work.observedRemote?.etag == baseline.remoteEtag ->
+                validExistingReceipt ?: MediaBackupReceipt(
+                    localKey = key,
+                    localRevision = localEntry.revision,
+                    localSize = requireNotNull(localEntry.size),
+                    remotePath = path,
+                    remoteEtag = requireNotNull(baseline.remoteEtag),
+                    verifiedAtEpochMillis = nowEpochMillis,
+                )
+            else -> validExistingReceipt
+        }
+        val state = when (work.state) {
+            FileSyncExecutionState.Ready -> MediaBackupTransferState.Pending
+            FileSyncExecutionState.Running -> MediaBackupTransferState.Uploading
+            FileSyncExecutionState.Failed -> MediaBackupTransferState.Failed
+            FileSyncExecutionState.AwaitingDecision,
+            FileSyncExecutionState.Skipped,
+            -> error("Only executable upload work belongs in the media ledger.")
+        }
+        val failure = work.failureMessage.takeIf { state == MediaBackupTransferState.Failed }
+        val unchanged = existing?.let { current ->
+            current.local == localObject &&
+                current.receipt == receipt &&
+                current.transferState == state &&
+                current.attemptCount == work.attemptCount &&
+                current.failureMessage == failure
+        } == true
+        return MediaBackupLedgerRecord(
+            accountId = pair.accountId,
+            local = localObject,
+            receipt = receipt,
+            transferState = state,
+            attemptCount = work.attemptCount,
+            updatedAtEpochMillis = if (unchanged) requireNotNull(existing).updatedAtEpochMillis else nowEpochMillis,
+            failureMessage = failure,
+        )
+}
+
+internal fun mediaBackupSucceededRecord(
+    pair: FileSyncPair,
+    work: FileSyncWorkItem,
+    local: LocalSyncEntry,
+    baseline: FileSyncBaseline,
+    nowEpochMillis: Long,
+): MediaBackupLedgerRecord {
+    require(work.operation is FileSyncOperation.Upload)
+    require(local.kind == SyncEntryKind.File && local.relativePath == work.relativePath)
+    require(baseline.relativePath == work.relativePath)
+    val key = mediaBackupLocalKey(pair.localRootId, work.relativePath)
+    val localObject = local.toMediaBackupLocalObject(key)
+    return MediaBackupLedgerRecord(
+        accountId = pair.accountId,
+        local = localObject,
+        receipt = MediaBackupReceipt(
+            localKey = key,
+            localRevision = local.revision,
+            localSize = requireNotNull(local.size),
+            remotePath = pair.mediaBackupRemotePath(work.relativePath),
+            remoteEtag = requireNotNull(baseline.remoteEtag),
+            verifiedAtEpochMillis = nowEpochMillis,
+        ),
+        transferState = MediaBackupTransferState.Succeeded,
+        attemptCount = work.attemptCount,
+        updatedAtEpochMillis = nowEpochMillis,
+    )
+}
+
+internal fun mediaBackupVerifiedRecord(
+    pair: FileSyncPair,
+    local: LocalSyncEntry,
+    baseline: FileSyncBaseline,
+    existing: MediaBackupLedgerRecord?,
+    nowEpochMillis: Long,
+): MediaBackupLedgerRecord? {
+    require(local.kind == SyncEntryKind.File && baseline.kind == SyncEntryKind.File)
+    require(local.relativePath == baseline.relativePath && local.revision == baseline.localRevision)
+    val key = mediaBackupLocalKey(pair.localRootId, local.relativePath)
+    val localObject = local.toMediaBackupLocalObject(key)
+    val currentReceipt = existing?.receipt
+    val path = pair.mediaBackupRemotePath(local.relativePath)
+    if (
+        existing?.local == localObject &&
+        currentReceipt?.localRevision == local.revision &&
+        currentReceipt.localSize == local.size &&
+        currentReceipt.remotePath == path &&
+        currentReceipt.remoteEtag == baseline.remoteEtag &&
+        existing.transferState == MediaBackupTransferState.Succeeded
+    ) {
+        return null
+    }
+    return MediaBackupLedgerRecord(
+        accountId = pair.accountId,
+        local = localObject,
+        receipt = MediaBackupReceipt(
+            localKey = key,
+            localRevision = local.revision,
+            localSize = requireNotNull(local.size),
+            remotePath = path,
+            remoteEtag = requireNotNull(baseline.remoteEtag),
+            verifiedAtEpochMillis = currentReceipt
+                ?.takeIf {
+                    it.localRevision == local.revision &&
+                        it.remoteEtag == baseline.remoteEtag
+                }
+                ?.verifiedAtEpochMillis
+                ?: nowEpochMillis,
+        ),
+        transferState = MediaBackupTransferState.Succeeded,
+        attemptCount = existing?.attemptCount ?: 0,
+        updatedAtEpochMillis = nowEpochMillis,
+    )
+}
+
+internal fun mediaBackupCloudOnlyRecord(
+    pair: FileSyncPair,
+    baseline: FileSyncBaseline,
+    remote: RemoteSyncEntry,
+    existing: MediaBackupLedgerRecord?,
+    nowEpochMillis: Long,
+): MediaBackupLedgerRecord? {
+    require(baseline.kind == SyncEntryKind.File && remote.kind == SyncEntryKind.File)
+    require(baseline.relativePath == remote.relativePath)
+    val receipt = existing?.receipt ?: return null
+    if (
+        receipt.remotePath != pair.mediaBackupRemotePath(baseline.relativePath) ||
+        receipt.remoteEtag != baseline.remoteEtag ||
+        remote.etag != baseline.remoteEtag
+    ) {
+        return null
+    }
+    if (existing.local == null && existing.transferState == MediaBackupTransferState.Succeeded) {
+        return null
+    }
+    return existing.copy(
+        local = null,
+        transferState = MediaBackupTransferState.Succeeded,
+        updatedAtEpochMillis = nowEpochMillis,
+        failureMessage = null,
+    )
+}
+
+private fun LocalSyncEntry.toMediaBackupLocalObject(key: String): LocalMediaObject =
+    LocalMediaObject(
+        key = key,
+        displayName = relativePath.substringAfterLast('/'),
+        size = requireNotNull(size),
+        revision = revision,
+    )
+
+private fun FileSyncPair.mediaBackupRemotePath(relativePath: String): String =
+    if (remoteRootPath.isBlank()) relativePath else "$remoteRootPath/$relativePath"
+
+internal fun mediaBackupLocalKey(localRootId: String, relativePath: String): String {
+    require(localRootId.isNotBlank() && relativePath.isNotBlank())
+    return MessageDigest.getInstance("SHA-256")
+        .digest("${localRootId.length}:$localRootId$relativePath".encodeToByteArray())
+        .joinToString("") { byte ->
+            (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+        }
+}
+
+internal suspend fun <T> withAndroidMediaBackupLedger(
+    context: Context,
+    pair: FileSyncPair,
+    block: suspend (AndroidMediaBackupLedgerBridge?) -> T,
+): T {
+    val bridge = try {
+        AndroidMediaBackupLedgerBridge.open(context, pair)
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (_: Throwable) {
+        null
+    }
+    return try {
+        block(bridge)
+    } finally {
+        bridge?.close()
+    }
+}
+
+/**
+ * Keeps the media ledger an eventual UI projection. Sync completion and WebDAV writes remain
+ * authoritative even if the local projection cannot be opened or updated.
+ */
+internal suspend fun runMediaBackupProjection(block: suspend () -> Unit): Boolean =
+    try {
+        block()
+        true
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (_: Throwable) {
+        false
+    }
+
+internal object MediaBackupStatusUpdates {
+    val changes = MutableSharedFlow<String>(extraBufferCapacity = 1)
+}

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
@@ -39,6 +39,8 @@ import dev.obiente.nextcloudnative.app.FileSyncConfiguration
 import dev.obiente.nextcloudnative.app.FileSyncDecisionChoice
 import dev.obiente.nextcloudnative.app.FileSyncLocalRoot
 import dev.obiente.nextcloudnative.app.MediaSyncFolderDiscovery
+import dev.obiente.nextcloudnative.app.MAX_MEDIA_BACKUP_STATUS_PATHS
+import dev.obiente.nextcloudnative.app.MediaBackupStatus
 import dev.obiente.nextcloudnative.app.filesByIdDavSearchRequest
 import dev.obiente.nextcloudnative.app.ExternalFileHandoffAction
 import dev.obiente.nextcloudnative.app.ExternalFileHandoffCapability
@@ -105,6 +107,9 @@ import java.net.URI
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -467,6 +472,45 @@ internal class AndroidNextcloudServices(
         )
         check(response.status == 207) { "WebDAV media search failed (HTTP ${response.status})." }
         parseDavFiles(response.body, userId).take(80)
+    }
+
+    override suspend fun loadMediaBackupStatuses(
+        session: NextcloudSession,
+        userId: String,
+        files: Collection<NextcloudFile>,
+    ): Map<String, MediaBackupStatus> = withContext(Dispatchers.IO) {
+        val paths = files.asSequence()
+            .filterNot(NextcloudFile::isDirectory)
+            .map { it.path.trim('/') }
+            .filter(String::isNotBlank)
+            .distinct()
+            .toList()
+        if (paths.isEmpty()) return@withContext emptyMap()
+        val store = createAndroidMediaBackupLedgerStore(
+            context = appContext,
+            recoverInterruptedTransfers = false,
+        )
+        try {
+            buildMap {
+                paths.chunked(MAX_MEDIA_BACKUP_STATUS_PATHS).forEach { chunk ->
+                    putAll(
+                        store.statusesForRemotePaths(
+                            accountId = NextcloudDocumentIds.accountKey(session),
+                            remotePaths = chunk,
+                        ),
+                    )
+                }
+            }
+        } finally {
+            store.close()
+        }
+    }
+
+    override fun observeMediaBackupStatusChanges(session: NextcloudSession): Flow<Unit> {
+        val accountId = NextcloudDocumentIds.accountKey(session)
+        return MediaBackupStatusUpdates.changes
+            .filter { changedAccountId -> changedAccountId == accountId }
+            .map { }
     }
 
     override suspend fun listSystemTags(session: NextcloudSession): List<NextcloudSystemTag> =

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedgerBridgeTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaBackupLedgerBridgeTest.kt
@@ -1,0 +1,191 @@
+package dev.obiente.nextcloudnative
+
+import dev.obiente.nextcloudnative.app.FileSyncBaseline
+import dev.obiente.nextcloudnative.app.FileSyncConfiguration
+import dev.obiente.nextcloudnative.app.FileSyncDirection
+import dev.obiente.nextcloudnative.app.FileSyncExecutionState
+import dev.obiente.nextcloudnative.app.FileSyncOperation
+import dev.obiente.nextcloudnative.app.FileSyncPair
+import dev.obiente.nextcloudnative.app.FileSyncWorkItem
+import dev.obiente.nextcloudnative.app.LocalSyncEntry
+import dev.obiente.nextcloudnative.app.MediaBackupStatus
+import dev.obiente.nextcloudnative.app.RemoteSyncEntry
+import dev.obiente.nextcloudnative.app.SyncEntryKind
+import dev.obiente.nextcloudnative.app.resolveMediaBackupStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+
+class AndroidMediaBackupLedgerBridgeTest {
+    @Test
+    fun projectionFailureCannotFailAuthoritativeSync() {
+        runBlocking {
+            assertTrue(runMediaBackupProjection { })
+            assertFalse(runMediaBackupProjection { error("projection unavailable") })
+            assertFailsWith<CancellationException> {
+                runMediaBackupProjection { throw CancellationException("cancelled") }
+            }
+        }
+    }
+
+    private val accountId = "0123456789abcdef0123456789abcdef"
+    private val localRoot = "${MEDIA_STORE_SYNC_ROOT_PREFIX}DCIM/Camera"
+    private val pair = FileSyncPair(
+        id = "pair-1",
+        accountId = accountId,
+        localRootId = localRoot,
+        remoteRootPath = "Photos/Camera",
+        configuration = FileSyncConfiguration(
+            direction = FileSyncDirection.UploadOnly,
+            deviceLabel = "Test device",
+        ),
+    )
+    private val local = LocalSyncEntry(
+        relativePath = "IMG_0042.jpg",
+        kind = SyncEntryKind.File,
+        revision = "generation:9",
+        size = 4_096,
+    )
+
+    @Test
+    fun localIdentityIsStableNonPersonalSha256() {
+        val key = mediaBackupLocalKey(localRoot, local.relativePath)
+
+        assertEquals(64, key.length)
+        assertTrue(key.all { it in "0123456789abcdef" })
+        assertEquals(key, mediaBackupLocalKey(localRoot, local.relativePath))
+        assertNotEquals(key, mediaBackupLocalKey(localRoot, "IMG_0043.jpg"))
+    }
+
+    @Test
+    fun uploadLifecycleAndChangedRevisionRemainVisible() {
+        val ready = uploadWork(FileSyncExecutionState.Ready)
+
+        var record = mediaBackupLedgerRecordForWork(pair, ready, existing = null, nowEpochMillis = 1_000)
+        assertEquals(MediaBackupStatus.Pending, record.resolveMediaBackupStatus())
+
+        val running = ready.copy(state = FileSyncExecutionState.Running, attemptCount = 1)
+        record = mediaBackupLedgerRecordForWork(
+            pair,
+            running,
+            existing = record,
+            nowEpochMillis = 2_000,
+        )
+        assertEquals(MediaBackupStatus.Uploading, record.resolveMediaBackupStatus())
+
+        record = mediaBackupLedgerRecordForWork(
+            pair,
+            running.copy(
+                state = FileSyncExecutionState.Failed,
+                failureMessage = "Network unavailable",
+            ),
+            existing = record,
+            nowEpochMillis = 3_000,
+        )
+        assertEquals(MediaBackupStatus.Failed, record.resolveMediaBackupStatus())
+
+        val baseline = FileSyncBaseline(
+            relativePath = local.relativePath,
+            kind = SyncEntryKind.File,
+            localRevision = local.revision,
+            remoteEtag = "\"remote-42\"",
+        )
+        record = mediaBackupSucceededRecord(
+            pair = pair,
+            work = running.copy(attemptCount = 2),
+            local = local,
+            baseline = baseline,
+            nowEpochMillis = 4_000,
+        )
+        assertEquals(MediaBackupStatus.BackedUp, record.resolveMediaBackupStatus())
+        assertEquals("Photos/Camera/IMG_0042.jpg", record.receipt?.remotePath)
+
+        val changed = local.copy(revision = "generation:10")
+        record = mediaBackupLedgerRecordForWork(
+            pair = pair,
+            work = ready.copy(
+                observedLocal = changed,
+                observedRemote = dev.obiente.nextcloudnative.app.RemoteSyncEntry(
+                    relativePath = local.relativePath,
+                    kind = SyncEntryKind.File,
+                    etag = requireNotNull(baseline.remoteEtag),
+                    size = local.size,
+                ),
+                observedBaseline = baseline,
+            ),
+            existing = record,
+            nowEpochMillis = 5_000,
+        )
+        assertEquals(MediaBackupStatus.ChangedAfterBackup, record.resolveMediaBackupStatus())
+    }
+
+    @Test
+    fun verifiedCoordinatorBaselineSeedsAPreviouslyEmptyLedger() {
+        val baseline = FileSyncBaseline(
+            relativePath = local.relativePath,
+            kind = SyncEntryKind.File,
+            localRevision = local.revision,
+            remoteEtag = "\"remote-42\"",
+        )
+
+        val record = requireNotNull(
+            mediaBackupVerifiedRecord(pair, local, baseline, existing = null, nowEpochMillis = 1_000),
+        )
+
+        assertEquals(MediaBackupStatus.BackedUp, record.resolveMediaBackupStatus())
+        assertNull(mediaBackupVerifiedRecord(pair, local, baseline, record, nowEpochMillis = 2_000))
+    }
+
+    @Test
+    fun missingLocalFileBecomesCloudOnlyOnlyWhileRemoteReceiptStillMatches() {
+        val baseline = FileSyncBaseline(
+            relativePath = local.relativePath,
+            kind = SyncEntryKind.File,
+            localRevision = local.revision,
+            remoteEtag = "\"remote-42\"",
+        )
+        val backedUp = requireNotNull(
+            mediaBackupVerifiedRecord(pair, local, baseline, existing = null, nowEpochMillis = 1_000),
+        )
+        val remote = RemoteSyncEntry(
+            relativePath = local.relativePath,
+            kind = SyncEntryKind.File,
+            etag = requireNotNull(baseline.remoteEtag),
+            size = local.size,
+        )
+
+        val cloudOnly = requireNotNull(
+            mediaBackupCloudOnlyRecord(pair, baseline, remote, backedUp, nowEpochMillis = 2_000),
+        )
+        assertEquals(MediaBackupStatus.CloudOnly, cloudOnly.resolveMediaBackupStatus())
+        assertNull(
+            mediaBackupCloudOnlyRecord(
+                pair,
+                baseline,
+                remote.copy(etag = "\"changed\""),
+                backedUp,
+                nowEpochMillis = 3_000,
+            ),
+        )
+        val restored = requireNotNull(
+            mediaBackupVerifiedRecord(pair, local, baseline, cloudOnly, nowEpochMillis = 4_000),
+        )
+        assertEquals(MediaBackupStatus.BackedUp, restored.resolveMediaBackupStatus())
+    }
+
+    private fun uploadWork(state: FileSyncExecutionState) = FileSyncWorkItem(
+        id = 1,
+        relativePath = local.relativePath,
+        observedLocal = local,
+        observedRemote = null,
+        observedBaseline = null,
+        operation = FileSyncOperation.Upload(local.relativePath, expectedRemoteEtag = null),
+        state = state,
+    )
+}

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedger.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedger.kt
@@ -113,6 +113,15 @@ data class MediaBackupLedgerSummary(
         get() = pending + uploading + failed + succeeded
 }
 
+fun MediaBackupLedgerRecord.resolveMediaBackupStatus(): MediaBackupStatus = when {
+    transferState == MediaBackupTransferState.Uploading -> MediaBackupStatus.Uploading
+    transferState == MediaBackupTransferState.Failed -> MediaBackupStatus.Failed
+    local == null -> MediaBackupStatus.CloudOnly
+    receipt == null -> MediaBackupStatus.Pending
+    receipt.matches(local) -> MediaBackupStatus.BackedUp
+    else -> MediaBackupStatus.ChangedAfterBackup
+}
+
 enum class MediaBackupStatus {
     Pending,
     Uploading,
@@ -171,4 +180,7 @@ private fun String.isSafeMediaLedgerText(maxLength: Int): Boolean =
 
 internal const val MAX_MEDIA_BACKUP_LEDGER_RECORDS_PER_ACCOUNT = 25_000
 internal const val MAX_MEDIA_BACKUP_LEDGER_PAGE_SIZE = 200
+const val MAX_MEDIA_BACKUP_STATUS_PATHS = 500
+const val MAX_MEDIA_BACKUP_LEDGER_QUERY_KEYS = 500
+const val MAX_MEDIA_BACKUP_LEDGER_WRITE_BATCH = 500
 private const val MAX_MEDIA_BACKUP_ATTEMPTS = 1_000

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerStore.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerStore.kt
@@ -20,15 +20,22 @@ class MediaBackupLedgerStoreException(message: String, cause: Throwable? = null)
 class MediaBackupLedgerStore internal constructor(
     private val connection: SQLiteConnection,
     private val maxRecordsPerAccount: Int = MAX_MEDIA_BACKUP_LEDGER_RECORDS_PER_ACCOUNT,
+    recoverInterruptedTransfers: Boolean = true,
 ) {
     private val mutex = Mutex()
 
-    constructor(databasePath: String) : this(BundledSQLiteDriver().open(databasePath))
+    constructor(
+        databasePath: String,
+        recoverInterruptedTransfers: Boolean = true,
+    ) : this(
+        connection = BundledSQLiteDriver().open(databasePath),
+        recoverInterruptedTransfers = recoverInterruptedTransfers,
+    )
 
     init {
         require(maxRecordsPerAccount in 1..MAX_MEDIA_BACKUP_LEDGER_RECORDS_PER_ACCOUNT)
         try {
-            initializeSchema()
+            initializeSchema(recoverInterruptedTransfers)
         } catch (failure: Throwable) {
             connection.close()
             throw if (failure is MediaBackupLedgerStoreException) {
@@ -39,15 +46,24 @@ class MediaBackupLedgerStore internal constructor(
         }
     }
 
-    suspend fun upsert(record: MediaBackupLedgerRecord) = mutex.withLock {
+    suspend fun upsert(record: MediaBackupLedgerRecord) = upsertAll(listOf(record))
+
+    suspend fun upsertAll(records: Collection<MediaBackupLedgerRecord>) = mutex.withLock {
+        require(records.size <= MAX_MEDIA_BACKUP_LEDGER_WRITE_BATCH)
+        require(records.map { it.accountId to it.localKey }.distinct().size == records.size)
+        if (records.isEmpty()) return@withLock
         transaction {
-            connection.prepare(UPSERT_RECORD).use { statement ->
-                statement.bindRecord(record)
-                check(!statement.step()) { "Media ledger upsert returned an unexpected row." }
+            records.forEach { record ->
+                connection.prepare(UPSERT_RECORD).use { statement ->
+                    statement.bindRecord(record)
+                    check(!statement.step()) { "Media ledger upsert returned an unexpected row." }
+                }
             }
-            pruneCompletedHistory(record.accountId)
-            check(countRecords(record.accountId) <= maxRecordsPerAccount) {
-                "The media ledger contains too many unfinished transfers for this account."
+            records.map(MediaBackupLedgerRecord::accountId).distinct().forEach { accountId ->
+                pruneCompletedHistory(accountId)
+                check(countRecords(accountId) <= maxRecordsPerAccount) {
+                    "The media ledger contains too many unfinished transfers for this account."
+                }
             }
         }
     }
@@ -62,6 +78,30 @@ class MediaBackupLedgerStore internal constructor(
             statement.bindText(1, accountId)
             statement.bindText(2, localKey)
             if (statement.step()) statement.readRecord() else null
+        }
+    }
+
+    suspend fun loadMany(
+        accountId: String,
+        localKeys: Collection<String>,
+    ): Map<String, MediaBackupLedgerRecord> = mutex.withLock {
+        requireAccountId(accountId)
+        val keys = localKeys.distinct()
+        require(keys.size <= MAX_MEDIA_BACKUP_LEDGER_QUERY_KEYS)
+        keys.forEach(::requireLocalKey)
+        if (keys.isEmpty()) return@withLock emptyMap()
+        val placeholders = List(keys.size) { "?" }.joinToString()
+        connection.prepare(
+            "$SELECT_COLUMNS WHERE account_id = ? AND local_key IN ($placeholders)",
+        ).use { statement ->
+            statement.bindText(1, accountId)
+            keys.forEachIndexed { index, key -> statement.bindText(index + 2, key) }
+            buildMap {
+                while (statement.step()) {
+                    val record = statement.readRecord()
+                    put(record.localKey, record)
+                }
+            }
         }
     }
 
@@ -134,6 +174,32 @@ class MediaBackupLedgerStore internal constructor(
         )
     }
 
+    suspend fun statusesForRemotePaths(
+        accountId: String,
+        remotePaths: Collection<String>,
+    ): Map<String, MediaBackupStatus> = mutex.withLock {
+        requireAccountId(accountId)
+        val paths = remotePaths.distinct()
+        require(paths.size <= MAX_MEDIA_BACKUP_STATUS_PATHS)
+        paths.forEach(::requireValidSyncPath)
+        if (paths.isEmpty()) return@withLock emptyMap()
+        val placeholders = List(paths.size) { "?" }.joinToString()
+        connection.prepare(
+            "$SELECT_COLUMNS WHERE account_id = ? AND remote_path IN ($placeholders) " +
+                "ORDER BY updated_at DESC, local_key DESC",
+        ).use { statement ->
+            statement.bindText(1, accountId)
+            paths.forEachIndexed { index, path -> statement.bindText(index + 2, path) }
+            buildMap {
+                while (statement.step()) {
+                    val record = statement.readRecord()
+                    val path = requireNotNull(record.receipt).remotePath
+                    putIfAbsent(path, record.resolveMediaBackupStatus())
+                }
+            }
+        }
+    }
+
     suspend fun deleteAccount(accountId: String) = mutex.withLock {
         requireAccountId(accountId)
         transaction {
@@ -148,7 +214,7 @@ class MediaBackupLedgerStore internal constructor(
         connection.close()
     }
 
-    private fun initializeSchema() {
+    private fun initializeSchema(recoverInterruptedTransfers: Boolean) {
         connection.prepare("PRAGMA journal_mode = WAL").use(SQLiteStatement::step)
         connection.execSQL("PRAGMA synchronous = FULL")
         connection.execSQL("PRAGMA foreign_keys = ON")
@@ -161,6 +227,11 @@ class MediaBackupLedgerStore internal constructor(
                 connection.execSQL(CREATE_TABLE)
                 connection.execSQL(CREATE_ACCOUNT_STATE_INDEX)
                 connection.execSQL(CREATE_ACCOUNT_UPDATED_INDEX)
+                connection.execSQL(CREATE_ACCOUNT_REMOTE_PATH_INDEX)
+                connection.execSQL("PRAGMA user_version = $SCHEMA_VERSION")
+            }
+            1 -> transaction {
+                connection.execSQL(CREATE_ACCOUNT_REMOTE_PATH_INDEX)
                 connection.execSQL("PRAGMA user_version = $SCHEMA_VERSION")
             }
             SCHEMA_VERSION -> Unit
@@ -168,11 +239,13 @@ class MediaBackupLedgerStore internal constructor(
                 "Media backup ledger schema version $version is unsupported.",
             )
         }
-        transaction {
-            connection.execSQL(
-                "UPDATE media_backup_ledger SET transfer_state = 'Pending', failure_message = NULL " +
-                    "WHERE transfer_state = 'Uploading'",
-            )
+        if (recoverInterruptedTransfers) {
+            transaction {
+                connection.execSQL(
+                    "UPDATE media_backup_ledger SET transfer_state = 'Pending', failure_message = NULL " +
+                        "WHERE transfer_state = 'Uploading'",
+                )
+            }
         }
     }
 
@@ -296,7 +369,7 @@ class MediaBackupLedgerStore internal constructor(
     }
 
     private companion object {
-        const val SCHEMA_VERSION = 1
+        const val SCHEMA_VERSION = 2
 
         const val SELECT_COLUMNS =
             "SELECT account_id, local_key, local_display_name, local_size, local_revision, " +
@@ -347,6 +420,10 @@ class MediaBackupLedgerStore internal constructor(
         const val CREATE_ACCOUNT_UPDATED_INDEX =
             "CREATE INDEX media_backup_account_updated " +
                 "ON media_backup_ledger(account_id, updated_at DESC, local_key DESC)"
+
+        const val CREATE_ACCOUNT_REMOTE_PATH_INDEX =
+            "CREATE INDEX media_backup_account_remote_path_updated " +
+                "ON media_backup_ledger(account_id, remote_path, updated_at DESC, local_key DESC)"
 
         val UPSERT_RECORD =
             """

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupStatusIndicator.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaBackupStatusIndicator.kt
@@ -1,0 +1,91 @@
+package dev.obiente.nextcloudnative.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dev.obiente.nextcloudnative.app.design.NextcloudIcons
+import dev.obiente.nextcloudnative.app.design.NextcloudRadii
+
+internal data class MediaBackupStatusPresentation(
+    val label: String,
+    val icon: ImageVector,
+)
+
+internal fun MediaBackupStatus.presentation(): MediaBackupStatusPresentation = when (this) {
+    MediaBackupStatus.Pending -> MediaBackupStatusPresentation("Pending", NextcloudIcons.Schedule)
+    MediaBackupStatus.Uploading -> MediaBackupStatusPresentation("Uploading", NextcloudIcons.Refresh)
+    MediaBackupStatus.BackedUp -> MediaBackupStatusPresentation("Backed up", NextcloudIcons.CheckCircle)
+    MediaBackupStatus.ChangedAfterBackup -> MediaBackupStatusPresentation("Changed", NextcloudIcons.Error)
+    MediaBackupStatus.Failed -> MediaBackupStatusPresentation("Failed", NextcloudIcons.Error)
+    MediaBackupStatus.CloudOnly -> MediaBackupStatusPresentation("Cloud only", NextcloudIcons.Cloud)
+}
+
+@Composable
+internal fun MediaBackupStatusIndicator(
+    status: MediaBackupStatus,
+    modifier: Modifier = Modifier,
+) {
+    val presentation = status.presentation()
+    val compact = status == MediaBackupStatus.BackedUp || status == MediaBackupStatus.CloudOnly
+    val containerColor = when (status) {
+        MediaBackupStatus.Failed -> MaterialTheme.colorScheme.errorContainer
+        MediaBackupStatus.ChangedAfterBackup -> MaterialTheme.colorScheme.tertiaryContainer
+        MediaBackupStatus.Uploading -> MaterialTheme.colorScheme.primaryContainer
+        MediaBackupStatus.BackedUp -> MaterialTheme.colorScheme.secondaryContainer
+        MediaBackupStatus.Pending,
+        MediaBackupStatus.CloudOnly,
+        -> MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
+    }
+    val contentColor = when (status) {
+        MediaBackupStatus.Failed -> MaterialTheme.colorScheme.onErrorContainer
+        MediaBackupStatus.ChangedAfterBackup -> MaterialTheme.colorScheme.onTertiaryContainer
+        MediaBackupStatus.Uploading -> MaterialTheme.colorScheme.onPrimaryContainer
+        MediaBackupStatus.BackedUp -> MaterialTheme.colorScheme.onSecondaryContainer
+        MediaBackupStatus.Pending,
+        MediaBackupStatus.CloudOnly,
+        -> MaterialTheme.colorScheme.onSurface
+    }
+    Surface(
+        modifier = modifier
+            .semantics { contentDescription = presentation.label }
+            .then(if (compact) Modifier.size(24.dp) else Modifier),
+        color = containerColor,
+        contentColor = contentColor,
+        shape = RoundedCornerShape(NextcloudRadii.Pill),
+        shadowElevation = 1.dp,
+    ) {
+        if (compact) {
+            Icon(
+                imageVector = presentation.icon,
+                contentDescription = null,
+                modifier = Modifier.padding(5.dp),
+            )
+        } else {
+            Row(
+                modifier = Modifier.padding(horizontal = 5.dp, vertical = 3.dp),
+                horizontalArrangement = Arrangement.spacedBy(3.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = presentation.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(12.dp),
+                )
+                Text(presentation.label, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+    }
+}

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionBrowser.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionBrowser.kt
@@ -307,6 +307,7 @@ fun NativeMediaCollectionContent(
     collection: NativeMediaCollection,
     items: List<NativeMediaItem>,
     resolvedFiles: Map<Long, NextcloudFile> = emptyMap(),
+    backupStatuses: Map<String, MediaBackupStatus> = emptyMap(),
     services: NextcloudPlatformServices,
     session: NextcloudSession,
     loadingMore: Boolean,
@@ -336,6 +337,7 @@ fun NativeMediaCollectionContent(
             NativeMediaItemTile(
                 media = media,
                 file = file,
+                backupStatus = backupStatuses[file.path.trim('/')],
                 services = services,
                 session = session,
                 onClick = { onOpenMedia(file, files) },
@@ -350,6 +352,7 @@ fun NativeMediaCollectionContent(
 private fun NativeMediaItemTile(
     media: NativeMediaItem,
     file: NextcloudFile,
+    backupStatus: MediaBackupStatus?,
     services: NextcloudPlatformServices,
     session: NextcloudSession,
     onClick: () -> Unit,
@@ -429,6 +432,12 @@ private fun NativeMediaItemTile(
                     modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp),
                 )
             }
+        }
+        backupStatus?.let { status ->
+            MediaBackupStatusIndicator(
+                status = status,
+                modifier = Modifier.align(Alignment.BottomStart).padding(5.dp),
+            )
         }
     }
 }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -127,6 +127,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -216,6 +217,7 @@ private class MediaCollectionsUiState {
     var dayIndex by mutableStateOf<NativeMediaDayIndex?>(null)
     var collectionItems by mutableStateOf<List<NativeMediaItem>>(emptyList())
     var resolvedFiles by mutableStateOf<Map<Long, NextcloudFile>>(emptyMap())
+    var backupStatuses by mutableStateOf<Map<String, MediaBackupStatus>>(emptyMap())
     var cursor by mutableStateOf<NativeMediaDayCursor?>(null)
     var loading by mutableStateOf(false)
     var error by mutableStateOf<String?>(null)
@@ -4664,6 +4666,9 @@ private fun MediaScreen(
     onOpenPerson: (NextcloudPerson) -> Unit,
 ) {
     var media by remember(userId) { mutableStateOf<List<NextcloudFile>?>(null) }
+    var mediaBackupStatuses by remember(userId) {
+        mutableStateOf<Map<String, MediaBackupStatus>>(emptyMap())
+    }
     val peopleByBackend = remember(userId) {
         mutableStateMapOf<NextcloudPeopleBackend, List<NextcloudPerson>>()
     }
@@ -4690,10 +4695,34 @@ private fun MediaScreen(
     LaunchedEffect(userId, mediaLoadAttempt) {
         if (userId == null) return@LaunchedEffect
         media = null
+        mediaBackupStatuses = emptyMap()
         mediaError = null
-        runCatching { services.listMedia(session, userId) }
-            .onSuccess { media = it }
+        runCatching {
+            val loaded = services.listMedia(session, userId)
+            val statuses = runCatching {
+                services.loadMediaBackupStatuses(session, userId, loaded)
+            }.getOrDefault(emptyMap())
+            loaded to statuses
+        }
+            .onSuccess { (loaded, statuses) ->
+                media = loaded
+                mediaBackupStatuses = statuses
+            }
             .onFailure { mediaError = it.message ?: "Could not load media." }
+    }
+    LaunchedEffect(userId, services) {
+        if (userId == null) return@LaunchedEffect
+        services.observeMediaBackupStatusChanges(session).collectLatest {
+            val visibleFiles = (media.orEmpty() + resolvedFiles.values)
+                .distinctBy { file -> file.path.trim('/') }
+            if (visibleFiles.isNotEmpty()) {
+                val statuses = runCatching {
+                    services.loadMediaBackupStatuses(session, userId, visibleFiles)
+                }.getOrDefault(emptyMap())
+                mediaBackupStatuses = mediaBackupStatuses + statuses
+                backupStatuses = backupStatuses + statuses
+            }
+        }
     }
     LaunchedEffect(mode, peopleBackend, peopleLoadAttempt) {
         if (mode != MediaMode.People || peopleBackend in peopleByBackend) return@LaunchedEffect
@@ -4734,13 +4763,22 @@ private fun MediaScreen(
                     services.resolveFilesById(session, userId, page.items.map(NativeMediaItem::fileId))
                 }.getOrDefault(emptyMap())
             }
-            Triple(index, page, resolved)
+            val statuses = if (userId == null || resolved.isEmpty()) {
+                emptyMap()
+            } else {
+                runCatching {
+                    services.loadMediaBackupStatuses(session, userId, resolved.values)
+                }.getOrDefault(emptyMap())
+            }
+            Triple(index, page, resolved) to statuses
         }
         if (generation != requestGeneration || selectedCollection?.key != collection.key) return
-        result.onSuccess { (index, page, resolved) ->
+        result.onSuccess { (loaded, statuses) ->
+            val (index, page, resolved) = loaded
             dayIndex = index
             collectionItems = if (reset) page.items else (collectionItems + page.items).distinctBy { it.fileId }
             resolvedFiles = if (reset) resolved else resolvedFiles + resolved
+            backupStatuses = if (reset) statuses else backupStatuses + statuses
             cursor = page.nextCursor
         }.onFailure {
             error = it.message ?: "Could not load this collection."
@@ -4756,6 +4794,7 @@ private fun MediaScreen(
             dayIndex = null
             collectionItems = emptyList()
             resolvedFiles = emptyMap()
+            backupStatuses = emptyMap()
             cursor = null
             loading = false
             error = null
@@ -4783,6 +4822,7 @@ private fun MediaScreen(
                     collection = collection,
                     items = collectionItems,
                     resolvedFiles = resolvedFiles,
+                    backupStatuses = backupStatuses,
                     services = services,
                     session = session,
                     loadingMore = loading,
@@ -5183,6 +5223,7 @@ private fun MediaScreen(
                             session = session,
                             file = stack.cover,
                             badge = stack.badge,
+                            backupStatus = mediaBackupStatuses[stack.cover.path.trim('/')],
                             onClick = { onOpenMedia(stack.cover, viewerSequence) },
                             onLongClick = {
                                 mediaToAdd = stack.cover
@@ -5225,6 +5266,7 @@ private fun MediaScreen(
                         dayIndex = null
                         collectionItems = emptyList()
                         resolvedFiles = emptyMap()
+                        backupStatuses = emptyMap()
                         cursor = null
                         loading = true
                         error = null
@@ -5389,6 +5431,9 @@ private fun PersonMediaScreen(
     var resolvedMediaFiles by remember(person.id, person.backend) {
         mutableStateOf<Map<Long, NextcloudFile>>(emptyMap())
     }
+    var mediaBackupStatuses by remember(person.id, person.backend) {
+        mutableStateOf<Map<String, MediaBackupStatus>>(emptyMap())
+    }
     var mediaDayIndex by remember(person.id, person.backend) { mutableStateOf<PersonMediaDayIndex?>(null) }
     var mediaCursor by remember(person.id, person.backend) { mutableStateOf<NativeMediaDayCursor?>(null) }
     var mediaLoadingMore by remember(person.id, person.backend) { mutableStateOf(false) }
@@ -5475,10 +5520,18 @@ private fun PersonMediaScreen(
                     )
                 }.getOrDefault(emptyMap())
             }
-            Triple(index, page, resolved)
+            val statuses = if (resolved.isEmpty()) {
+                emptyMap()
+            } else {
+                runCatching {
+                    services.loadMediaBackupStatuses(session, currentUserId, resolved.values)
+                }.getOrDefault(emptyMap())
+            }
+            Triple(index, page, resolved) to statuses
         }
         if (generation != mediaRequestGeneration) return
-        result.onSuccess { (index, page, resolved) ->
+        result.onSuccess { (loaded, statuses) ->
+            val (index, page, resolved) = loaded
             mediaDayIndex = index
             mediaItems = if (reset) {
                 page.items
@@ -5486,6 +5539,7 @@ private fun PersonMediaScreen(
                 (mediaItems.orEmpty() + page.items).distinctBy(NativeMediaItem::fileId)
             }
             resolvedMediaFiles = if (reset) resolved else resolvedMediaFiles + resolved
+            mediaBackupStatuses = if (reset) statuses else mediaBackupStatuses + statuses
             mediaCursor = page.nextCursor
         }.onFailure { failure ->
             val message = failure.message ?: "Could not load photos for this person."
@@ -5562,6 +5616,17 @@ private fun PersonMediaScreen(
         mediaLoadMoreError = null
         error = null
         loadPersonMediaPage(reset = true)
+    }
+    LaunchedEffect(person.id, person.backend, services) {
+        services.observeMediaBackupStatusChanges(session).collectLatest {
+            val visibleFiles = resolvedMediaFiles.values
+            if (visibleFiles.isNotEmpty()) {
+                val statuses = runCatching {
+                    services.loadMediaBackupStatuses(session, currentUserId, visibleFiles)
+                }.getOrDefault(emptyMap())
+                mediaBackupStatuses = mediaBackupStatuses + statuses
+            }
+        }
     }
     LaunchedEffect(mergePickerVisible, person.id, person.backend) {
         if (!mergePickerVisible || mergeTargets != null) return@LaunchedEffect
@@ -5716,6 +5781,7 @@ private fun PersonMediaScreen(
                             session = session,
                             file = file,
                             badge = if (photoSelectionMode != null && selectable) "Choose" else null,
+                            backupStatus = mediaBackupStatuses[file.path.trim('/')],
                             onClick = {
                                 when (photoSelectionMode) {
                                     PersonPhotoSelectionMode.Cover -> if (selectable) {
@@ -6190,6 +6256,7 @@ private fun MediaTile(
     session: NextcloudSession,
     file: NextcloudFile,
     badge: String? = null,
+    backupStatus: MediaBackupStatus? = null,
     onClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
 ) {
@@ -6236,6 +6303,12 @@ private fun MediaTile(
                         style = MaterialTheme.typography.labelSmall,
                     )
                 }
+            }
+            backupStatus?.let { status ->
+                MediaBackupStatusIndicator(
+                    status = status,
+                    modifier = Modifier.align(Alignment.BottomStart).padding(6.dp),
+                )
             }
         }
     }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
@@ -1,5 +1,7 @@
 package dev.obiente.nextcloudnative.app
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.serialization.Serializable
 
 enum class ThemePreference {
@@ -486,6 +488,21 @@ interface NextcloudPlatformServices {
     )
 
     suspend fun listMedia(session: NextcloudSession, userId: String): List<NextcloudFile>
+
+    /**
+     * Returns locally known backup state for authoritative server paths.
+     *
+     * Missing paths mean this platform has no device-local backup evidence. Callers must not infer
+     * a successful backup from a missing entry.
+     */
+    suspend fun loadMediaBackupStatuses(
+        session: NextcloudSession,
+        userId: String,
+        files: Collection<NextcloudFile>,
+    ): Map<String, MediaBackupStatus> = emptyMap()
+
+    /** Emits after this device changes backup evidence for the active account. */
+    fun observeMediaBackupStatusChanges(session: NextcloudSession): Flow<Unit> = emptyFlow()
 
     /**
      * Resolves stable server file IDs to current authoritative Files records.

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerTest.kt
@@ -48,6 +48,62 @@ class MediaBackupLedgerTest {
     }
 
     @Test
+    fun ledgerRecordsResolveEveryUserFacingBackupState() {
+        fun record(
+            state: MediaBackupTransferState,
+            localObject: LocalMediaObject? = local,
+            storedReceipt: MediaBackupReceipt? = null,
+            failure: String? = null,
+        ) = MediaBackupLedgerRecord(
+            accountId = accountId,
+            local = localObject,
+            receipt = storedReceipt,
+            transferState = state,
+            attemptCount = 1,
+            updatedAtEpochMillis = 2_000,
+            failureMessage = failure,
+        )
+
+        assertEquals(
+            MediaBackupStatus.Pending,
+            record(MediaBackupTransferState.Pending).resolveMediaBackupStatus(),
+        )
+        assertEquals(
+            MediaBackupStatus.Uploading,
+            record(MediaBackupTransferState.Uploading).resolveMediaBackupStatus(),
+        )
+        assertEquals(
+            MediaBackupStatus.Failed,
+            record(MediaBackupTransferState.Failed, failure = "Network unavailable")
+                .resolveMediaBackupStatus(),
+        )
+        assertEquals(
+            MediaBackupStatus.BackedUp,
+            record(MediaBackupTransferState.Succeeded, storedReceipt = receipt)
+                .resolveMediaBackupStatus(),
+        )
+        assertEquals(
+            MediaBackupStatus.ChangedAfterBackup,
+            record(
+                MediaBackupTransferState.Pending,
+                storedReceipt = receipt.copy(localRevision = "generation:8"),
+            ).resolveMediaBackupStatus(),
+        )
+        assertEquals(
+            MediaBackupStatus.CloudOnly,
+            record(
+                MediaBackupTransferState.Succeeded,
+                localObject = null,
+                storedReceipt = receipt,
+            ).resolveMediaBackupStatus(),
+        )
+        assertEquals(
+            listOf("Pending", "Uploading", "Backed up", "Changed", "Failed", "Cloud only"),
+            MediaBackupStatus.entries.map { it.presentation().label },
+        )
+    }
+
+    @Test
     fun sqliteLedgerRecoversInterruptedUploadAsPending() = runBlocking {
         val connection = BundledSQLiteDriver().open(":memory:")
         val firstProcess = MediaBackupLedgerStore(connection)
@@ -96,6 +152,47 @@ class MediaBackupLedgerTest {
     }
 
     @Test
+    fun remotePathStatusLookupIsBoundedAccountScopedAndUsesNewestRecord() = runBlocking {
+        val otherAccount = "fedcba9876543210fedcba9876543210"
+        val store = MediaBackupLedgerStore(BundledSQLiteDriver().open(":memory:"))
+        store.upsert(succeededRecord("external:old", 1_000))
+        store.upsert(
+            MediaBackupLedgerRecord(
+                accountId = accountId,
+                local = local.copy(key = "external:new"),
+                receipt = receipt.copy(localKey = "external:new"),
+                transferState = MediaBackupTransferState.Failed,
+                attemptCount = 2,
+                updatedAtEpochMillis = 2_000,
+                failureMessage = "Upload failed",
+            ),
+        )
+        val otherRecord = succeededRecord("external:other", 3_000)
+        store.upsert(
+            otherRecord.copy(
+                accountId = otherAccount,
+                receipt = requireNotNull(otherRecord.receipt).copy(remotePath = receipt.remotePath),
+            ),
+        )
+
+        assertEquals(
+            mapOf(receipt.remotePath to MediaBackupStatus.Failed),
+            store.statusesForRemotePaths(accountId, listOf(receipt.remotePath, "Photos/Absent.jpg")),
+        )
+        assertEquals(
+            mapOf(receipt.remotePath to MediaBackupStatus.BackedUp),
+            store.statusesForRemotePaths(otherAccount, listOf(receipt.remotePath)),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            store.statusesForRemotePaths(
+                accountId,
+                List(MAX_MEDIA_BACKUP_STATUS_PATHS + 1) { "Photos/$it.jpg" },
+            )
+        }
+        store.close()
+    }
+
+    @Test
     fun completedHistoryIsPrunedBeforeUnfinishedWork() = runBlocking {
         val store = MediaBackupLedgerStore(
             connection = BundledSQLiteDriver().open(":memory:"),
@@ -124,11 +221,27 @@ class MediaBackupLedgerTest {
         store.close()
 
         val future = BundledSQLiteDriver().open(":memory:")
-        future.execSQL("PRAGMA user_version = 2")
+        future.execSQL("PRAGMA user_version = 3")
         assertFailsWith<MediaBackupLedgerStoreException> {
             MediaBackupLedgerStore(future)
         }
         Unit
+    }
+
+    @Test
+    fun versionOneLedgerMigratesRemotePathIndex() = runBlocking {
+        val connection = BundledSQLiteDriver().open(":memory:")
+        MediaBackupLedgerStore(connection)
+        connection.execSQL("DROP INDEX media_backup_account_remote_path_updated")
+        connection.execSQL("PRAGMA user_version = 1")
+
+        val migrated = MediaBackupLedgerStore(connection)
+
+        connection.prepare("PRAGMA user_version").use { statement ->
+            check(statement.step())
+            assertEquals(2L, statement.getLong(0))
+        }
+        migrated.close()
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerPersistenceTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/MediaBackupLedgerPersistenceTest.kt
@@ -8,6 +8,42 @@ import kotlin.test.assertEquals
 
 class MediaBackupLedgerPersistenceTest {
     @Test
+    fun readOnlyUiConnectionDoesNotRecoverAnActiveUpload() = runBlocking {
+        val directory = Files.createTempDirectory("media-ledger-reader-")
+        val databasePath = directory.resolve("ledger.db").toString()
+        val accountId = "0123456789abcdef0123456789abcdef"
+        val local = LocalMediaObject(
+            key = "external:active",
+            displayName = "active.jpg",
+            size = 2_048,
+            revision = "generation:5",
+        )
+        val writer = MediaBackupLedgerStore(databasePath)
+        writer.upsert(
+            MediaBackupLedgerRecord(
+                accountId = accountId,
+                local = local,
+                receipt = null,
+                transferState = MediaBackupTransferState.Uploading,
+                attemptCount = 1,
+                updatedAtEpochMillis = 2_000,
+            ),
+        )
+
+        val reader = MediaBackupLedgerStore(
+            databasePath = databasePath,
+            recoverInterruptedTransfers = false,
+        )
+        assertEquals(MediaBackupTransferState.Uploading, reader.load(accountId, local.key)?.transferState)
+        reader.close()
+        assertEquals(MediaBackupTransferState.Uploading, writer.load(accountId, local.key)?.transferState)
+
+        writer.close()
+        directory.toFile().deleteRecursively()
+        Unit
+    }
+
+    @Test
     fun fileBackedLedgerSurvivesCloseAndRecoversActiveWork() = runBlocking {
         val directory = Files.createTempDirectory("media-ledger-")
         val databasePath = directory.resolve("ledger.db").toString()


### PR DESCRIPTION
## Summary

- persist account-scoped media upload state and verified remote receipts in the SQLite media ledger
- show pending, uploading, backed-up, changed, failed, and cloud-only state in timeline, collection, and person photo grids
- update visible media state while synchronization runs
- keep ledger failures isolated from authoritative WebDAV synchronization
- prevent read-only UI access from recovering or resetting an active upload

## User impact

People can see which device media is waiting, actively uploading, safely backed up, changed since backup, failed, or available only in the cloud. Routine states use compact icon badges while actionable states remain labeled.

## Validation

- `:contractAcquisition:test`
- `:androidApp:testDebugUnitTest`
- `:ui:desktopTest`
- `:androidApp:assembleDebug`
- repository hygiene and diff checks
- installed and cold-launched on a physical Android device

Closes #64