### PR TITLE
feat(sync): add native destination folder picker

### DIFF
--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
@@ -69,6 +69,11 @@ internal fun FileOfflineCenterScreen(
     var syncBusyPairId by remember(session, userId) { mutableStateOf<String?>(null) }
     var pendingLocalRoot by remember(session, userId) { mutableStateOf<FileSyncLocalRoot?>(null) }
     var pendingMediaSuggestion by remember(session, userId) { mutableStateOf<MediaSyncFolderSuggestion?>(null) }
+    var pendingRemotePath by remember(session, userId) { mutableStateOf<String?>(null) }
+    var pendingSyncConfiguration by remember(session, userId) {
+        mutableStateOf<FileSyncConfiguration?>(null)
+    }
+    var remoteFolderPickerVisible by remember(session, userId) { mutableStateOf(false) }
     var removeSyncPair by remember(session, userId) { mutableStateOf<FileSyncPairSummary?>(null) }
     var pendingSyncDecision by remember(session, userId) {
         mutableStateOf<PendingFileSyncDecision?>(null)
@@ -223,6 +228,11 @@ internal fun FileOfflineCenterScreen(
                                         .onSuccess { selected ->
                                             pendingMediaSuggestion = null
                                             pendingLocalRoot = selected
+                                            pendingRemotePath = null
+                                            pendingSyncConfiguration = selected?.let {
+                                                defaultFileSyncConfiguration(isMediaSuggestion = false)
+                                            }
+                                            remoteFolderPickerVisible = selected != null
                                         }
                                         .onFailure { failure ->
                                             actionMessage = failure.message ?: "Could not select a local folder."
@@ -234,6 +244,9 @@ internal fun FileOfflineCenterScreen(
                             if (syncBusyPairId == null) {
                                 pendingMediaSuggestion = suggestion
                                 pendingLocalRoot = suggestion.localRoot
+                                pendingRemotePath = null
+                                pendingSyncConfiguration = defaultFileSyncConfiguration(isMediaSuggestion = true)
+                                remoteFolderPickerVisible = true
                             }
                         },
                         onRequestMediaPermission = {
@@ -343,18 +356,51 @@ internal fun FileOfflineCenterScreen(
         )
     }
 
-    pendingLocalRoot?.let { localRoot ->
+    val localRootForDestination = pendingLocalRoot
+    if (remoteFolderPickerVisible && localRootForDestination != null) {
+        RemoteFolderPickerDialog(
+            services = services,
+            session = session,
+            userId = userId,
+            initialPath = pendingRemotePath
+                ?: pendingMediaSuggestion?.suggestedRemoteRootPath.orEmpty(),
+            onDismiss = {
+                remoteFolderPickerVisible = false
+                if (pendingRemotePath == null) {
+                    pendingLocalRoot = null
+                    pendingMediaSuggestion = null
+                    pendingSyncConfiguration = null
+                }
+            },
+            onSelected = { selectedPath ->
+                pendingRemotePath = selectedPath
+                remoteFolderPickerVisible = false
+            },
+        )
+    }
+
+    pendingLocalRoot?.takeIf {
+        !remoteFolderPickerVisible && pendingRemotePath != null && pendingSyncConfiguration != null
+    }?.let { localRoot ->
         AddFolderSyncDialog(
             localRoot = localRoot,
             mediaSuggestion = pendingMediaSuggestion,
+            remotePath = requireNotNull(pendingRemotePath),
+            configuration = requireNotNull(pendingSyncConfiguration),
             busy = syncBusyPairId == ADD_PAIR_BUSY_ID,
             onDismiss = {
                 if (syncBusyPairId == null) {
                     pendingLocalRoot = null
                     pendingMediaSuggestion = null
+                    pendingRemotePath = null
+                    pendingSyncConfiguration = null
                 }
             },
-            onAdd = { remotePath, configuration ->
+            onChooseDestination = {
+                if (syncBusyPairId == null) remoteFolderPickerVisible = true
+            },
+            onConfigurationChanged = { pendingSyncConfiguration = it },
+            onAdd = {
                 if (syncBusyPairId != null) return@AddFolderSyncDialog
                 syncBusyPairId = ADD_PAIR_BUSY_ID
                 actionMessage = null
@@ -364,14 +410,18 @@ internal fun FileOfflineCenterScreen(
                             session,
                             userId,
                             localRoot,
-                            remotePath,
-                            configuration,
+                            requireNotNull(pendingRemotePath),
+                            requireNotNull(pendingSyncConfiguration).let { configuration ->
+                                configuration.copy(deviceLabel = configuration.deviceLabel.trim())
+                            },
                         )
                     }.onSuccess { result ->
                         actionMessage = result.fileSyncCenterMessage()
                         if (result is FileSyncCenterActionResult.Completed) {
                             pendingLocalRoot = null
                             pendingMediaSuggestion = null
+                            pendingRemotePath = null
+                            pendingSyncConfiguration = null
                             refreshAttempt += 1
                         }
                     }.onFailure { failure ->
@@ -719,23 +769,14 @@ private fun FolderSyncPairCard(
 private fun AddFolderSyncDialog(
     localRoot: FileSyncLocalRoot,
     mediaSuggestion: MediaSyncFolderSuggestion?,
+    remotePath: String,
+    configuration: FileSyncConfiguration,
     busy: Boolean,
     onDismiss: () -> Unit,
-    onAdd: (String, FileSyncConfiguration) -> Unit,
+    onChooseDestination: () -> Unit,
+    onConfigurationChanged: (FileSyncConfiguration) -> Unit,
+    onAdd: () -> Unit,
 ) {
-    var remotePath by remember(localRoot, mediaSuggestion) {
-        mutableStateOf(mediaSuggestion?.suggestedRemoteRootPath.orEmpty())
-    }
-    var direction by remember(localRoot, mediaSuggestion) {
-        mutableStateOf(
-            if (mediaSuggestion == null) FileSyncDirection.Bidirectional else FileSyncDirection.UploadOnly,
-        )
-    }
-    var conflictPolicy by remember(localRoot) { mutableStateOf(FileSyncConflictPolicy.Ask) }
-    var deletionPolicy by remember(localRoot) { mutableStateOf(FileSyncDeletionPolicy.Ask) }
-    var networkPolicy by remember(localRoot) { mutableStateOf(FileSyncNetworkPolicy.AnyConnection) }
-    var powerPolicy by remember(localRoot) { mutableStateOf(FileSyncPowerPolicy.BatteryNotLow) }
-    var deviceLabel by remember(localRoot) { mutableStateOf("mobile") }
     AlertDialog(
         onDismissRequest = { if (!busy) onDismiss() },
         title = { Text("Add folder sync") },
@@ -745,57 +786,72 @@ private fun AddFolderSyncDialog(
                 verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
             ) {
                 Text("Local folder: ${mediaSuggestion?.relativePath ?: localRoot.displayName}")
-                OutlinedTextField(
-                    value = remotePath,
-                    onValueChange = { remotePath = it },
+                Surface(
                     modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Nextcloud folder path") },
-                    supportingText = { Text("For example Notes/Obsidian. Leave empty for the Files root.") },
-                    singleLine = true,
-                )
+                    color = NextcloudTheme.colors.appTile,
+                    shape = RoundedCornerShape(NextcloudRadii.Small),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(NextcloudSpacing.Medium),
+                        verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                    ) {
+                        Text("Nextcloud destination", style = MaterialTheme.typography.labelLarge)
+                        Text(
+                            if (remotePath.isEmpty()) "Files root" else "/$remotePath",
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        OutlinedButton(enabled = !busy, onClick = onChooseDestination) {
+                            Text("Choose another folder")
+                        }
+                    }
+                }
                 Text("Direction", style = MaterialTheme.typography.labelLarge)
                 FileSyncDirection.entries.forEach { option ->
                     FilterChip(
-                        selected = direction == option,
-                        onClick = { direction = option },
+                        selected = configuration.direction == option,
+                        onClick = { onConfigurationChanged(configuration.copy(direction = option)) },
                         label = { Text(option.readableSyncDirection()) },
                     )
                 }
                 Text("When both copies changed", style = MaterialTheme.typography.labelLarge)
                 FileSyncConflictPolicy.entries.forEach { option ->
                     FilterChip(
-                        selected = conflictPolicy == option,
-                        onClick = { conflictPolicy = option },
+                        selected = configuration.conflictPolicy == option,
+                        onClick = { onConfigurationChanged(configuration.copy(conflictPolicy = option)) },
                         label = { Text(option.readableConflictPolicy()) },
                     )
                 }
                 Text("When a file was deleted", style = MaterialTheme.typography.labelLarge)
                 FileSyncDeletionPolicy.entries.forEach { option ->
                     FilterChip(
-                        selected = deletionPolicy == option,
-                        onClick = { deletionPolicy = option },
+                        selected = configuration.deletionPolicy == option,
+                        onClick = { onConfigurationChanged(configuration.copy(deletionPolicy = option)) },
                         label = { Text(option.readableDeletionPolicy()) },
                     )
                 }
                 Text("Connection", style = MaterialTheme.typography.labelLarge)
                 FileSyncNetworkPolicy.entries.forEach { option ->
                     FilterChip(
-                        selected = networkPolicy == option,
-                        onClick = { networkPolicy = option },
+                        selected = configuration.networkPolicy == option,
+                        onClick = { onConfigurationChanged(configuration.copy(networkPolicy = option)) },
                         label = { Text(option.readableNetworkPolicy()) },
                     )
                 }
                 Text("Power", style = MaterialTheme.typography.labelLarge)
                 FileSyncPowerPolicy.entries.forEach { option ->
                     FilterChip(
-                        selected = powerPolicy == option,
-                        onClick = { powerPolicy = option },
+                        selected = configuration.powerPolicy == option,
+                        onClick = { onConfigurationChanged(configuration.copy(powerPolicy = option)) },
                         label = { Text(option.readablePowerPolicy()) },
                     )
                 }
                 OutlinedTextField(
-                    value = deviceLabel,
-                    onValueChange = { deviceLabel = it.take(128) },
+                    value = configuration.deviceLabel,
+                    onValueChange = {
+                        onConfigurationChanged(configuration.copy(deviceLabel = it.take(128)))
+                    },
                     modifier = Modifier.fillMaxWidth(),
                     label = { Text("Device label for conflict copies") },
                     singleLine = true,
@@ -804,20 +860,8 @@ private fun AddFolderSyncDialog(
         },
         confirmButton = {
             Button(
-                enabled = !busy && deviceLabel.isNotBlank(),
-                onClick = {
-                    onAdd(
-                        remotePath,
-                        FileSyncConfiguration(
-                            direction = direction,
-                            conflictPolicy = conflictPolicy,
-                            deletionPolicy = deletionPolicy,
-                            deviceLabel = deviceLabel.trim(),
-                            networkPolicy = networkPolicy,
-                            powerPolicy = powerPolicy,
-                        ),
-                    )
-                },
+                enabled = !busy && configuration.deviceLabel.isNotBlank(),
+                onClick = onAdd,
             ) {
                 if (busy) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
                 else Text("Add sync")
@@ -828,6 +872,16 @@ private fun AddFolderSyncDialog(
         },
     )
 }
+
+private fun defaultFileSyncConfiguration(isMediaSuggestion: Boolean): FileSyncConfiguration =
+    FileSyncConfiguration(
+        direction = if (isMediaSuggestion) FileSyncDirection.UploadOnly else FileSyncDirection.Bidirectional,
+        conflictPolicy = FileSyncConflictPolicy.Ask,
+        deletionPolicy = FileSyncDeletionPolicy.Ask,
+        deviceLabel = "mobile",
+        networkPolicy = FileSyncNetworkPolicy.AnyConnection,
+        powerPolicy = FileSyncPowerPolicy.BatteryNotLow,
+    )
 
 @Composable
 private fun OfflineCenterSummaryCard(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
@@ -1,0 +1,512 @@
+package dev.obiente.nextcloudnative.app
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.obiente.nextcloudnative.app.design.NextcloudIcons
+import dev.obiente.nextcloudnative.app.design.NextcloudRadii
+import dev.obiente.nextcloudnative.app.design.NextcloudSpacing
+import dev.obiente.nextcloudnative.app.design.NextcloudTheme
+import kotlinx.coroutines.launch
+
+internal data class RemoteFolderBreadcrumb(
+    val label: String,
+    val path: String,
+)
+
+internal fun canonicalRemoteFolderPath(value: String): String? {
+    if (value.isEmpty()) return ""
+    if (value.length > MAX_REMOTE_FOLDER_PATH_LENGTH ||
+        value.startsWith('/') ||
+        value.endsWith('/') ||
+        '\\' in value ||
+        '\u0000' in value ||
+        value.any(Char::isISOControl)
+    ) {
+        return null
+    }
+    val segments = value.split('/')
+    if (segments.any { it.isBlank() || it == "." || it == ".." }) return null
+    return value
+}
+
+internal fun normalizeRemoteFolderInput(value: String): String? =
+    canonicalRemoteFolderPath(value.trim().trim('/'))
+
+internal fun remoteFolderBreadcrumbs(path: String): List<RemoteFolderBreadcrumb> {
+    val canonical = requireNotNull(canonicalRemoteFolderPath(path)) {
+        "The remote folder path is invalid."
+    }
+    val breadcrumbs = mutableListOf(RemoteFolderBreadcrumb("Files", ""))
+    var current = ""
+    canonical.split('/').filter(String::isNotEmpty).forEach { segment ->
+        current = if (current.isEmpty()) segment else "$current/$segment"
+        breadcrumbs += RemoteFolderBreadcrumb(segment, current)
+    }
+    return breadcrumbs
+}
+
+internal fun remoteFolderParentPath(path: String): String? {
+    val canonical = requireNotNull(canonicalRemoteFolderPath(path)) {
+        "The remote folder path is invalid."
+    }
+    if (canonical.isEmpty()) return null
+    return canonical.substringBeforeLast('/', missingDelimiterValue = "")
+}
+
+internal fun remoteFolderDirectories(
+    files: List<NextcloudFile>,
+    parentPath: String,
+    query: String,
+): List<NextcloudFile> {
+    val canonicalParent = requireNotNull(canonicalRemoteFolderPath(parentPath)) {
+        "The remote folder path is invalid."
+    }
+    val normalizedQuery = query.trim()
+    return files.asSequence()
+        .filter(NextcloudFile::isDirectory)
+        .filter { file ->
+            canonicalRemoteFolderPath(file.path) == file.path &&
+                remoteFolderParentPath(file.path) == canonicalParent
+        }
+        .filter { file ->
+            normalizedQuery.isEmpty() || file.name.contains(normalizedQuery, ignoreCase = true)
+        }
+        .distinctBy(NextcloudFile::path)
+        .sortedBy { it.name.lowercase() }
+        .toList()
+}
+
+internal fun newRemoteFolderPath(parentPath: String, name: String): String? {
+    val parent = canonicalRemoteFolderPath(parentPath) ?: return null
+    if (name.isBlank() || name != name.trim() ||
+        name in setOf(".", "..") ||
+        name.any { it == '/' || it == '\\' || it == '\u0000' || it.isISOControl() }
+    ) {
+        return null
+    }
+    return canonicalRemoteFolderPath(if (parent.isEmpty()) name else "$parent/$name")
+}
+
+@Composable
+internal fun RemoteFolderPickerDialog(
+    services: NextcloudPlatformServices,
+    session: NextcloudSession,
+    userId: String,
+    initialPath: String,
+    onDismiss: () -> Unit,
+    onSelected: (String) -> Unit,
+) {
+    val safeInitialPath = remember(initialPath) { normalizeRemoteFolderInput(initialPath).orEmpty() }
+    var currentPath by remember(session, userId, safeInitialPath) { mutableStateOf(safeInitialPath) }
+    var files by remember(session, userId) { mutableStateOf<List<NextcloudFile>?>(null) }
+    var listingSource by remember(session, userId) {
+        mutableStateOf<NextcloudFileListingSource?>(null)
+    }
+    var networkConfirmedPath by remember(session, userId) { mutableStateOf<String?>(null) }
+    var loading by remember(session, userId) { mutableStateOf(true) }
+    var refreshing by remember(session, userId) { mutableStateOf(false) }
+    var error by remember(session, userId) { mutableStateOf<String?>(null) }
+    var query by remember(session, userId) { mutableStateOf("") }
+    var loadAttempt by remember(session, userId) { mutableStateOf(0) }
+    var createVisible by remember(session, userId) { mutableStateOf(false) }
+    var createName by remember(session, userId) { mutableStateOf("") }
+    var createError by remember(session, userId) { mutableStateOf<String?>(null) }
+    var createRunning by remember(session, userId) { mutableStateOf(false) }
+    var manualVisible by remember(session, userId) { mutableStateOf(false) }
+    var manualPath by remember(session, userId) { mutableStateOf(safeInitialPath) }
+    var manualError by remember(session, userId) { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(session, userId, currentPath, loadAttempt) {
+        files = null
+        listingSource = null
+        networkConfirmedPath = null
+        loading = true
+        refreshing = false
+        error = null
+        query = ""
+        val cached = runCatching {
+            services.listFilesCachedWithSource(session, userId, currentPath)
+        }.getOrNull()
+        if (cached != null) {
+            files = cached.files
+            listingSource = cached.source
+            loading = false
+            refreshing = true
+        }
+        runCatching { services.listFilesWithSource(session, userId, currentPath) }
+            .onSuccess { listing ->
+                files = listing.files
+                listingSource = listing.source
+                networkConfirmedPath = currentPath.takeIf {
+                    listing.source == NextcloudFileListingSource.Network
+                }
+                loading = false
+                refreshing = false
+                if (listing.source != NextcloudFileListingSource.Network) {
+                    error = "Connect to Nextcloud to confirm this destination."
+                }
+            }
+            .onFailure { failure ->
+                loading = false
+                refreshing = false
+                error = if (files == null) {
+                    failure.message ?: "Could not open this Nextcloud folder."
+                } else {
+                    "Could not confirm this cached folder with Nextcloud."
+                }
+            }
+    }
+
+    val directories = remember(files, currentPath, query) {
+        remoteFolderDirectories(files.orEmpty(), currentPath, query)
+    }
+    val breadcrumbs = remember(currentPath) { remoteFolderBreadcrumbs(currentPath) }
+    val canConfirm = networkConfirmedPath == currentPath && !createRunning
+
+    AlertDialog(
+        onDismissRequest = { if (!createRunning) onDismiss() },
+        title = { Text("Choose Nextcloud folder") },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth().heightIn(max = 590.dp),
+                verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState()),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    breadcrumbs.forEachIndexed { index, breadcrumb ->
+                        if (index > 0) {
+                            Text(
+                                " / ",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        TextButton(
+                            enabled = !createRunning && breadcrumb.path != currentPath,
+                            onClick = {
+                                currentPath = breadcrumb.path
+                                manualPath = breadcrumb.path
+                            },
+                        ) {
+                            Text(
+                                breadcrumb.label,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
+                Text(
+                    if (currentPath.isEmpty()) "Files root" else "/$currentPath",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it.take(MAX_REMOTE_FOLDER_SEARCH_LENGTH) },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Search this folder") },
+                    leadingIcon = {
+                        Icon(NextcloudIcons.Search, contentDescription = null)
+                    },
+                    singleLine = true,
+                )
+                when {
+                    loading -> {
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(NextcloudSpacing.Large),
+                            horizontalArrangement = Arrangement.Center,
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                        }
+                    }
+                    files == null -> {
+                        PickerMessage(
+                            message = error ?: "Could not open this folder.",
+                            parentPath = remoteFolderParentPath(currentPath),
+                            onParent = { parent ->
+                                currentPath = parent
+                                manualPath = parent
+                            },
+                            onRetry = { loadAttempt += 1 },
+                        )
+                    }
+                    else -> {
+                        if (refreshing) {
+                            Text(
+                                "Showing cached folders while refreshing…",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        error?.let {
+                            Text(
+                                it,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(
+                                    min = 96.dp,
+                                    max = if (createVisible || manualVisible) 150.dp else 280.dp,
+                                ),
+                        ) {
+                            if (directories.isEmpty()) {
+                                item {
+                                    Text(
+                                        if (query.isBlank()) {
+                                            "No folders here. You can select this folder or create one."
+                                        } else {
+                                            "No folders match your search."
+                                        },
+                                        modifier = Modifier.padding(NextcloudSpacing.Large),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            } else {
+                                items(directories, key = NextcloudFile::path) { directory ->
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clickable(enabled = !createRunning) {
+                                                currentPath = directory.path
+                                                manualPath = directory.path
+                                            }
+                                            .padding(vertical = NextcloudSpacing.Medium),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
+                                    ) {
+                                        Icon(
+                                            NextcloudIcons.Folder,
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.primary,
+                                        )
+                                        Text(
+                                            directory.name,
+                                            modifier = Modifier.weight(1f),
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                        Icon(NextcloudIcons.ChevronRight, contentDescription = "Open folder")
+                                    }
+                                    HorizontalDivider()
+                                }
+                            }
+                        }
+                    }
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                ) {
+                    OutlinedButton(
+                        enabled = !createRunning && networkConfirmedPath == currentPath,
+                        onClick = {
+                            createVisible = !createVisible
+                            manualVisible = false
+                            createError = null
+                            createName = ""
+                        },
+                    ) {
+                        Icon(
+                            NextcloudIcons.Add,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(" New folder")
+                    }
+                    TextButton(
+                        enabled = !createRunning,
+                        onClick = {
+                            manualVisible = !manualVisible
+                            createVisible = false
+                            manualPath = currentPath
+                            manualError = null
+                        },
+                    ) {
+                        Text("Advanced path")
+                    }
+                }
+                if (createVisible) {
+                    OutlinedTextField(
+                        value = createName,
+                        onValueChange = {
+                            createName = it.take(MAX_REMOTE_FOLDER_NAME_LENGTH)
+                            createError = null
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("New folder name") },
+                        supportingText = createError?.let { message -> { Text(message) } },
+                        isError = createError != null,
+                        singleLine = true,
+                    )
+                    Button(
+                        enabled = !createRunning && newRemoteFolderPath(currentPath, createName) != null,
+                        onClick = {
+                            val target = newRemoteFolderPath(currentPath, createName)
+                            if (target == null) {
+                                createError = "Enter a valid folder name."
+                                return@Button
+                            }
+                            createRunning = true
+                            createError = null
+                            scope.launch {
+                                runCatching {
+                                    services.createDirectoryIfAbsent(session, userId, target)
+                                }.onSuccess {
+                                    createVisible = false
+                                    createName = ""
+                                    currentPath = target
+                                    manualPath = target
+                                }.onFailure { failure ->
+                                    createError = failure.message ?: "Could not create this folder."
+                                }
+                                createRunning = false
+                            }
+                        },
+                    ) {
+                        if (createRunning) {
+                            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                        } else {
+                            Text("Create and open")
+                        }
+                    }
+                }
+                if (manualVisible) {
+                    OutlinedTextField(
+                        value = manualPath,
+                        onValueChange = {
+                            manualPath = it.take(MAX_REMOTE_FOLDER_PATH_LENGTH)
+                            manualError = null
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("Advanced Nextcloud path") },
+                        supportingText = {
+                            Text(manualError ?: "This path is opened and verified before it can be selected.")
+                        },
+                        isError = manualError != null,
+                        singleLine = true,
+                    )
+                    OutlinedButton(
+                        enabled = !createRunning,
+                        onClick = {
+                            val target = normalizeRemoteFolderInput(manualPath)
+                            if (target == null) {
+                                manualError = "Enter a valid relative Nextcloud path."
+                            } else {
+                                manualVisible = false
+                                currentPath = target
+                                manualPath = target
+                            }
+                        },
+                    ) {
+                        Text("Open path")
+                    }
+                }
+                Text(
+                    when {
+                        canConfirm && currentPath.isEmpty() -> "The Files root is ready to select."
+                        canConfirm -> "/$currentPath is ready to select."
+                        listingSource == NextcloudFileListingSource.Cache ->
+                            "This cached destination must be confirmed online before selection."
+                        else -> "Open an accessible folder before confirming."
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = if (canConfirm) FontWeight.Medium else FontWeight.Normal,
+                    color = if (canConfirm) {
+                        NextcloudTheme.colors.success
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                enabled = canConfirm,
+                onClick = { onSelected(currentPath) },
+            ) {
+                Text(if (currentPath.isEmpty()) "Use Files root" else "Use this folder")
+            }
+        },
+        dismissButton = {
+            TextButton(enabled = !createRunning, onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+@Composable
+private fun PickerMessage(
+    message: String,
+    parentPath: String?,
+    onParent: (String) -> Unit,
+    onRetry: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.errorContainer,
+        shape = RoundedCornerShape(NextcloudRadii.Small),
+    ) {
+        Column(
+            modifier = Modifier.padding(NextcloudSpacing.Large),
+            verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+        ) {
+            Text(message, color = MaterialTheme.colorScheme.onErrorContainer)
+            Row(horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small)) {
+                parentPath?.let { parent ->
+                    TextButton(onClick = { onParent(parent) }) { Text("Go to parent") }
+                }
+                TextButton(onClick = onRetry) { Text("Retry") }
+            }
+        }
+    }
+}
+
+private const val MAX_REMOTE_FOLDER_PATH_LENGTH = 8_192
+private const val MAX_REMOTE_FOLDER_NAME_LENGTH = 255
+private const val MAX_REMOTE_FOLDER_SEARCH_LENGTH = 256

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
@@ -122,6 +122,13 @@ internal fun remoteFolderDirectories(
         .toList()
 }
 
+internal fun remoteFolderRowKey(path: String): String {
+    val canonical = requireNotNull(canonicalRemoteFolderPath(path)) {
+        "The remote folder path is invalid."
+    }
+    return "remote-folder:${canonical.length}:$canonical"
+}
+
 internal fun newRemoteFolderPath(parentPath: String, name: String): String? {
     val parent = canonicalRemoteFolderPath(parentPath) ?: return null
     if (name.isBlank() || name != name.trim() ||
@@ -331,7 +338,7 @@ internal fun RemoteFolderPickerDialog(
                                 )
                             }
                         } else {
-                            items(directories, key = NextcloudFile::path) { directory ->
+                            items(directories, key = { directory -> remoteFolderRowKey(directory.path) }) { directory ->
                                 Row(
                                     modifier = Modifier
                                         .fillMaxWidth()

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
@@ -40,6 +40,7 @@ import dev.obiente.nextcloudnative.app.design.NextcloudIcons
 import dev.obiente.nextcloudnative.app.design.NextcloudRadii
 import dev.obiente.nextcloudnative.app.design.NextcloudSpacing
 import dev.obiente.nextcloudnative.app.design.NextcloudTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 internal data class RemoteFolderBreadcrumb(
@@ -140,6 +141,30 @@ internal fun newRemoteFolderPath(parentPath: String, name: String): String? {
     return canonicalRemoteFolderPath(if (parent.isEmpty()) name else "$parent/$name")
 }
 
+internal fun <T> Result<T>.rethrowRemoteFolderCancellation(): Result<T> {
+    val failure = exceptionOrNull()
+    if (failure is CancellationException) throw failure
+    return this
+}
+
+internal fun remoteFolderSelectionStatus(
+    loading: Boolean,
+    currentPath: String,
+    canConfirm: Boolean,
+    listingSource: NextcloudFileListingSource?,
+    manualPathVisible: Boolean,
+    manualPathDraft: String,
+): String = when {
+    loading -> "Loading this Nextcloud folder before it can be selected."
+    manualPathVisible && normalizeRemoteFolderInput(manualPathDraft) != currentPath ->
+        "Open and verify the advanced path before selecting it."
+    canConfirm && currentPath.isEmpty() -> "The Files root is ready to select."
+    canConfirm -> "/$currentPath is ready to select."
+    listingSource == NextcloudFileListingSource.Cache ->
+        "This cached destination must be confirmed online before selection."
+    else -> "Open an accessible folder before confirming."
+}
+
 @Composable
 internal fun RemoteFolderPickerDialog(
     services: NextcloudPlatformServices,
@@ -180,7 +205,7 @@ internal fun RemoteFolderPickerDialog(
         query = ""
         val cached = runCatching {
             services.listFilesCachedWithSource(session, userId, currentPath)
-        }.getOrNull()
+        }.rethrowRemoteFolderCancellation().getOrNull()
         if (cached != null) {
             files = cached.files
             listingSource = cached.source
@@ -188,6 +213,7 @@ internal fun RemoteFolderPickerDialog(
             refreshing = true
         }
         runCatching { services.listFilesWithSource(session, userId, currentPath) }
+            .rethrowRemoteFolderCancellation()
             .onSuccess { listing ->
                 files = listing.files
                 listingSource = listing.source
@@ -430,7 +456,7 @@ internal fun RemoteFolderPickerDialog(
                                     scope.launch {
                                         runCatching {
                                             services.createDirectoryIfAbsent(session, userId, target)
-                                        }.onSuccess {
+                                        }.rethrowRemoteFolderCancellation().onSuccess {
                                             createVisible = false
                                             createName = ""
                                             currentPath = target
@@ -491,15 +517,14 @@ internal fun RemoteFolderPickerDialog(
                 }
                 item(key = "selection-status") {
                     Text(
-                        when {
-                            manualVisible && normalizeRemoteFolderInput(manualPath) != currentPath ->
-                                "Open and verify the advanced path before selecting it."
-                            canConfirm && currentPath.isEmpty() -> "The Files root is ready to select."
-                            canConfirm -> "/$currentPath is ready to select."
-                            listingSource == NextcloudFileListingSource.Cache ->
-                                "This cached destination must be confirmed online before selection."
-                            else -> "Open an accessible folder before confirming."
-                        },
+                        remoteFolderSelectionStatus(
+                            loading = loading,
+                            currentPath = currentPath,
+                            canConfirm = canConfirm,
+                            listingSource = listingSource,
+                            manualPathVisible = manualVisible,
+                            manualPathDraft = manualPath,
+                        ),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = if (canConfirm) FontWeight.Medium else FontWeight.Normal,
                         color = if (canConfirm) {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
@@ -64,7 +64,19 @@ internal fun canonicalRemoteFolderPath(value: String): String? {
 }
 
 internal fun normalizeRemoteFolderInput(value: String): String? =
-    canonicalRemoteFolderPath(value.trim().trim('/'))
+    canonicalRemoteFolderPath(value.trim('/'))
+
+internal fun canConfirmRemoteFolderSelection(
+    currentPath: String,
+    networkConfirmedPath: String?,
+    manualPathVisible: Boolean,
+    manualPathDraft: String,
+    busy: Boolean,
+): Boolean {
+    if (busy || networkConfirmedPath != currentPath) return false
+    if (!manualPathVisible) return true
+    return normalizeRemoteFolderInput(manualPathDraft) == currentPath
+}
 
 internal fun remoteFolderBreadcrumbs(path: String): List<RemoteFolderBreadcrumb> {
     val canonical = requireNotNull(canonicalRemoteFolderPath(path)) {
@@ -196,272 +208,300 @@ internal fun RemoteFolderPickerDialog(
         remoteFolderDirectories(files.orEmpty(), currentPath, query)
     }
     val breadcrumbs = remember(currentPath) { remoteFolderBreadcrumbs(currentPath) }
-    val canConfirm = networkConfirmedPath == currentPath && !createRunning
+    val canConfirm = canConfirmRemoteFolderSelection(
+        currentPath = currentPath,
+        networkConfirmedPath = networkConfirmedPath,
+        manualPathVisible = manualVisible,
+        manualPathDraft = manualPath,
+        busy = createRunning,
+    )
 
     AlertDialog(
         onDismissRequest = { if (!createRunning) onDismiss() },
         title = { Text("Choose Nextcloud folder") },
         text = {
-            Column(
+            LazyColumn(
                 modifier = Modifier.fillMaxWidth().heightIn(max = 590.dp),
                 verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
             ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState()),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    breadcrumbs.forEachIndexed { index, breadcrumb ->
-                        if (index > 0) {
-                            Text(
-                                " / ",
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                        TextButton(
-                            enabled = !createRunning && breadcrumb.path != currentPath,
-                            onClick = {
-                                currentPath = breadcrumb.path
-                                manualPath = breadcrumb.path
-                            },
-                        ) {
-                            Text(
-                                breadcrumb.label,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
+                item(key = "breadcrumbs") {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState()),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        breadcrumbs.forEachIndexed { index, breadcrumb ->
+                            if (index > 0) {
+                                Text(
+                                    " / ",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            TextButton(
+                                enabled = !createRunning && breadcrumb.path != currentPath,
+                                onClick = {
+                                    currentPath = breadcrumb.path
+                                    manualPath = breadcrumb.path
+                                },
+                            ) {
+                                Text(
+                                    breadcrumb.label,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
                         }
                     }
                 }
-                Text(
-                    if (currentPath.isEmpty()) "Files root" else "/$currentPath",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                OutlinedTextField(
-                    value = query,
-                    onValueChange = { query = it.take(MAX_REMOTE_FOLDER_SEARCH_LENGTH) },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Search this folder") },
-                    leadingIcon = {
-                        Icon(NextcloudIcons.Search, contentDescription = null)
-                    },
-                    singleLine = true,
-                )
+                item(key = "current-path") {
+                    Text(
+                        if (currentPath.isEmpty()) "Files root" else "/$currentPath",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                item(key = "search") {
+                    OutlinedTextField(
+                        value = query,
+                        onValueChange = { query = it.take(MAX_REMOTE_FOLDER_SEARCH_LENGTH) },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("Search this folder") },
+                        leadingIcon = {
+                            Icon(NextcloudIcons.Search, contentDescription = null)
+                        },
+                        singleLine = true,
+                    )
+                }
                 when {
                     loading -> {
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(NextcloudSpacing.Large),
-                            horizontalArrangement = Arrangement.Center,
-                        ) {
-                            CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                        item(key = "loading") {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(NextcloudSpacing.Large),
+                                horizontalArrangement = Arrangement.Center,
+                            ) {
+                                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                            }
                         }
                     }
                     files == null -> {
-                        PickerMessage(
-                            message = error ?: "Could not open this folder.",
-                            parentPath = remoteFolderParentPath(currentPath),
-                            onParent = { parent ->
-                                currentPath = parent
-                                manualPath = parent
-                            },
-                            onRetry = { loadAttempt += 1 },
-                        )
+                        item(key = "load-error") {
+                            PickerMessage(
+                                message = error ?: "Could not open this folder.",
+                                parentPath = remoteFolderParentPath(currentPath),
+                                onParent = { parent ->
+                                    currentPath = parent
+                                    manualPath = parent
+                                },
+                                onRetry = { loadAttempt += 1 },
+                            )
+                        }
                     }
                     else -> {
                         if (refreshing) {
-                            Text(
-                                "Showing cached folders while refreshing…",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                            item(key = "refreshing") {
+                                Text(
+                                    "Showing cached folders while refreshing…",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                         }
                         error?.let {
-                            Text(
-                                it,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.error,
-                            )
+                            item(key = "listing-error") {
+                                Text(
+                                    it,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            }
                         }
-                        LazyColumn(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .heightIn(
-                                    min = 96.dp,
-                                    max = if (createVisible || manualVisible) 150.dp else 280.dp,
-                                ),
-                        ) {
-                            if (directories.isEmpty()) {
-                                item {
-                                    Text(
-                                        if (query.isBlank()) {
-                                            "No folders here. You can select this folder or create one."
-                                        } else {
-                                            "No folders match your search."
-                                        },
-                                        modifier = Modifier.padding(NextcloudSpacing.Large),
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        if (directories.isEmpty()) {
+                            item(key = "empty-folders") {
+                                Text(
+                                    if (query.isBlank()) {
+                                        "No folders here. You can select this folder or create one."
+                                    } else {
+                                        "No folders match your search."
+                                    },
+                                    modifier = Modifier.padding(NextcloudSpacing.Large),
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else {
+                            items(directories, key = NextcloudFile::path) { directory ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable(enabled = !createRunning) {
+                                            currentPath = directory.path
+                                            manualPath = directory.path
+                                        }
+                                        .padding(vertical = NextcloudSpacing.Medium),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
+                                ) {
+                                    Icon(
+                                        NextcloudIcons.Folder,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
                                     )
+                                    Text(
+                                        directory.name,
+                                        modifier = Modifier.weight(1f),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                    Icon(NextcloudIcons.ChevronRight, contentDescription = "Open folder")
                                 }
-                            } else {
-                                items(directories, key = NextcloudFile::path) { directory ->
-                                    Row(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .clickable(enabled = !createRunning) {
-                                                currentPath = directory.path
-                                                manualPath = directory.path
-                                            }
-                                            .padding(vertical = NextcloudSpacing.Medium),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
-                                    ) {
-                                        Icon(
-                                            NextcloudIcons.Folder,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.primary,
-                                        )
-                                        Text(
-                                            directory.name,
-                                            modifier = Modifier.weight(1f),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                        )
-                                        Icon(NextcloudIcons.ChevronRight, contentDescription = "Open folder")
-                                    }
-                                    HorizontalDivider()
-                                }
+                                HorizontalDivider()
                             }
                         }
                     }
                 }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
-                ) {
-                    OutlinedButton(
-                        enabled = !createRunning && networkConfirmedPath == currentPath,
-                        onClick = {
-                            createVisible = !createVisible
-                            manualVisible = false
-                            createError = null
-                            createName = ""
-                        },
+                item(key = "folder-actions") {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
                     ) {
-                        Icon(
-                            NextcloudIcons.Add,
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Text(" New folder")
-                    }
-                    TextButton(
-                        enabled = !createRunning,
-                        onClick = {
-                            manualVisible = !manualVisible
-                            createVisible = false
-                            manualPath = currentPath
-                            manualError = null
-                        },
-                    ) {
-                        Text("Advanced path")
+                        OutlinedButton(
+                            enabled = !createRunning && networkConfirmedPath == currentPath,
+                            onClick = {
+                                createVisible = !createVisible
+                                manualVisible = false
+                                createError = null
+                                createName = ""
+                            },
+                        ) {
+                            Icon(
+                                NextcloudIcons.Add,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(" New folder")
+                        }
+                        TextButton(
+                            enabled = !createRunning,
+                            onClick = {
+                                manualVisible = !manualVisible
+                                createVisible = false
+                                manualPath = currentPath
+                                manualError = null
+                            },
+                        ) {
+                            Text("Advanced path")
+                        }
                     }
                 }
                 if (createVisible) {
-                    OutlinedTextField(
-                        value = createName,
-                        onValueChange = {
-                            createName = it.take(MAX_REMOTE_FOLDER_NAME_LENGTH)
-                            createError = null
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        label = { Text("New folder name") },
-                        supportingText = createError?.let { message -> { Text(message) } },
-                        isError = createError != null,
-                        singleLine = true,
-                    )
-                    Button(
-                        enabled = !createRunning && newRemoteFolderPath(currentPath, createName) != null,
-                        onClick = {
-                            val target = newRemoteFolderPath(currentPath, createName)
-                            if (target == null) {
-                                createError = "Enter a valid folder name."
-                                return@Button
-                            }
-                            createRunning = true
-                            createError = null
-                            scope.launch {
-                                runCatching {
-                                    services.createDirectoryIfAbsent(session, userId, target)
-                                }.onSuccess {
-                                    createVisible = false
-                                    createName = ""
-                                    currentPath = target
-                                    manualPath = target
-                                }.onFailure { failure ->
-                                    createError = failure.message ?: "Could not create this folder."
+                    item(key = "create-folder") {
+                        Column(verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small)) {
+                            OutlinedTextField(
+                                value = createName,
+                                onValueChange = {
+                                    createName = it.take(MAX_REMOTE_FOLDER_NAME_LENGTH)
+                                    createError = null
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("New folder name") },
+                                supportingText = createError?.let { message -> { Text(message) } },
+                                isError = createError != null,
+                                singleLine = true,
+                            )
+                            Button(
+                                enabled = !createRunning && newRemoteFolderPath(currentPath, createName) != null,
+                                onClick = {
+                                    val target = newRemoteFolderPath(currentPath, createName)
+                                    if (target == null) {
+                                        createError = "Enter a valid folder name."
+                                        return@Button
+                                    }
+                                    createRunning = true
+                                    createError = null
+                                    scope.launch {
+                                        runCatching {
+                                            services.createDirectoryIfAbsent(session, userId, target)
+                                        }.onSuccess {
+                                            createVisible = false
+                                            createName = ""
+                                            currentPath = target
+                                            manualPath = target
+                                        }.onFailure { failure ->
+                                            createError = failure.message ?: "Could not create this folder."
+                                        }
+                                        createRunning = false
+                                    }
+                                },
+                            ) {
+                                if (createRunning) {
+                                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                                } else {
+                                    Text("Create and open")
                                 }
-                                createRunning = false
                             }
-                        },
-                    ) {
-                        if (createRunning) {
-                            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                        } else {
-                            Text("Create and open")
                         }
                     }
                 }
                 if (manualVisible) {
-                    OutlinedTextField(
-                        value = manualPath,
-                        onValueChange = {
-                            manualPath = it.take(MAX_REMOTE_FOLDER_PATH_LENGTH)
-                            manualError = null
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                        label = { Text("Advanced Nextcloud path") },
-                        supportingText = {
-                            Text(manualError ?: "This path is opened and verified before it can be selected.")
-                        },
-                        isError = manualError != null,
-                        singleLine = true,
-                    )
-                    OutlinedButton(
-                        enabled = !createRunning,
-                        onClick = {
-                            val target = normalizeRemoteFolderInput(manualPath)
-                            if (target == null) {
-                                manualError = "Enter a valid relative Nextcloud path."
-                            } else {
-                                manualVisible = false
-                                currentPath = target
-                                manualPath = target
+                    item(key = "manual-path") {
+                        Column(verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small)) {
+                            OutlinedTextField(
+                                value = manualPath,
+                                onValueChange = {
+                                    manualPath = it.take(MAX_REMOTE_FOLDER_PATH_LENGTH)
+                                    manualError = null
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                label = { Text("Advanced Nextcloud path") },
+                                supportingText = {
+                                    Text(
+                                        manualError
+                                            ?: "Open and verify this path before selecting the destination.",
+                                    )
+                                },
+                                isError = manualError != null,
+                                singleLine = true,
+                            )
+                            OutlinedButton(
+                                enabled = !createRunning,
+                                onClick = {
+                                    val target = normalizeRemoteFolderInput(manualPath)
+                                    if (target == null) {
+                                        manualError = "Enter a valid relative Nextcloud path."
+                                    } else {
+                                        manualVisible = false
+                                        currentPath = target
+                                        manualPath = target
+                                    }
+                                },
+                            ) {
+                                Text("Open and verify")
                             }
-                        },
-                    ) {
-                        Text("Open path")
+                        }
                     }
                 }
-                Text(
-                    when {
-                        canConfirm && currentPath.isEmpty() -> "The Files root is ready to select."
-                        canConfirm -> "/$currentPath is ready to select."
-                        listingSource == NextcloudFileListingSource.Cache ->
-                            "This cached destination must be confirmed online before selection."
-                        else -> "Open an accessible folder before confirming."
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                    fontWeight = if (canConfirm) FontWeight.Medium else FontWeight.Normal,
-                    color = if (canConfirm) {
-                        NextcloudTheme.colors.success
-                    } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                )
+                item(key = "selection-status") {
+                    Text(
+                        when {
+                            manualVisible && normalizeRemoteFolderInput(manualPath) != currentPath ->
+                                "Open and verify the advanced path before selecting it."
+                            canConfirm && currentPath.isEmpty() -> "The Files root is ready to select."
+                            canConfirm -> "/$currentPath is ready to select."
+                            listingSource == NextcloudFileListingSource.Cache ->
+                                "This cached destination must be confirmed online before selection."
+                            else -> "Open an accessible folder before confirming."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = if (canConfirm) FontWeight.Medium else FontWeight.Normal,
+                        color = if (canConfirm) {
+                            NextcloudTheme.colors.success
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
             }
         },
         confirmButton = {

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
@@ -1,0 +1,84 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RemoteFolderPickerTest {
+    @Test
+    fun `canonical paths preserve server names while manual input normalizes outer separators`() {
+        assertEquals("", canonicalRemoteFolderPath(""))
+        assertEquals(" Photos / Camera ", canonicalRemoteFolderPath(" Photos / Camera "))
+        assertNull(canonicalRemoteFolderPath("/Photos/Camera/"))
+        assertEquals("", normalizeRemoteFolderInput(" / "))
+        assertEquals("Photos/Camera", normalizeRemoteFolderInput(" /Photos/Camera/ "))
+
+        assertNull(canonicalRemoteFolderPath("Photos//Camera"))
+        assertNull(canonicalRemoteFolderPath("Photos/../Secrets"))
+        assertNull(canonicalRemoteFolderPath("Photos\\Camera"))
+        assertNull(canonicalRemoteFolderPath("Photos/\u0000Camera"))
+    }
+
+    @Test
+    fun `breadcrumbs retain canonical path for files root and every ancestor`() {
+        assertEquals(
+            listOf(
+                RemoteFolderBreadcrumb("Files", ""),
+                RemoteFolderBreadcrumb("Photos", "Photos"),
+                RemoteFolderBreadcrumb("Camera", "Photos/Camera"),
+            ),
+            remoteFolderBreadcrumbs("Photos/Camera"),
+        )
+        assertEquals(listOf(RemoteFolderBreadcrumb("Files", "")), remoteFolderBreadcrumbs(""))
+        assertEquals("Photos", remoteFolderParentPath("Photos/Camera"))
+        assertEquals("", remoteFolderParentPath("Photos"))
+        assertNull(remoteFolderParentPath(""))
+    }
+
+    @Test
+    fun `folder listing rejects files nested entries and duplicate server rows`() {
+        val files = listOf(
+            directory("Photos/Camera", "Camera"),
+            directory("Photos/Screenshots", "Screenshots"),
+            directory("Photos/Camera/2026", "2026"),
+            directory("Photos/Camera", "Camera duplicate"),
+            file("Photos/readme.txt", "readme.txt"),
+            directory("../Outside", "Outside"),
+        )
+
+        assertEquals(
+            listOf("Photos/Camera", "Photos/Screenshots"),
+            remoteFolderDirectories(files, "Photos", "").map(NextcloudFile::path),
+        )
+        assertEquals(
+            listOf("Photos/Screenshots"),
+            remoteFolderDirectories(files, "Photos", "shots").map(NextcloudFile::path),
+        )
+    }
+
+    @Test
+    fun `new folders are canonical children and unsafe names are rejected`() {
+        assertEquals("Photos/Camera", newRemoteFolderPath("Photos", "Camera"))
+        assertEquals("Photos", newRemoteFolderPath("", "Photos"))
+
+        assertNull(newRemoteFolderPath("Photos", " Camera"))
+        assertNull(newRemoteFolderPath("Photos", "../Camera"))
+        assertNull(newRemoteFolderPath("Photos", "Camera/2026"))
+        assertNull(newRemoteFolderPath("../Outside", "Camera"))
+    }
+
+    private fun directory(path: String, name: String) = nextcloudFile(path, name, isDirectory = true)
+
+    private fun file(path: String, name: String) = nextcloudFile(path, name, isDirectory = false)
+
+    private fun nextcloudFile(path: String, name: String, isDirectory: Boolean) = NextcloudFile(
+        path = path,
+        name = name,
+        isDirectory = isDirectory,
+        mimeType = if (isDirectory) "httpd/unix-directory" else "text/plain",
+        size = null,
+        lastModified = null,
+        fileId = null,
+        hasPreview = false,
+    )
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
@@ -10,13 +10,84 @@ class RemoteFolderPickerTest {
         assertEquals("", canonicalRemoteFolderPath(""))
         assertEquals(" Photos / Camera ", canonicalRemoteFolderPath(" Photos / Camera "))
         assertNull(canonicalRemoteFolderPath("/Photos/Camera/"))
-        assertEquals("", normalizeRemoteFolderInput(" / "))
-        assertEquals("Photos/Camera", normalizeRemoteFolderInput(" /Photos/Camera/ "))
+        assertEquals("", normalizeRemoteFolderInput("/"))
+        assertEquals("Photos/Camera", normalizeRemoteFolderInput("/Photos/Camera/"))
+        assertEquals(" Photos ", normalizeRemoteFolderInput("/ Photos /"))
+        assertEquals(" Photos ", normalizeRemoteFolderInput(" Photos "))
+        assertEquals(" Photos /Camera ", normalizeRemoteFolderInput("/ Photos /Camera /"))
+        assertEquals(
+            listOf(RemoteFolderBreadcrumb("Files", ""), RemoteFolderBreadcrumb(" Photos ", " Photos ")),
+            remoteFolderBreadcrumbs(requireNotNull(normalizeRemoteFolderInput("/ Photos /"))),
+        )
 
         assertNull(canonicalRemoteFolderPath("Photos//Camera"))
         assertNull(canonicalRemoteFolderPath("Photos/../Secrets"))
         assertNull(canonicalRemoteFolderPath("Photos\\Camera"))
         assertNull(canonicalRemoteFolderPath("Photos/\u0000Camera"))
+    }
+
+    @Test
+    fun `unopened advanced path draft cannot confirm the previously verified folder`() {
+        assertEquals(
+            true,
+            canConfirmRemoteFolderSelection(
+                currentPath = "Photos",
+                networkConfirmedPath = "Photos",
+                manualPathVisible = false,
+                manualPathDraft = "Photos",
+                busy = false,
+            ),
+        )
+        assertEquals(
+            false,
+            canConfirmRemoteFolderSelection(
+                currentPath = "Documents",
+                networkConfirmedPath = null,
+                manualPathVisible = false,
+                manualPathDraft = "Documents",
+                busy = false,
+            ),
+        )
+        assertEquals(
+            true,
+            canConfirmRemoteFolderSelection(
+                currentPath = "Documents",
+                networkConfirmedPath = "Documents",
+                manualPathVisible = false,
+                manualPathDraft = "Documents",
+                busy = false,
+            ),
+        )
+        assertEquals(
+            false,
+            canConfirmRemoteFolderSelection(
+                currentPath = "Photos",
+                networkConfirmedPath = "Photos",
+                manualPathVisible = true,
+                manualPathDraft = "Documents",
+                busy = false,
+            ),
+        )
+        assertEquals(
+            false,
+            canConfirmRemoteFolderSelection(
+                currentPath = "Photos",
+                networkConfirmedPath = "Photos",
+                manualPathVisible = true,
+                manualPathDraft = "../Photos",
+                busy = false,
+            ),
+        )
+        assertEquals(
+            true,
+            canConfirmRemoteFolderSelection(
+                currentPath = " Photos ",
+                networkConfirmedPath = " Photos ",
+                manualPathVisible = true,
+                manualPathDraft = "/ Photos /",
+                busy = false,
+            ),
+        )
     }
 
     @Test

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
@@ -1,8 +1,11 @@
 package dev.obiente.nextcloudnative.app
 
+import kotlinx.coroutines.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 class RemoteFolderPickerTest {
     @Test
@@ -163,6 +166,37 @@ class RemoteFolderPickerTest {
         assertNull(newRemoteFolderPath("Photos", "../Camera"))
         assertNull(newRemoteFolderPath("Photos", "Camera/2026"))
         assertNull(newRemoteFolderPath("../Outside", "Camera"))
+    }
+
+    @Test
+    fun `folder operations preserve coroutine cancellation`() {
+        val cancellation = CancellationException("folder changed")
+
+        val thrown = assertFailsWith<CancellationException> {
+            Result.failure<Unit>(cancellation).rethrowRemoteFolderCancellation()
+        }
+
+        assertSame(cancellation, thrown)
+        assertNull(
+            Result.failure<Unit>(IllegalStateException("offline"))
+                .rethrowRemoteFolderCancellation()
+                .getOrNull(),
+        )
+    }
+
+    @Test
+    fun `selection status explains that the folder is still loading`() {
+        assertEquals(
+            "Loading this Nextcloud folder before it can be selected.",
+            remoteFolderSelectionStatus(
+                loading = true,
+                currentPath = "Photos",
+                canConfirm = false,
+                listingSource = null,
+                manualPathVisible = false,
+                manualPathDraft = "Photos",
+            ),
+        )
     }
 
     private fun directory(path: String, name: String) = nextcloudFile(path, name, isDirectory = true)

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
@@ -128,6 +128,33 @@ class RemoteFolderPickerTest {
     }
 
     @Test
+    fun `directory row keys cannot collide with static picker item keys`() {
+        val staticKeys = setOf(
+            "breadcrumbs",
+            "current-path",
+            "search",
+            "loading",
+            "load-error",
+            "refreshing",
+            "listing-error",
+            "empty-folders",
+            "folder-actions",
+            "create-folder",
+            "manual-path",
+            "selection-status",
+        )
+        val collisionPronePaths = staticKeys + setOf(
+            "remote-folder:11:breadcrumbs",
+            "folder-actions/selection-status",
+        )
+        val directoryKeys = collisionPronePaths.map(::remoteFolderRowKey)
+
+        assertEquals(directoryKeys.size, directoryKeys.distinct().size)
+        assertEquals(emptySet(), directoryKeys.toSet().intersect(staticKeys))
+        assertEquals("remote-folder:11:breadcrumbs", remoteFolderRowKey("breadcrumbs"))
+    }
+
+    @Test
     fun `new folders are canonical children and unsafe names are rejected`() {
         assertEquals("Photos/Camera", newRemoteFolderPath("Photos", "Camera"))
         assertEquals("Photos", newRemoteFolderPath("", "Photos"))


### PR DESCRIPTION
## Summary

- replace typed Nextcloud destination paths with a native remote-folder picker
- preserve whitespace and safely encode folder paths
- scope folder identity keys to avoid collisions
- keep advanced unverified paths disabled until explicitly validated
- make the picker usable in constrained and landscape layouts

## Impact

Media and folder-sync setup can select an existing Nextcloud destination without entering internal paths or identifiers manually.

## Validation

- focused remote folder picker tests
- Android Kotlin compilation
- full repository validation gate
- repository hygiene and diff checks

Closes #171