### PR TITLE
feat(media): preview folders before enabling sync

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
@@ -390,6 +390,9 @@ internal class AndroidFileSyncEngine(context: Context) {
     ): FileSyncExecutionSuccess {
         val pair = state.pairs.first { it.id == command.pairId }
         val work = pair.workItems.first { it.id == command.workId }
+        require(isAndroidFileSyncExecutionAllowed(pair.localRootId, command.operation)) {
+            "Detected media folders permit upload operations only."
+        }
         return when (val operation = command.operation) {
             is FileSyncOperation.Upload -> {
                 val source = requireNotNull(work.observedLocal)
@@ -549,3 +552,9 @@ internal fun supportsAndroidFileSyncDirection(
     direction: FileSyncDirection,
 ): Boolean =
     !localRootId.startsWith(MEDIA_STORE_SYNC_ROOT_PREFIX) || direction == FileSyncDirection.UploadOnly
+
+internal fun isAndroidFileSyncExecutionAllowed(
+    localRootId: String,
+    operation: FileSyncOperation,
+): Boolean =
+    !localRootId.startsWith(MEDIA_STORE_SYNC_ROOT_PREFIX) || operation is FileSyncOperation.Upload

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
@@ -14,6 +14,7 @@ import dev.obiente.nextcloudnative.app.FileSyncExecutionSuccess
 import dev.obiente.nextcloudnative.app.FileSyncExecutionState
 import dev.obiente.nextcloudnative.app.FileSyncLocalRoot
 import dev.obiente.nextcloudnative.app.FileSyncDecisionChoice
+import dev.obiente.nextcloudnative.app.FileSyncDirection
 import dev.obiente.nextcloudnative.app.FileSyncOperation
 import dev.obiente.nextcloudnative.app.FileSyncPair
 import dev.obiente.nextcloudnative.app.NextcloudSession
@@ -76,6 +77,11 @@ internal class AndroidFileSyncEngine(context: Context) {
         remoteRootPath: String,
         configuration: FileSyncConfiguration,
     ): FileSyncCenterActionResult = ENGINE_LOCK.withLock {
+        if (!supportsAndroidFileSyncDirection(localRoot.localRootId, configuration.direction)) {
+            return@withLock FileSyncCenterActionResult.Rejected(
+                "Detected media folders support upload-only sync.",
+            )
+        }
         // Constructing the adapter verifies that its persisted SAF grant or detected media root is usable.
         createAndroidFileSyncLocalTree(appContext.contentResolver, localRoot.localRootId)
         val normalizedRemote = normalizeRemoteRoot(remoteRootPath)
@@ -176,6 +182,11 @@ internal class AndroidFileSyncEngine(context: Context) {
             ?: return FileSyncCenterActionResult.Rejected("The folder sync pair no longer exists.")
         if (initialPair.accountId != NextcloudDocumentIds.accountKey(session)) {
             return FileSyncCenterActionResult.Rejected("This folder sync pair belongs to another account.")
+        }
+        if (!supportsAndroidFileSyncDirection(initialPair.localRootId, initialPair.configuration.direction)) {
+            return FileSyncCenterActionResult.Rejected(
+                "This detected media-folder pair is not upload-only. Remove it and add it again.",
+            )
         }
         return withAndroidMediaBackupLedger(appContext, initialPair) { mediaLedger ->
         val remote = AndroidFileSyncRemoteTree(
@@ -532,3 +543,9 @@ internal class AndroidFileSyncEngine(context: Context) {
         val ENGINE_LOCK = Mutex()
     }
 }
+
+internal fun supportsAndroidFileSyncDirection(
+    localRootId: String,
+    direction: FileSyncDirection,
+): Boolean =
+    !localRootId.startsWith(MEDIA_STORE_SYNC_ROOT_PREFIX) || direction == FileSyncDirection.UploadOnly

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
@@ -54,11 +54,7 @@ internal class AndroidMediaStoreSyncLocalTree(
     }
 
     override fun scan(): List<AndroidLocalSyncDocument> {
-        val files = mediaFolderSyncFiles(root)
-        require(files.size <= MAX_MEDIA_FOLDER_SYNC_ENTRIES) {
-            "The local media folder contains too many uploadable files."
-        }
-        return files.map { file -> file.toSyncDocument(file.name) }
+        return mediaFolderSyncFiles(root).map { file -> file.toSyncDocument(file.name) }
     }
 
     override fun stageForUpload(path: String, destination: File, maximumBytes: Long): LocalSyncEntry {

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
@@ -95,11 +95,7 @@ internal class AndroidMediaStoreSyncLocalTree(
     }
 
     override fun delete(path: String, expectedLocalRevision: String) {
-        val current = requireNotNull(resolve(path)) { "The local item was already removed." }
-        require(current.entry.revision == expectedLocalRevision) {
-            "The local item changed after the sync scan."
-        }
-        require(current.uri.toFile().deleteRecursively()) { "The local item could not be removed." }
+        throw UnsupportedOperationException("Detected media folders are upload-only.")
     }
 
     override fun resolve(path: String): AndroidLocalSyncDocument? {
@@ -193,12 +189,23 @@ internal const val MAX_MEDIA_FOLDER_SYNC_ENTRIES = 20_000
  * Only direct, visible, regular media files are included. Subfolders, hidden files, sidecars,
  * documents, and temporary files are deliberately outside automatic media upload.
  */
-internal fun mediaFolderSyncFiles(root: File): List<File> {
+internal fun mediaFolderSyncFiles(
+    root: File,
+    maximumEntries: Int = MAX_MEDIA_FOLDER_SYNC_ENTRIES,
+): List<File> {
+    require(maximumEntries > 0)
     val result = mutableListOf<File>()
+    var exceedsLimit = false
     forEachMediaFolderSyncFile(root) {
-        result += it
-        true
+        if (result.size >= maximumEntries) {
+            exceedsLimit = true
+            false
+        } else {
+            result += it
+            true
+        }
     }
+    require(!exceedsLimit) { "The local media folder contains too many uploadable files." }
     return result.sortedBy { it.name.lowercase() }
 }
 

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaStoreSyncLocalTree.kt
@@ -8,8 +8,8 @@ import dev.obiente.nextcloudnative.app.SyncEntryKind
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.nio.file.Files
 import java.security.MessageDigest
-import java.util.UUID
 
 internal fun createAndroidFileSyncLocalTree(
     resolver: ContentResolver,
@@ -54,27 +54,11 @@ internal class AndroidMediaStoreSyncLocalTree(
     }
 
     override fun scan(): List<AndroidLocalSyncDocument> {
-        val result = ArrayList<AndroidLocalSyncDocument>()
-        val pending = ArrayDeque<Pair<String, File>>()
-        pending += "" to root
-        while (pending.isNotEmpty()) {
-            val (parentPath, parent) = pending.removeFirst()
-            require(parentPath.count { it == '/' } < MAX_DEPTH) { "The local folder is nested too deeply." }
-            val children = parent.listFiles()
-                ?.asSequence()
-                ?.filter { it.name.isSafeLocalName() }
-                ?.sortedBy { it.name.lowercase() }
-                ?.toList()
-                .orEmpty()
-            for (child in children) {
-                require(result.size < MAX_ENTRIES) { "The local folder contains too many entries." }
-                val path = if (parentPath.isBlank()) child.name else "$parentPath/${child.name}"
-                val document = child.toSyncDocument(path)
-                result += document
-                if (document.entry.kind == SyncEntryKind.Directory) pending += path to child
-            }
+        val files = mediaFolderSyncFiles(root)
+        require(files.size <= MAX_MEDIA_FOLDER_SYNC_ENTRIES) {
+            "The local media folder contains too many uploadable files."
         }
-        return result.sortedBy { it.entry.relativePath }
+        return files.map { file -> file.toSyncDocument(file.name) }
     }
 
     override fun stageForUpload(path: String, destination: File, maximumBytes: Long): LocalSyncEntry {
@@ -103,57 +87,11 @@ internal class AndroidMediaStoreSyncLocalTree(
     }
 
     override fun createDirectory(path: String, expectedLocalRevision: String?) {
-        val existing = resolve(path)
-        if (expectedLocalRevision != null) {
-            require(existing?.entry?.revision == expectedLocalRevision) {
-                "The local folder changed after the sync scan."
-            }
-            require(existing.entry.kind == SyncEntryKind.Directory)
-            return
-        }
-        require(existing == null) { "The local folder appeared after the sync scan." }
-        val target = safeFile(path)
-        require(target.mkdirs()) { "The local folder could not be created." }
+        throw UnsupportedOperationException("Detected media folders are upload-only.")
     }
 
     override fun writeFile(path: String, source: File, expectedLocalRevision: String?) {
-        require(source.isFile)
-        val current = resolve(path)
-        if (expectedLocalRevision == null) {
-            require(current == null) { "The local file appeared after the sync scan." }
-        } else {
-            require(current?.entry?.revision == expectedLocalRevision) {
-                "The local file changed after the sync scan."
-            }
-            require(current.entry.kind == SyncEntryKind.File) { "The local item changed type." }
-        }
-        val target = safeFile(path)
-        val parent = requireNotNull(target.parentFile)
-        require(parent.isDirectory || parent.mkdirs()) { "A local parent folder could not be created." }
-        val token = UUID.randomUUID().toString()
-        val staged = File(parent, ".${target.name}.nextcloud-native-download-$token")
-        val backup = File(parent, ".${target.name}.nextcloud-native-backup-$token")
-        try {
-            FileInputStream(source).use { input ->
-                FileOutputStream(staged).use { output ->
-                    input.copyTo(output, BUFFER_BYTES)
-                    output.fd.sync()
-                }
-            }
-            if (target.exists()) {
-                require(target.renameTo(backup)) {
-                    "The existing local file could not be protected before replacement."
-                }
-            }
-            require(staged.renameTo(target)) { "The staged local file could not be published." }
-            if (backup.exists()) {
-                require(backup.delete()) { "The replaced local file could not be cleaned up." }
-            }
-        } catch (failure: Throwable) {
-            staged.delete()
-            if (backup.exists() && !target.exists()) backup.renameTo(target)
-            throw failure
-        }
+        throw UnsupportedOperationException("Detected media folders are upload-only.")
     }
 
     override fun delete(path: String, expectedLocalRevision: String) {
@@ -168,7 +106,7 @@ internal class AndroidMediaStoreSyncLocalTree(
         if (path.isBlank()) return null
         val normalized = normalizeRelativeSyncPath(path)
         val file = safeFile(normalized)
-        if (!file.exists()) return null
+        if (!file.isMediaFolderSyncFile(root)) return null
         return file.toSyncDocument(normalized)
     }
 
@@ -217,7 +155,7 @@ internal class AndroidMediaStoreSyncLocalTree(
 
     private fun normalizeRelativeSyncPath(path: String): String {
         val segments = path.trim('/').split('/')
-        require(segments.isNotEmpty() && segments.size <= MAX_DEPTH)
+        require(segments.size == 1)
         require(segments.all { it.isSafeLocalName() }) { "The local sync path is invalid." }
         return segments.joinToString("/")
     }
@@ -243,8 +181,114 @@ internal class AndroidMediaStoreSyncLocalTree(
     private fun Uri.toFile(): File = File(requireNotNull(path))
 
     private companion object {
-        const val MAX_ENTRIES = 20_000
-        const val MAX_DEPTH = 64
         const val BUFFER_BYTES = 64 * 1024
     }
 }
+
+internal const val MAX_MEDIA_FOLDER_SYNC_ENTRIES = 20_000
+
+/**
+ * The exact upload scope used by detected media-folder sync and its confirmation preview.
+ *
+ * Only direct, visible, regular media files are included. Subfolders, hidden files, sidecars,
+ * documents, and temporary files are deliberately outside automatic media upload.
+ */
+internal fun mediaFolderSyncFiles(root: File): List<File> {
+    val result = mutableListOf<File>()
+    forEachMediaFolderSyncFile(root) {
+        result += it
+        true
+    }
+    return result.sortedBy { it.name.lowercase() }
+}
+
+internal data class MediaFolderSyncScopeInspection(
+    val previewFiles: List<File>,
+    val imageCount: Int,
+    val videoCount: Int,
+    val totalBytes: Long,
+    val exceedsSyncLimit: Boolean,
+) {
+    val totalItems: Int get() = imageCount + videoCount
+}
+
+internal fun inspectMediaFolderSyncScope(
+    root: File,
+    maximumPreviewItems: Int,
+): MediaFolderSyncScopeInspection {
+    require(maximumPreviewItems >= 0)
+    val previews = mutableListOf<File>()
+    var imageCount = 0
+    var videoCount = 0
+    var totalBytes = 0L
+    var exceedsSyncLimit = false
+    forEachMediaFolderSyncFile(root) { file ->
+        if (imageCount + videoCount >= MAX_MEDIA_FOLDER_SYNC_ENTRIES) {
+            exceedsSyncLimit = true
+            return@forEachMediaFolderSyncFile false
+        }
+        if (isMediaFolderSyncVideo(file)) videoCount++ else imageCount++
+        val size = file.length().coerceAtLeast(0L)
+        totalBytes = if (Long.MAX_VALUE - totalBytes < size) Long.MAX_VALUE else totalBytes + size
+        previews += file
+        previews.sortWith(compareByDescending<File>(File::lastModified).thenBy { it.name.lowercase() })
+        if (previews.size > maximumPreviewItems) previews.removeAt(previews.lastIndex)
+        true
+    }
+    return MediaFolderSyncScopeInspection(
+        previewFiles = previews,
+        imageCount = imageCount,
+        videoCount = videoCount,
+        totalBytes = totalBytes,
+        exceedsSyncLimit = exceedsSyncLimit,
+    )
+}
+
+private inline fun forEachMediaFolderSyncFile(
+    root: File,
+    visit: (File) -> Boolean = { true },
+) {
+    val canonicalRoot = root.canonicalFile
+    Files.newDirectoryStream(canonicalRoot.toPath()).use { entries ->
+        for (entry in entries) {
+            val file = entry.toFile()
+            if (file.isMediaFolderSyncFile(canonicalRoot) && !visit(file)) return
+        }
+    }
+}
+
+private fun File.isMediaFolderSyncFile(root: File): Boolean {
+    if (
+        !isFile ||
+        Files.isSymbolicLink(toPath()) ||
+        isHidden ||
+        name.startsWith('.') ||
+        !name.isSafeMediaFolderSyncName()
+    ) {
+        return false
+    }
+    val canonicalRoot = root.canonicalFile
+    val canonicalFile = runCatching { canonicalFile }.getOrNull() ?: return false
+    if (canonicalFile.parentFile != canonicalRoot) return false
+    return extension.lowercase() in MEDIA_FOLDER_SYNC_IMAGE_EXTENSIONS ||
+        extension.lowercase() in MEDIA_FOLDER_SYNC_VIDEO_EXTENSIONS
+}
+
+private fun String.isSafeMediaFolderSyncName(): Boolean =
+    isNotBlank() &&
+        this !in setOf(".", "..") &&
+        '/' !in this &&
+        '\\' !in this &&
+        none(Char::isISOControl)
+
+internal fun isMediaFolderSyncVideo(file: File): Boolean =
+    file.extension.lowercase() in MEDIA_FOLDER_SYNC_VIDEO_EXTENSIONS
+
+private val MEDIA_FOLDER_SYNC_IMAGE_EXTENSIONS = setOf(
+    "jpg", "jpeg", "png", "gif", "webp", "heic", "heif", "avif", "bmp", "tif", "tiff", "jxl",
+    "dng", "arw", "cr2", "cr3", "nef", "nrw", "orf", "raf", "rw2", "pef", "srw", "x3f",
+)
+
+private val MEDIA_FOLDER_SYNC_VIDEO_EXTENSIONS = setOf(
+    "mp4", "m4v", "mkv", "webm", "mov", "avi", "3gp", "3gpp", "mpg", "mpeg", "ts", "mts", "m2ts", "ogv",
+)

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetector.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetector.kt
@@ -1,23 +1,41 @@
 package dev.obiente.nextcloudnative
 
+import android.Manifest
+import android.content.ContentResolver
+import android.content.ContentUris
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Build
+import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
+import android.util.Size
 import androidx.core.content.ContextCompat
+import dev.obiente.nextcloudnative.app.MAX_MEDIA_PREVIEW_THUMBNAIL_BYTES
+import dev.obiente.nextcloudnative.app.MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS
+import dev.obiente.nextcloudnative.app.MediaSyncFolderAccess
 import dev.obiente.nextcloudnative.app.MediaSyncFolderDiscovery
 import dev.obiente.nextcloudnative.app.MediaSyncFolderDiscoverySupport
 import dev.obiente.nextcloudnative.app.MediaSyncFolderKind
+import dev.obiente.nextcloudnative.app.MediaSyncFolderPreview
+import dev.obiente.nextcloudnative.app.MediaSyncFolderPreviewItem
+import dev.obiente.nextcloudnative.app.MediaSyncFolderPreviewState
 import dev.obiente.nextcloudnative.app.MediaSyncFolderSuggestion
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.util.LinkedHashMap
 
 internal data class DetectedMediaFolderItem(
     val relativePath: String,
     val isImage: Boolean,
+    val sizeBytes: Long = 0L,
 )
 
 internal class AndroidMediaSyncFolderDetector(private val context: Context) {
+    private val thumbnailCache = MediaFolderThumbnailCache(MAX_CACHED_MEDIA_FOLDER_THUMBNAILS)
+
     fun discover(): MediaSyncFolderDiscovery {
         if (!hasMediaPermission()) {
             return MediaSyncFolderDiscovery(
@@ -26,7 +44,7 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
                 message = "Allow photos and videos access to find folders for automatic upload.",
             )
         }
-        val items = runCatching { queryMediaFolders() }.getOrElse { failure ->
+        val folders = runCatching { queryMediaFolderAggregates() }.getOrElse { failure ->
             return MediaSyncFolderDiscovery(
                 support = MediaSyncFolderDiscoverySupport.Unsupported,
                 suggestions = emptyList(),
@@ -35,8 +53,76 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
         }
         return MediaSyncFolderDiscovery(
             support = MediaSyncFolderDiscoverySupport.Available,
-            suggestions = buildMediaSyncFolderSuggestions(items),
-            message = if (items.isEmpty()) "No local photo or video folders were found." else null,
+            suggestions = buildMediaSyncFolderSuggestions(folders),
+            message = if (folders.isEmpty()) "No local photo or video folders were found." else null,
+            access = mediaLibraryAccess(),
+        )
+    }
+
+    fun preview(suggestion: MediaSyncFolderSuggestion): MediaSyncFolderPreview {
+        if (!hasMediaPermission()) {
+            return unavailablePreview(
+                suggestion,
+                MediaSyncFolderPreviewState.Inaccessible,
+                "Photo and video access is required to preview this folder.",
+            )
+        }
+        val current = runCatching {
+            queryMediaFolderAggregates().firstOrNull {
+                it.relativePath == suggestion.relativePath.trim('/')
+            }
+        }.getOrElse {
+            return unavailablePreview(
+                suggestion,
+                MediaSyncFolderPreviewState.Inaccessible,
+                "Android could not read this media folder.",
+            )
+        }
+        if (current == null) {
+            if (mediaFolderAccess(suggestion) == MediaSyncFolderAccess.LimitedSelection) {
+                return unavailablePreview(
+                    suggestion,
+                    MediaSyncFolderPreviewState.Empty,
+                    "No items from this folder are included in Android's current media permission.",
+                )
+            }
+            val folderExists = runCatching {
+                File(Environment.getExternalStorageDirectory(), suggestion.relativePath).isDirectory
+            }.getOrDefault(false)
+            return unavailablePreview(
+                suggestion,
+                if (folderExists) MediaSyncFolderPreviewState.Empty else MediaSyncFolderPreviewState.Removed,
+                if (folderExists) {
+                    "This media folder is currently empty."
+                } else {
+                    "This media folder was removed from the device."
+                },
+            )
+        }
+        val changed =
+            current.imageCount != suggestion.imageCount ||
+                current.videoCount != suggestion.videoCount ||
+                current.totalBytes != suggestion.totalBytes
+        val items = runCatching { queryPreviewItems(suggestion.relativePath) }.getOrElse {
+            return unavailablePreview(
+                suggestion,
+                MediaSyncFolderPreviewState.Inaccessible,
+                "Android could not load a preview for this media folder.",
+            )
+        }
+        return MediaSyncFolderPreview(
+            localRootHint = suggestion.localRootHint,
+            state = if (changed) MediaSyncFolderPreviewState.Changed else MediaSyncFolderPreviewState.Available,
+            access = mediaFolderAccess(suggestion),
+            totalItems = saturatingMediaItemCount(current.imageCount, current.videoCount),
+            totalBytes = current.totalBytes,
+            items = items,
+            message = when {
+                mediaFolderAccess(suggestion) == MediaSyncFolderAccess.LimitedSelection ->
+                    "Only photos and videos included in Android's current media permission are represented."
+                changed -> "The folder changed since it was detected. These are the latest totals."
+                else -> null
+            },
         )
     }
 
@@ -45,74 +131,281 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
             ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
         }
 
-    private fun queryMediaFolders(): List<DetectedMediaFolderItem> {
+    private fun mediaLibraryAccess(): MediaSyncFolderAccess =
+        if (
+            hasFullMediaLibraryAccess(Build.VERSION.SDK_INT) { permission ->
+                ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+            }
+        ) {
+            MediaSyncFolderAccess.FullLibrary
+        } else {
+            MediaSyncFolderAccess.LimitedSelection
+        }
+
+    private fun mediaFolderAccess(suggestion: MediaSyncFolderSuggestion): MediaSyncFolderAccess =
+        if (
+            hasFullMediaFolderAccess(
+                sdk = Build.VERSION.SDK_INT,
+                includesImages = suggestion.imageCount > 0,
+                includesVideos = suggestion.videoCount > 0,
+            ) { permission ->
+                ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+            }
+        ) {
+            MediaSyncFolderAccess.FullLibrary
+        } else {
+            MediaSyncFolderAccess.LimitedSelection
+        }
+
+    private fun queryMediaFolderAggregates(): List<DetectedMediaFolderAggregate> {
         val modernStorage = Build.VERSION.SDK_INT >= 29
         val pathColumn = if (modernStorage) MediaStore.Files.FileColumns.RELATIVE_PATH
         else MediaStore.Files.FileColumns.DATA
         val mediaTypeColumn = MediaStore.Files.FileColumns.MEDIA_TYPE
-        val collection = MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL)
+        val sizeColumn = MediaStore.Files.FileColumns.SIZE
+        val collection = externalMediaCollection()
         val selection = "$mediaTypeColumn = ? OR $mediaTypeColumn = ?"
         val selectionArgs = arrayOf(
             MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE.toString(),
             MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString(),
         )
-        return buildList {
-            context.contentResolver.query(
-                collection,
-                arrayOf(pathColumn, mediaTypeColumn),
-                selection,
-                selectionArgs,
-                null,
-            )?.use { cursor ->
-                val pathIndex = cursor.getColumnIndexOrThrow(pathColumn)
-                val typeIndex = cursor.getColumnIndexOrThrow(mediaTypeColumn)
-                while (cursor.moveToNext()) {
-                    val storedPath = cursor.getString(pathIndex) ?: continue
-                    val relativePath = if (modernStorage) {
-                        storedPath
+        val folders = linkedMapOf<String, MutableDetectedMediaFolderAggregate>()
+        context.contentResolver.query(
+            collection,
+            arrayOf(pathColumn, mediaTypeColumn, sizeColumn),
+            selection,
+            selectionArgs,
+            null,
+        )?.use { cursor ->
+            val pathIndex = cursor.getColumnIndexOrThrow(pathColumn)
+            val typeIndex = cursor.getColumnIndexOrThrow(mediaTypeColumn)
+            val sizeIndex = cursor.getColumnIndex(sizeColumn)
+            while (cursor.moveToNext()) {
+                val storedPath = cursor.getString(pathIndex) ?: continue
+                val relativePath = if (modernStorage) {
+                    storedPath
+                } else {
+                    File(storedPath).parent
+                        ?.removePrefix(Environment.getExternalStorageDirectory().absolutePath)
+                }.orEmpty().trim('/')
+                if (relativePath.isBlank()) continue
+                val aggregate = folders.getOrPut(relativePath) {
+                    MutableDetectedMediaFolderAggregate(relativePath)
+                }
+                aggregate.add(
+                    isImage =
+                        cursor.getInt(typeIndex) == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE,
+                    sizeBytes = if (sizeIndex >= 0 && !cursor.isNull(sizeIndex)) {
+                        cursor.getLong(sizeIndex).coerceAtLeast(0L)
                     } else {
-                        File(storedPath).parent
-                            ?.removePrefix(Environment.getExternalStorageDirectory().absolutePath)
-                    }.orEmpty().trim('/')
-                    if (relativePath.isBlank()) continue
+                        0L
+                    },
+                )
+            }
+        }
+        return folders.values.map(MutableDetectedMediaFolderAggregate::toImmutable)
+    }
+
+    private fun queryPreviewItems(relativePath: String): List<MediaSyncFolderPreviewItem> {
+        val collection = externalMediaCollection()
+        val modernStorage = Build.VERSION.SDK_INT >= 29
+        val pathColumn = if (modernStorage) MediaStore.Files.FileColumns.RELATIVE_PATH
+        else MediaStore.Files.FileColumns.DATA
+        val mediaTypeColumn = MediaStore.Files.FileColumns.MEDIA_TYPE
+        val selection = if (modernStorage) {
+            "($pathColumn = ? OR $pathColumn = ?) AND ($mediaTypeColumn = ? OR $mediaTypeColumn = ?)"
+        } else {
+            "$pathColumn LIKE ? AND ($mediaTypeColumn = ? OR $mediaTypeColumn = ?)"
+        }
+        val normalized = normalizeMediaStoreRelativePath(relativePath)
+        val selectionArgs = if (modernStorage) {
+            arrayOf(
+                normalized,
+                "$normalized/",
+                MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE.toString(),
+                MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString(),
+            )
+        } else {
+            arrayOf(
+                File(Environment.getExternalStorageDirectory(), normalized).absolutePath + "/%",
+                MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE.toString(),
+                MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString(),
+            )
+        }
+        val queryArgs = Bundle().apply {
+            putString(ContentResolver.QUERY_ARG_SQL_SELECTION, selection)
+            putStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, selectionArgs)
+            putStringArray(
+                ContentResolver.QUERY_ARG_SORT_COLUMNS,
+                arrayOf(MediaStore.Files.FileColumns.DATE_MODIFIED, MediaStore.Files.FileColumns._ID),
+            )
+            putInt(ContentResolver.QUERY_ARG_SORT_DIRECTION, ContentResolver.QUERY_SORT_DIRECTION_DESCENDING)
+            putInt(ContentResolver.QUERY_ARG_LIMIT, MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS)
+        }
+        val projection = arrayOf(
+            MediaStore.Files.FileColumns._ID,
+            MediaStore.Files.FileColumns.DISPLAY_NAME,
+            MediaStore.Files.FileColumns.MIME_TYPE,
+            MediaStore.Files.FileColumns.SIZE,
+            MediaStore.Files.FileColumns.DATE_MODIFIED,
+            mediaTypeColumn,
+        )
+        return buildList {
+            context.contentResolver.query(collection, projection, queryArgs, null)?.use { cursor ->
+                val idIndex = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID)
+                val nameIndex = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns.DISPLAY_NAME)
+                val mimeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.MIME_TYPE)
+                val sizeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.SIZE)
+                val modifiedIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.DATE_MODIFIED)
+                val typeIndex = cursor.getColumnIndexOrThrow(mediaTypeColumn)
+                while (cursor.moveToNext() && size < MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS) {
+                    val id = cursor.getLong(idIndex)
+                    val modifiedSeconds = nullableLong(cursor, modifiedIndex)
+                    val mediaType = cursor.getInt(typeIndex)
+                    val cacheKey = "$id:${modifiedSeconds ?: 0L}:$mediaType"
+                    val thumbnail = thumbnailCache.get(cacheKey) ?: loadThumbnailBytes(
+                        ContentUris.withAppendedId(collection, id),
+                        id,
+                        mediaType,
+                    )?.also { thumbnailCache.put(cacheKey, it) }
                     add(
-                        DetectedMediaFolderItem(
-                            relativePath = relativePath,
-                            isImage = cursor.getInt(typeIndex) == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE,
+                        MediaSyncFolderPreviewItem(
+                            stableId = "media:$cacheKey",
+                            displayName = safeMediaDisplayName(cursor.getString(nameIndex)),
+                            mimeType = nullableString(cursor, mimeIndex)
+                                ?.filterNot(Char::isISOControl)
+                                ?.take(256)
+                                ?.takeIf(String::isNotBlank),
+                            sizeBytes = nullableLong(cursor, sizeIndex)?.coerceAtLeast(0L),
+                            modifiedAtEpochMillis = modifiedSeconds?.coerceAtLeast(0L)?.let {
+                                if (it > Long.MAX_VALUE / 1_000L) Long.MAX_VALUE else it * 1_000L
+                            },
+                            thumbnailBytes = thumbnail,
                         ),
                     )
                 }
             }
         }
     }
+
+    private fun loadThumbnailBytes(uri: Uri, id: Long, mediaType: Int): ByteArray? =
+        runCatching {
+            val bitmap = if (Build.VERSION.SDK_INT >= 29) {
+                context.contentResolver.loadThumbnail(uri, Size(THUMBNAIL_EDGE_PX, THUMBNAIL_EDGE_PX), null)
+            } else if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+                @Suppress("DEPRECATION")
+                MediaStore.Video.Thumbnails.getThumbnail(
+                    context.contentResolver,
+                    id,
+                    MediaStore.Video.Thumbnails.MINI_KIND,
+                    null,
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                MediaStore.Images.Thumbnails.getThumbnail(
+                    context.contentResolver,
+                    id,
+                    MediaStore.Images.Thumbnails.MINI_KIND,
+                    null,
+                )
+            } ?: return@runCatching null
+            ByteArrayOutputStream().use { output ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, THUMBNAIL_JPEG_QUALITY, output)
+                output.toByteArray().takeIf { it.size <= MAX_MEDIA_PREVIEW_THUMBNAIL_BYTES }
+            }
+        }.getOrNull()
+
+    private fun unavailablePreview(
+        suggestion: MediaSyncFolderSuggestion,
+        state: MediaSyncFolderPreviewState,
+        message: String,
+    ) = MediaSyncFolderPreview(
+        localRootHint = suggestion.localRootHint,
+        state = state,
+        access = mediaFolderAccess(suggestion),
+        totalItems = 0,
+        totalBytes = 0L,
+        items = emptyList(),
+        message = message,
+    )
+
+    private fun externalMediaCollection(): Uri = MediaStore.Files.getContentUri(
+        if (Build.VERSION.SDK_INT >= 29) MediaStore.VOLUME_EXTERNAL else "external",
+    )
+
+    private fun nullableLong(cursor: android.database.Cursor, index: Int): Long? =
+        if (index < 0 || cursor.isNull(index)) null else cursor.getLong(index)
+
+    private fun nullableString(cursor: android.database.Cursor, index: Int): String? =
+        if (index < 0 || cursor.isNull(index)) null else cursor.getString(index)
+}
+
+internal data class DetectedMediaFolderAggregate(
+    val relativePath: String,
+    val imageCount: Int,
+    val videoCount: Int,
+    val totalBytes: Long,
+)
+
+private class MutableDetectedMediaFolderAggregate(val relativePath: String) {
+    private var imageCount = 0
+    private var videoCount = 0
+    private var totalBytes = 0L
+
+    fun add(isImage: Boolean, sizeBytes: Long) {
+        if (isImage) {
+            if (imageCount < Int.MAX_VALUE) imageCount++
+        } else {
+            if (videoCount < Int.MAX_VALUE) videoCount++
+        }
+        totalBytes = if (Long.MAX_VALUE - totalBytes < sizeBytes) Long.MAX_VALUE else totalBytes + sizeBytes
+    }
+
+    fun toImmutable() = DetectedMediaFolderAggregate(relativePath, imageCount, videoCount, totalBytes)
 }
 
 internal fun buildMediaSyncFolderSuggestions(
     items: List<DetectedMediaFolderItem>,
-): List<MediaSyncFolderSuggestion> =
-    items.groupBy { it.relativePath.trim('/') }
-        .mapNotNull { (relativePath, folderItems) ->
-            if (relativePath.isBlank()) return@mapNotNull null
-            val imageCount = folderItems.count(DetectedMediaFolderItem::isImage)
-            val videoCount = folderItems.size - imageCount
-            val displayName = relativePath.substringAfterLast('/').takeIf { it != "." && it != ".." }
-                ?: return@mapNotNull null
-            val kind = classifyMediaSyncFolder(relativePath, imageCount, videoCount)
-            val remoteCategory = if (kind == MediaSyncFolderKind.Videos) "Videos" else "Photos"
-            MediaSyncFolderSuggestion(
-                localRootHint = mediaStoreSyncRootId(relativePath),
-                displayName = displayName,
-                relativePath = relativePath,
-                kind = kind,
-                imageCount = imageCount,
-                videoCount = videoCount,
-                suggestedRemoteRootPath = "$remoteCategory/$displayName",
-            )
+): List<MediaSyncFolderSuggestion> {
+    val aggregates = linkedMapOf<String, MutableDetectedMediaFolderAggregate>()
+    items.forEach { item ->
+        val relativePath = item.relativePath.trim('/')
+        if (relativePath.isNotBlank()) {
+            aggregates.getOrPut(relativePath) {
+                MutableDetectedMediaFolderAggregate(relativePath)
+            }.add(item.isImage, item.sizeBytes.coerceAtLeast(0L))
         }
+    }
+    return buildMediaSyncFolderSuggestions(aggregates.values.map(MutableDetectedMediaFolderAggregate::toImmutable))
+}
+
+internal fun buildMediaSyncFolderSuggestions(
+    folders: Collection<DetectedMediaFolderAggregate>,
+): List<MediaSyncFolderSuggestion> =
+    folders.mapNotNull { folder ->
+        val relativePath = folder.relativePath
+        if (relativePath.isBlank()) return@mapNotNull null
+        val imageCount = folder.imageCount
+        val videoCount = folder.videoCount
+        val displayName = relativePath.substringAfterLast('/').takeIf { it != "." && it != ".." }
+            ?: return@mapNotNull null
+        val kind = classifyMediaSyncFolder(relativePath, imageCount, videoCount)
+        val remoteCategory = if (kind == MediaSyncFolderKind.Videos) "Videos" else "Photos"
+        MediaSyncFolderSuggestion(
+            localRootHint = mediaStoreSyncRootId(relativePath),
+            displayName = displayName,
+            relativePath = relativePath,
+            kind = kind,
+            imageCount = imageCount,
+            videoCount = videoCount,
+            suggestedRemoteRootPath = "$remoteCategory/$displayName",
+            totalBytes = folder.totalBytes,
+        )
+    }
         .sortedWith(
             compareBy<MediaSyncFolderSuggestion>(
                 { it.kind.sortPriority() },
-                { -(it.imageCount + it.videoCount) },
+                { -(it.imageCount.toLong() + it.videoCount.toLong()) },
                 { it.displayName.lowercase() },
             ),
         )
@@ -158,3 +451,61 @@ internal fun normalizeMediaStoreRelativePath(relativePath: String): String {
 
 internal const val MEDIA_STORE_SYNC_ROOT_PREFIX = "media-store://primary/"
 private const val MAX_MEDIA_FOLDER_SUGGESTIONS = 24
+private const val MAX_CACHED_MEDIA_FOLDER_THUMBNAILS = 48
+private const val THUMBNAIL_EDGE_PX = 240
+private const val THUMBNAIL_JPEG_QUALITY = 82
+
+internal class MediaFolderThumbnailCache(private val maximumEntries: Int) {
+    init {
+        require(maximumEntries > 0)
+    }
+
+    private val entries = object : LinkedHashMap<String, ByteArray>(maximumEntries, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ByteArray>?): Boolean =
+            size > maximumEntries
+    }
+
+    @Synchronized
+    fun get(key: String): ByteArray? = entries[key]
+
+    @Synchronized
+    fun put(key: String, bytes: ByteArray) {
+        require(bytes.size <= MAX_MEDIA_PREVIEW_THUMBNAIL_BYTES)
+        entries[key] = bytes
+    }
+
+    @Synchronized
+    internal fun keys(): Set<String> = entries.keys.toSet()
+}
+
+internal fun hasFullMediaLibraryAccess(
+    sdk: Int,
+    permissionGranted: (String) -> Boolean,
+): Boolean = when {
+    sdk >= 33 ->
+        permissionGranted(Manifest.permission.READ_MEDIA_IMAGES) &&
+            permissionGranted(Manifest.permission.READ_MEDIA_VIDEO)
+    else -> permissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)
+}
+
+internal fun hasFullMediaFolderAccess(
+    sdk: Int,
+    includesImages: Boolean,
+    includesVideos: Boolean,
+    permissionGranted: (String) -> Boolean,
+): Boolean = when {
+    sdk >= 33 ->
+        (!includesImages || permissionGranted(Manifest.permission.READ_MEDIA_IMAGES)) &&
+            (!includesVideos || permissionGranted(Manifest.permission.READ_MEDIA_VIDEO))
+    else -> permissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)
+}
+
+internal fun safeMediaDisplayName(value: String?): String =
+    value
+        ?.filterNot(Char::isISOControl)
+        ?.take(512)
+        ?.takeIf(String::isNotBlank)
+        ?: "Media item"
+
+private fun saturatingMediaItemCount(images: Int, videos: Int): Int =
+    (images.toLong() + videos.toLong()).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetector.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetector.kt
@@ -1,17 +1,16 @@
 package dev.obiente.nextcloudnative
 
 import android.Manifest
-import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
-import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Size
+import android.webkit.MimeTypeMap
 import androidx.core.content.ContextCompat
 import dev.obiente.nextcloudnative.app.MAX_MEDIA_PREVIEW_THUMBNAIL_BYTES
 import dev.obiente.nextcloudnative.app.MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS
@@ -25,6 +24,7 @@ import dev.obiente.nextcloudnative.app.MediaSyncFolderPreviewState
 import dev.obiente.nextcloudnative.app.MediaSyncFolderSuggestion
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.security.MessageDigest
 import java.util.LinkedHashMap
 
 internal data class DetectedMediaFolderItem(
@@ -67,10 +67,26 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
                 "Photo and video access is required to preview this folder.",
             )
         }
-        val current = runCatching {
-            queryMediaFolderAggregates().firstOrNull {
-                it.relativePath == suggestion.relativePath.trim('/')
-            }
+        if (mediaLibraryAccess() != MediaSyncFolderAccess.FullLibrary) {
+            return unavailablePreview(
+                suggestion,
+                MediaSyncFolderPreviewState.Inaccessible,
+                "Full photo and video library access is required before automatic folder upload can be enabled.",
+            )
+        }
+        val unresolvedRoot = File(Environment.getExternalStorageDirectory(), suggestion.relativePath)
+        if (!unresolvedRoot.isDirectory) {
+            return unavailablePreview(
+                suggestion,
+                MediaSyncFolderPreviewState.Removed,
+                "This media folder was removed from the device.",
+            )
+        }
+        val root = runCatching {
+            resolveMediaStoreSyncRoot(
+                suggestion.localRootHint,
+                Environment.getExternalStorageDirectory(),
+            )
         }.getOrElse {
             return unavailablePreview(
                 suggestion,
@@ -78,32 +94,39 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
                 "Android could not read this media folder.",
             )
         }
-        if (current == null) {
-            if (mediaFolderAccess(suggestion) == MediaSyncFolderAccess.LimitedSelection) {
-                return unavailablePreview(
-                    suggestion,
-                    MediaSyncFolderPreviewState.Empty,
-                    "No items from this folder are included in Android's current media permission.",
-                )
-            }
-            val folderExists = runCatching {
-                File(Environment.getExternalStorageDirectory(), suggestion.relativePath).isDirectory
-            }.getOrDefault(false)
+        val inspection = runCatching {
+            inspectMediaFolderSyncScope(root, MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS)
+        }.getOrElse {
             return unavailablePreview(
                 suggestion,
-                if (folderExists) MediaSyncFolderPreviewState.Empty else MediaSyncFolderPreviewState.Removed,
-                if (folderExists) {
-                    "This media folder is currently empty."
-                } else {
-                    "This media folder was removed from the device."
-                },
+                MediaSyncFolderPreviewState.Inaccessible,
+                "Android could not inspect the files this sync would upload.",
+            )
+        }
+        if (inspection.exceedsSyncLimit) {
+            return unavailablePreview(
+                suggestion,
+                MediaSyncFolderPreviewState.Inaccessible,
+                "This folder has too many uploadable media files to sync safely.",
+            )
+        }
+        if (inspection.totalItems == 0) {
+            return unavailablePreview(
+                suggestion,
+                MediaSyncFolderPreviewState.Empty,
+                "No direct, visible photo, video, or RAW files are available to upload. " +
+                    "Subfolders, hidden files, and other file types are excluded.",
             )
         }
         val changed =
-            current.imageCount != suggestion.imageCount ||
-                current.videoCount != suggestion.videoCount ||
-                current.totalBytes != suggestion.totalBytes
-        val items = runCatching { queryPreviewItems(suggestion.relativePath) }.getOrElse {
+            inspection.imageCount != suggestion.imageCount ||
+                inspection.videoCount != suggestion.videoCount ||
+                inspection.totalBytes != suggestion.totalBytes
+        val items = runCatching {
+            inspection.previewFiles.asSequence()
+                .map { file -> file.toMediaSyncFolderPreviewItem(suggestion.relativePath) }
+                .toList()
+        }.getOrElse {
             return unavailablePreview(
                 suggestion,
                 MediaSyncFolderPreviewState.Inaccessible,
@@ -113,15 +136,16 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
         return MediaSyncFolderPreview(
             localRootHint = suggestion.localRootHint,
             state = if (changed) MediaSyncFolderPreviewState.Changed else MediaSyncFolderPreviewState.Available,
-            access = mediaFolderAccess(suggestion),
-            totalItems = saturatingMediaItemCount(current.imageCount, current.videoCount),
-            totalBytes = current.totalBytes,
+            access = MediaSyncFolderAccess.FullLibrary,
+            totalItems = inspection.totalItems,
+            totalBytes = inspection.totalBytes,
             items = items,
-            message = when {
-                mediaFolderAccess(suggestion) == MediaSyncFolderAccess.LimitedSelection ->
-                    "Only photos and videos included in Android's current media permission are represented."
-                changed -> "The folder changed since it was detected. These are the latest totals."
-                else -> null
+            message = if (changed) {
+                "The upload scope changed since detection. These are the exact current totals. " +
+                    "Only direct, visible photo, video, and RAW files are included."
+            } else {
+                "Only direct, visible photo, video, and RAW files are included. " +
+                    "Subfolders, hidden files, sidecars, and other file types are excluded."
             },
         )
     }
@@ -134,21 +158,6 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
     private fun mediaLibraryAccess(): MediaSyncFolderAccess =
         if (
             hasFullMediaLibraryAccess(Build.VERSION.SDK_INT) { permission ->
-                ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
-            }
-        ) {
-            MediaSyncFolderAccess.FullLibrary
-        } else {
-            MediaSyncFolderAccess.LimitedSelection
-        }
-
-    private fun mediaFolderAccess(suggestion: MediaSyncFolderSuggestion): MediaSyncFolderAccess =
-        if (
-            hasFullMediaFolderAccess(
-                sdk = Build.VERSION.SDK_INT,
-                includesImages = suggestion.imageCount > 0,
-                includesVideos = suggestion.videoCount > 0,
-            ) { permission ->
                 ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
             }
         ) {
@@ -206,84 +215,57 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
         return folders.values.map(MutableDetectedMediaFolderAggregate::toImmutable)
     }
 
-    private fun queryPreviewItems(relativePath: String): List<MediaSyncFolderPreviewItem> {
+    private fun File.toMediaSyncFolderPreviewItem(relativePath: String): MediaSyncFolderPreviewItem {
+        val identity = findMediaStoreIdentity(this, relativePath)
+        val cacheKey = identity?.let { "${it.id}:${lastModified()}:${length()}:${it.mediaType}" }
+        val thumbnail = if (identity == null || cacheKey == null) {
+            null
+        } else {
+            thumbnailCache.get(cacheKey) ?: loadThumbnailBytes(
+                identity.uri,
+                identity.id,
+                identity.mediaType,
+            )?.also { thumbnailCache.put(cacheKey, it) }
+        }
+        val extension = extension.lowercase()
+        val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+            ?: if (isMediaFolderSyncVideo(this)) "video/$extension" else "image/x-$extension"
+        return MediaSyncFolderPreviewItem(
+            stableId = stableMediaFileId(name, length(), lastModified()),
+            displayName = safeMediaDisplayName(name),
+            mimeType = mimeType,
+            sizeBytes = length().coerceAtLeast(0L),
+            modifiedAtEpochMillis = lastModified().coerceAtLeast(0L),
+            thumbnailBytes = thumbnail,
+        )
+    }
+
+    private fun findMediaStoreIdentity(
+        file: File,
+        relativePath: String,
+    ): MediaStorePreviewIdentity? {
         val collection = externalMediaCollection()
         val modernStorage = Build.VERSION.SDK_INT >= 29
-        val pathColumn = if (modernStorage) MediaStore.Files.FileColumns.RELATIVE_PATH
-        else MediaStore.Files.FileColumns.DATA
         val mediaTypeColumn = MediaStore.Files.FileColumns.MEDIA_TYPE
-        val selection = if (modernStorage) {
-            "($pathColumn = ? OR $pathColumn = ?) AND ($mediaTypeColumn = ? OR $mediaTypeColumn = ?)"
-        } else {
-            "$pathColumn LIKE ? AND ($mediaTypeColumn = ? OR $mediaTypeColumn = ?)"
-        }
-        val normalized = normalizeMediaStoreRelativePath(relativePath)
-        val selectionArgs = if (modernStorage) {
-            arrayOf(
-                normalized,
-                "$normalized/",
-                MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE.toString(),
-                MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString(),
-            )
-        } else {
-            arrayOf(
-                File(Environment.getExternalStorageDirectory(), normalized).absolutePath + "/%",
-                MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE.toString(),
-                MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString(),
-            )
-        }
-        val queryArgs = Bundle().apply {
-            putString(ContentResolver.QUERY_ARG_SQL_SELECTION, selection)
-            putStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS, selectionArgs)
-            putStringArray(
-                ContentResolver.QUERY_ARG_SORT_COLUMNS,
-                arrayOf(MediaStore.Files.FileColumns.DATE_MODIFIED, MediaStore.Files.FileColumns._ID),
-            )
-            putInt(ContentResolver.QUERY_ARG_SORT_DIRECTION, ContentResolver.QUERY_SORT_DIRECTION_DESCENDING)
-            putInt(ContentResolver.QUERY_ARG_LIMIT, MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS)
-        }
-        val projection = arrayOf(
-            MediaStore.Files.FileColumns._ID,
-            MediaStore.Files.FileColumns.DISPLAY_NAME,
-            MediaStore.Files.FileColumns.MIME_TYPE,
-            MediaStore.Files.FileColumns.SIZE,
-            MediaStore.Files.FileColumns.DATE_MODIFIED,
-            mediaTypeColumn,
-        )
-        return buildList {
-            context.contentResolver.query(collection, projection, queryArgs, null)?.use { cursor ->
+        val lookup = mediaStorePreviewSelection(modernStorage, relativePath, file)
+        return context.contentResolver.query(
+            collection,
+            arrayOf(MediaStore.Files.FileColumns._ID, mediaTypeColumn),
+            lookup.selection,
+            lookup.arguments.toTypedArray(),
+            null,
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
                 val idIndex = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID)
-                val nameIndex = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns.DISPLAY_NAME)
-                val mimeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.MIME_TYPE)
-                val sizeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.SIZE)
-                val modifiedIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.DATE_MODIFIED)
                 val typeIndex = cursor.getColumnIndexOrThrow(mediaTypeColumn)
-                while (cursor.moveToNext() && size < MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS) {
-                    val id = cursor.getLong(idIndex)
-                    val modifiedSeconds = nullableLong(cursor, modifiedIndex)
-                    val mediaType = cursor.getInt(typeIndex)
-                    val cacheKey = "$id:${modifiedSeconds ?: 0L}:$mediaType"
-                    val thumbnail = thumbnailCache.get(cacheKey) ?: loadThumbnailBytes(
-                        ContentUris.withAppendedId(collection, id),
-                        id,
-                        mediaType,
-                    )?.also { thumbnailCache.put(cacheKey, it) }
-                    add(
-                        MediaSyncFolderPreviewItem(
-                            stableId = "media:$cacheKey",
-                            displayName = safeMediaDisplayName(cursor.getString(nameIndex)),
-                            mimeType = nullableString(cursor, mimeIndex)
-                                ?.filterNot(Char::isISOControl)
-                                ?.take(256)
-                                ?.takeIf(String::isNotBlank),
-                            sizeBytes = nullableLong(cursor, sizeIndex)?.coerceAtLeast(0L),
-                            modifiedAtEpochMillis = modifiedSeconds?.coerceAtLeast(0L)?.let {
-                                if (it > Long.MAX_VALUE / 1_000L) Long.MAX_VALUE else it * 1_000L
-                            },
-                            thumbnailBytes = thumbnail,
-                        ),
-                    )
-                }
+                val id = cursor.getLong(idIndex)
+                MediaStorePreviewIdentity(
+                    id = id,
+                    mediaType = cursor.getInt(typeIndex),
+                    uri = ContentUris.withAppendedId(collection, id),
+                )
+            } else {
+                null
             }
         }
     }
@@ -322,7 +304,7 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
     ) = MediaSyncFolderPreview(
         localRootHint = suggestion.localRootHint,
         state = state,
-        access = mediaFolderAccess(suggestion),
+        access = mediaLibraryAccess(),
         totalItems = 0,
         totalBytes = 0L,
         items = emptyList(),
@@ -333,11 +315,39 @@ internal class AndroidMediaSyncFolderDetector(private val context: Context) {
         if (Build.VERSION.SDK_INT >= 29) MediaStore.VOLUME_EXTERNAL else "external",
     )
 
-    private fun nullableLong(cursor: android.database.Cursor, index: Int): Long? =
-        if (index < 0 || cursor.isNull(index)) null else cursor.getLong(index)
+}
 
-    private fun nullableString(cursor: android.database.Cursor, index: Int): String? =
-        if (index < 0 || cursor.isNull(index)) null else cursor.getString(index)
+private data class MediaStorePreviewIdentity(
+    val id: Long,
+    val mediaType: Int,
+    val uri: Uri,
+)
+
+internal data class MediaStorePreviewSelection(
+    val selection: String,
+    val arguments: List<String>,
+)
+
+internal fun mediaStorePreviewSelection(
+    modernStorage: Boolean,
+    relativePath: String,
+    file: File,
+): MediaStorePreviewSelection {
+    val normalized = normalizeMediaStoreRelativePath(relativePath)
+    return if (modernStorage) {
+        MediaStorePreviewSelection(
+            selection =
+                "(${MediaStore.Files.FileColumns.RELATIVE_PATH} = ? OR " +
+                    "${MediaStore.Files.FileColumns.RELATIVE_PATH} = ?) AND " +
+                    "${MediaStore.Files.FileColumns.DISPLAY_NAME} = ?",
+            arguments = listOf(normalized, "$normalized/", file.name),
+        )
+    } else {
+        MediaStorePreviewSelection(
+            selection = "${MediaStore.Files.FileColumns.DATA} = ?",
+            arguments = listOf(file.absolutePath),
+        )
+    }
 }
 
 internal data class DetectedMediaFolderAggregate(
@@ -488,18 +498,6 @@ internal fun hasFullMediaLibraryAccess(
     else -> permissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)
 }
 
-internal fun hasFullMediaFolderAccess(
-    sdk: Int,
-    includesImages: Boolean,
-    includesVideos: Boolean,
-    permissionGranted: (String) -> Boolean,
-): Boolean = when {
-    sdk >= 33 ->
-        (!includesImages || permissionGranted(Manifest.permission.READ_MEDIA_IMAGES)) &&
-            (!includesVideos || permissionGranted(Manifest.permission.READ_MEDIA_VIDEO))
-    else -> permissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)
-}
-
 internal fun safeMediaDisplayName(value: String?): String =
     value
         ?.filterNot(Char::isISOControl)
@@ -507,5 +505,8 @@ internal fun safeMediaDisplayName(value: String?): String =
         ?.takeIf(String::isNotBlank)
         ?: "Media item"
 
-private fun saturatingMediaItemCount(images: Int, videos: Int): Int =
-    (images.toLong() + videos.toLong()).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+internal fun stableMediaFileId(name: String, size: Long, modifiedAt: Long): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+        .digest("$name\u0000$size\u0000$modifiedAt".encodeToByteArray())
+    return "media-file-" + digest.take(16).joinToString("") { "%02x".format(it) }
+}

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
@@ -41,6 +41,8 @@ import dev.obiente.nextcloudnative.app.FileSyncLocalRoot
 import dev.obiente.nextcloudnative.app.MediaSyncFolderDiscovery
 import dev.obiente.nextcloudnative.app.MAX_MEDIA_BACKUP_STATUS_PATHS
 import dev.obiente.nextcloudnative.app.MediaBackupStatus
+import dev.obiente.nextcloudnative.app.MediaSyncFolderPreview
+import dev.obiente.nextcloudnative.app.MediaSyncFolderSuggestion
 import dev.obiente.nextcloudnative.app.filesByIdDavSearchRequest
 import dev.obiente.nextcloudnative.app.ExternalFileHandoffAction
 import dev.obiente.nextcloudnative.app.ExternalFileHandoffCapability
@@ -396,6 +398,12 @@ internal class AndroidNextcloudServices(
         withContext(Dispatchers.IO) {
             mediaSyncFolderDetector.discover()
         }
+
+    override suspend fun previewMediaSyncFolder(
+        suggestion: MediaSyncFolderSuggestion,
+    ): MediaSyncFolderPreview = withContext(Dispatchers.IO) {
+        mediaSyncFolderDetector.preview(suggestion)
+    }
 
     override suspend fun loadFileSyncCenter(
         session: NextcloudSession,

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaFolderSyncScopeTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaFolderSyncScopeTest.kt
@@ -1,0 +1,107 @@
+package dev.obiente.nextcloudnative
+
+import dev.obiente.nextcloudnative.app.FileSyncDirection
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AndroidMediaFolderSyncScopeTest {
+    @Test
+    fun previewAndUploaderScopeContainsOnlyDirectVisibleMediaFiles() {
+        val root = Files.createTempDirectory("media-scope-").toFile()
+        try {
+            root.resolve("photo.jpg").writeBytes(byteArrayOf(1))
+            root.resolve("negative.raf").writeBytes(byteArrayOf(2))
+            root.resolve("clip.mp4").writeBytes(byteArrayOf(3))
+            root.resolve("notes.txt").writeText("not media")
+            root.resolve(".hidden.jpg").writeBytes(byteArrayOf(4))
+            root.resolve("folder.jpg").mkdir()
+            root.resolve("nested").also { nested ->
+                nested.mkdir()
+                nested.resolve("inside.jpg").writeBytes(byteArrayOf(5))
+            }
+
+            val uploaderFiles = mediaFolderSyncFiles(root).map { it.name }
+            val previewFiles = inspectMediaFolderSyncScope(root, maximumPreviewItems = 12)
+
+            assertEquals(listOf("clip.mp4", "negative.raf", "photo.jpg"), uploaderFiles)
+            assertEquals(uploaderFiles.toSet(), previewFiles.previewFiles.map { it.name }.toSet())
+            assertEquals(uploaderFiles.size, previewFiles.totalItems)
+            assertTrue(isMediaFolderSyncVideo(root.resolve("clip.mp4")))
+            assertFalse(isMediaFolderSyncVideo(root.resolve("photo.jpg")))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun legacyPreviewLookupUsesExactPathEvenWithLikeMetacharacters() {
+        val root = Files.createTempDirectory("media_%_scope-").toFile()
+        try {
+            val file = root.resolve("100%_actual.jpg").also { it.writeBytes(byteArrayOf(1)) }
+            val lookup = mediaStorePreviewSelection(
+                modernStorage = false,
+                relativePath = "DCIM/Camera%_",
+                file = file,
+            )
+
+            assertEquals("${android.provider.MediaStore.Files.FileColumns.DATA} = ?", lookup.selection)
+            assertEquals(listOf(file.absolutePath), lookup.arguments)
+            assertFalse("LIKE" in lookup.selection)
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun inspectionRetainsOnlyBoundedRecentFilesWhileCountingTheWholeScope() {
+        val root = Files.createTempDirectory("media-bounded-").toFile()
+        try {
+            repeat(20) { index ->
+                root.resolve("photo-$index.jpg").also { file ->
+                    file.writeBytes(ByteArray(index + 1))
+                    file.setLastModified(1_000L + index)
+                }
+            }
+
+            val inspection = inspectMediaFolderSyncScope(root, maximumPreviewItems = 3)
+
+            assertEquals(20, inspection.totalItems)
+            assertEquals(210L, inspection.totalBytes)
+            assertEquals(
+                listOf("photo-19.jpg", "photo-18.jpg", "photo-17.jpg"),
+                inspection.previewFiles.map { it.name },
+            )
+            assertFalse(inspection.exceedsSyncLimit)
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun stablePreviewIdentityChangesWithFileRevision() {
+        val initial = stableMediaFileId("photo.jpg", size = 10L, modifiedAt = 100L)
+
+        assertEquals(initial, stableMediaFileId("photo.jpg", size = 10L, modifiedAt = 100L))
+        assertNotEquals(initial, stableMediaFileId("photo.jpg", size = 11L, modifiedAt = 100L))
+        assertNotEquals(initial, stableMediaFileId("photo.jpg", size = 10L, modifiedAt = 101L))
+    }
+
+    @Test
+    fun detectedMediaRootsAcceptUploadOnlyDirection() {
+        val root = "media-store://primary/DCIM/Camera"
+
+        assertTrue(supportsAndroidFileSyncDirection(root, FileSyncDirection.UploadOnly))
+        assertFalse(supportsAndroidFileSyncDirection(root, FileSyncDirection.DownloadOnly))
+        assertFalse(supportsAndroidFileSyncDirection(root, FileSyncDirection.Bidirectional))
+        assertTrue(
+            supportsAndroidFileSyncDirection(
+                "content://documents/tree/primary%3ANotes",
+                FileSyncDirection.Bidirectional,
+            ),
+        )
+    }
+}

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaFolderSyncScopeTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaFolderSyncScopeTest.kt
@@ -1,11 +1,25 @@
 package dev.obiente.nextcloudnative
 
 import dev.obiente.nextcloudnative.app.FileSyncDirection
+import dev.obiente.nextcloudnative.app.FileSyncConfiguration
+import dev.obiente.nextcloudnative.app.FileSyncCoordinatorState
+import dev.obiente.nextcloudnative.app.FileSyncDecisionChoice
+import dev.obiente.nextcloudnative.app.FileSyncOperation
+import dev.obiente.nextcloudnative.app.FileSyncPair
+import dev.obiente.nextcloudnative.app.LocalSyncEntry
+import dev.obiente.nextcloudnative.app.RemoteSyncEntry
+import dev.obiente.nextcloudnative.app.SyncEntryKind
+import dev.obiente.nextcloudnative.app.claimNextFileSyncOperation
+import dev.obiente.nextcloudnative.app.resolveFileSyncDecision
+import dev.obiente.nextcloudnative.app.scanFileSyncPair
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class AndroidMediaFolderSyncScopeTest {
@@ -103,5 +117,74 @@ class AndroidMediaFolderSyncScopeTest {
                 FileSyncDirection.Bidirectional,
             ),
         )
+    }
+
+    @Test
+    fun useRemoteTypeConflictCannotDeleteDetectedLocalMedia() {
+        val root = Files.createTempDirectory("media-conflict-").toFile()
+        try {
+            val localFile = root.resolve("photo.jpg").also { it.writeBytes(byteArrayOf(1)) }
+            val pair = FileSyncPair(
+                id = "pair",
+                accountId = "account",
+                localRootId = "media-store://primary/DCIM/Camera",
+                remoteRootPath = "Photos/Camera",
+                configuration = FileSyncConfiguration(
+                    direction = FileSyncDirection.UploadOnly,
+                    deviceLabel = "device",
+                ),
+            )
+            var state = FileSyncCoordinatorState(listOf(pair))
+            state = scanFileSyncPair(
+                state = state,
+                pairId = pair.id,
+                localEntries = listOf(
+                    LocalSyncEntry("photo.jpg", SyncEntryKind.File, "local-revision", size = 1L),
+                ),
+                remoteEntries = listOf(
+                    RemoteSyncEntry("photo.jpg", SyncEntryKind.Directory, "remote-etag"),
+                ),
+                nowEpochMillis = 1L,
+            )
+            val work = state.pairs.single().workItems.single()
+            state = resolveFileSyncDecision(
+                state,
+                pair.id,
+                work.id,
+                FileSyncDecisionChoice.UseRemote,
+            )
+            val command = assertNotNull(
+                claimNextFileSyncOperation(state, pair.id, nowEpochMillis = 2L).command,
+            )
+
+            assertIs<FileSyncOperation.Download>(command.operation)
+            assertFalse(isAndroidFileSyncExecutionAllowed(pair.localRootId, command.operation))
+            val tree = AndroidMediaStoreSyncLocalTree(root)
+            assertFailsWith<UnsupportedOperationException> {
+                tree.delete("photo.jpg", "local-revision")
+            }
+            assertTrue(localFile.exists())
+            assertEquals(byteArrayOf(1).toList(), localFile.readBytes().toList())
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun uploaderEnumerationFailsAtOneEntryBeyondItsBound() {
+        val root = Files.createTempDirectory("media-over-limit-").toFile()
+        try {
+            repeat(4) { index ->
+                root.resolve("photo-$index.jpg").writeBytes(byteArrayOf(index.toByte()))
+            }
+
+            val failure = assertFailsWith<IllegalArgumentException> {
+                mediaFolderSyncFiles(root, maximumEntries = 3)
+            }
+
+            assertTrue("too many uploadable files" in failure.message.orEmpty())
+        } finally {
+            root.deleteRecursively()
+        }
     }
 }

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetectorTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetectorTest.kt
@@ -78,24 +78,6 @@ class AndroidMediaSyncFolderDetectorTest {
                 )
             },
         )
-        assertTrue(
-            hasFullMediaFolderAccess(
-                sdk = 36,
-                includesImages = true,
-                includesVideos = false,
-            ) { permission ->
-                permission == android.Manifest.permission.READ_MEDIA_IMAGES
-            },
-        )
-        assertFalse(
-            hasFullMediaFolderAccess(
-                sdk = 36,
-                includesImages = true,
-                includesVideos = true,
-            ) { permission ->
-                permission == android.Manifest.permission.READ_MEDIA_IMAGES
-            },
-        )
     }
 
     @Test

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetectorTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidMediaSyncFolderDetectorTest.kt
@@ -5,6 +5,8 @@ import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AndroidMediaSyncFolderDetectorTest {
     @Test
@@ -36,6 +38,64 @@ class AndroidMediaSyncFolderDetectorTest {
 
         assertEquals(MediaSyncFolderKind.Videos, suggestion.kind)
         assertEquals("Videos/Clips", suggestion.suggestedRemoteRootPath)
+    }
+
+    @Test
+    fun suggestionsAggregateBytesWithoutKeepingPerItemState() {
+        val suggestions = buildMediaSyncFolderSuggestions(
+            listOf(
+                DetectedMediaFolderItem("DCIM/Camera", isImage = true, sizeBytes = 4_000L),
+                DetectedMediaFolderItem("DCIM/Camera", isImage = false, sizeBytes = 12_000L),
+            ),
+        )
+
+        assertEquals(16_000L, suggestions.single().totalBytes)
+    }
+
+    @Test
+    fun thumbnailCacheEvictsLeastRecentlyUsedEntry() {
+        val cache = MediaFolderThumbnailCache(maximumEntries = 2)
+        cache.put("old", byteArrayOf(1))
+        cache.put("kept", byteArrayOf(2))
+        cache.get("old")
+        cache.put("new", byteArrayOf(3))
+
+        assertEquals(setOf("old", "new"), cache.keys())
+    }
+
+    @Test
+    fun fullLibraryAccessRequiresBothMediaTypesOnModernAndroid() {
+        assertFalse(
+            hasFullMediaLibraryAccess(36) { permission ->
+                permission == android.Manifest.permission.READ_MEDIA_IMAGES
+            },
+        )
+        assertTrue(
+            hasFullMediaLibraryAccess(36) { permission ->
+                permission in setOf(
+                    android.Manifest.permission.READ_MEDIA_IMAGES,
+                    android.Manifest.permission.READ_MEDIA_VIDEO,
+                )
+            },
+        )
+        assertTrue(
+            hasFullMediaFolderAccess(
+                sdk = 36,
+                includesImages = true,
+                includesVideos = false,
+            ) { permission ->
+                permission == android.Manifest.permission.READ_MEDIA_IMAGES
+            },
+        )
+        assertFalse(
+            hasFullMediaFolderAccess(
+                sdk = 36,
+                includesImages = true,
+                includesVideos = true,
+            ) { permission ->
+                permission == android.Manifest.permission.READ_MEDIA_IMAGES
+            },
+        )
     }
 
     @Test

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
@@ -50,6 +50,7 @@ import dev.obiente.nextcloudnative.app.design.NextcloudCardOverflow
 import dev.obiente.nextcloudnative.app.design.NextcloudSpacing
 import dev.obiente.nextcloudnative.app.design.NextcloudTheme
 import dev.obiente.nextcloudnative.app.design.nextcloudCardInteractions
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 @Composable
@@ -198,12 +199,15 @@ internal fun FileOfflineCenterScreen(
         mediaPreviewLoading = true
         mediaPreviewError = null
         pendingMediaPreview = null
-        runCatching { services.previewMediaSyncFolder(suggestion) }
-            .onSuccess { pendingMediaPreview = it }
-            .onFailure { failure ->
-                mediaPreviewError = failure.message ?: "Could not preview this media folder."
-            }
-        mediaPreviewLoading = false
+        try {
+            pendingMediaPreview = services.previewMediaSyncFolder(suggestion)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (failure: Throwable) {
+            mediaPreviewError = failure.message ?: "Could not preview this media folder."
+        } finally {
+            mediaPreviewLoading = false
+        }
     }
 
     Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
@@ -1020,11 +1020,23 @@ private fun AddFolderSyncDialog(
                     }
                 }
                 Text("Direction", style = MaterialTheme.typography.labelLarge)
-                FileSyncDirection.entries.forEach { option ->
+                val directionOptions = if (mediaSuggestion == null) {
+                    FileSyncDirection.entries
+                } else {
+                    listOf(FileSyncDirection.UploadOnly)
+                }
+                directionOptions.forEach { option ->
                     FilterChip(
                         selected = configuration.direction == option,
                         onClick = { onConfigurationChanged(configuration.copy(direction = option)) },
                         label = { Text(option.readableSyncDirection()) },
+                    )
+                }
+                if (mediaSuggestion != null) {
+                    Text(
+                        "Detected media folders are upload-only. Nextcloud never writes into this local folder.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 Text("When both copies changed", style = MaterialTheme.typography.labelLarge)
@@ -1071,17 +1083,10 @@ private fun AddFolderSyncDialog(
             }
         },
         confirmButton = {
-            val mediaPreviewReady = mediaSuggestion == null ||
-                (
-                    mediaPreview != null &&
-                        mediaPreview.access == MediaSyncFolderAccess.FullLibrary &&
-                        mediaPreview.state in setOf(
-                            MediaSyncFolderPreviewState.Available,
-                            MediaSyncFolderPreviewState.Changed,
-                        )
-                )
             Button(
-                enabled = !busy && configuration.deviceLabel.isNotBlank() && mediaPreviewReady,
+                enabled = !busy &&
+                    configuration.deviceLabel.isNotBlank() &&
+                    isMediaFolderPreviewReady(mediaSuggestion, mediaPreview),
                 onClick = onAdd,
             ) {
                 if (busy) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
@@ -1103,6 +1108,20 @@ private fun defaultFileSyncConfiguration(isMediaSuggestion: Boolean): FileSyncCo
         networkPolicy = FileSyncNetworkPolicy.AnyConnection,
         powerPolicy = FileSyncPowerPolicy.BatteryNotLow,
     )
+
+internal fun isMediaFolderPreviewReady(
+    suggestion: MediaSyncFolderSuggestion?,
+    preview: MediaSyncFolderPreview?,
+): Boolean =
+    suggestion == null ||
+        (
+            preview != null &&
+                preview.access == MediaSyncFolderAccess.FullLibrary &&
+                preview.state in setOf(
+                    MediaSyncFolderPreviewState.Available,
+                    MediaSyncFolderPreviewState.Changed,
+                )
+        )
 
 @Composable
 private fun OfflineCenterSummaryCard(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileOfflineCenterScreen.kt
@@ -1,5 +1,6 @@
 package dev.obiente.nextcloudnative.app
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -37,6 +39,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -74,6 +78,9 @@ internal fun FileOfflineCenterScreen(
         mutableStateOf<FileSyncConfiguration?>(null)
     }
     var remoteFolderPickerVisible by remember(session, userId) { mutableStateOf(false) }
+    var pendingMediaPreview by remember(session, userId) { mutableStateOf<MediaSyncFolderPreview?>(null) }
+    var mediaPreviewLoading by remember(session, userId) { mutableStateOf(false) }
+    var mediaPreviewError by remember(session, userId) { mutableStateOf<String?>(null) }
     var removeSyncPair by remember(session, userId) { mutableStateOf<FileSyncPairSummary?>(null) }
     var pendingSyncDecision by remember(session, userId) {
         mutableStateOf<PendingFileSyncDecision?>(null)
@@ -181,6 +188,24 @@ internal fun FileOfflineCenterScreen(
         loading = false
     }
 
+    LaunchedEffect(pendingMediaSuggestion) {
+        val suggestion = pendingMediaSuggestion ?: run {
+            pendingMediaPreview = null
+            mediaPreviewLoading = false
+            mediaPreviewError = null
+            return@LaunchedEffect
+        }
+        mediaPreviewLoading = true
+        mediaPreviewError = null
+        pendingMediaPreview = null
+        runCatching { services.previewMediaSyncFolder(suggestion) }
+            .onSuccess { pendingMediaPreview = it }
+            .onFailure { failure ->
+                mediaPreviewError = failure.message ?: "Could not preview this media folder."
+            }
+        mediaPreviewLoading = false
+    }
+
     Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
         ScreenHeader(
             title = "Sync & offline",
@@ -242,6 +267,8 @@ internal fun FileOfflineCenterScreen(
                         },
                         onOpenMediaSuggestion = { suggestion ->
                             if (syncBusyPairId == null) {
+                                pendingMediaPreview = null
+                                mediaPreviewError = null
                                 pendingMediaSuggestion = suggestion
                                 pendingLocalRoot = suggestion.localRoot
                                 pendingRemotePath = null
@@ -387,6 +414,9 @@ internal fun FileOfflineCenterScreen(
             mediaSuggestion = pendingMediaSuggestion,
             remotePath = requireNotNull(pendingRemotePath),
             configuration = requireNotNull(pendingSyncConfiguration),
+            mediaPreview = pendingMediaPreview,
+            mediaPreviewLoading = mediaPreviewLoading,
+            mediaPreviewError = mediaPreviewError,
             busy = syncBusyPairId == ADD_PAIR_BUSY_ID,
             onDismiss = {
                 if (syncBusyPairId == null) {
@@ -394,6 +424,7 @@ internal fun FileOfflineCenterScreen(
                     pendingMediaSuggestion = null
                     pendingRemotePath = null
                     pendingSyncConfiguration = null
+                    pendingMediaPreview = null
                 }
             },
             onChooseDestination = {
@@ -422,6 +453,7 @@ internal fun FileOfflineCenterScreen(
                             pendingMediaSuggestion = null
                             pendingRemotePath = null
                             pendingSyncConfiguration = null
+                            pendingMediaPreview = null
                             refreshAttempt += 1
                         }
                     }.onFailure { failure ->
@@ -605,6 +637,13 @@ private fun MediaFolderSuggestions(
                         "Future storage cleanup will only remove verified copies after an explicit review.",
                     errorTone = false,
                 )
+                if (discovery.access == MediaSyncFolderAccess.LimitedSelection) {
+                    OfflineCenterMessageCard(
+                        "Android granted partial media access. Counts and previews cover only permitted " +
+                            "photos and videos, not necessarily every item stored in these folders.",
+                        errorTone = true,
+                    )
+                }
                 discovery.suggestions.take(MAX_VISIBLE_MEDIA_FOLDER_SUGGESTIONS).forEach { suggestion ->
                     Surface(
                         modifier = Modifier.fillMaxWidth().nextcloudCardInteractions(
@@ -625,6 +664,11 @@ private fun MediaFolderSuggestions(
                                 Text(
                                     "${suggestion.kind.readableMediaFolderKind()} · " +
                                         "${suggestion.imageCount} photos · ${suggestion.videoCount} videos",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    "Estimated size ${formatOfflineBytes(suggestion.totalBytes)}",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -766,11 +810,171 @@ private fun FolderSyncPairCard(
 }
 
 @Composable
+private fun MediaFolderPreview(
+    suggestion: MediaSyncFolderSuggestion,
+    preview: MediaSyncFolderPreview?,
+    loading: Boolean,
+    error: String?,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = NextcloudTheme.colors.appTile,
+        shape = RoundedCornerShape(NextcloudRadii.Card),
+    ) {
+        Column(
+            modifier = Modifier.padding(NextcloudSpacing.Medium),
+            verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+        ) {
+            Text("Review what will upload", style = MaterialTheme.typography.labelLarge)
+            when {
+                loading -> {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    Text(
+                        "Loading a bounded preview…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                error != null -> {
+                    Text(error, color = MaterialTheme.colorScheme.error)
+                    Text(
+                        "Sync cannot be enabled until the folder can be reviewed.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                preview != null -> {
+                    val totalLabel = buildString {
+                        append(preview.totalItems).append(if (preview.totalItems == 1) " item" else " items")
+                        append(" · ").append(formatOfflineBytes(preview.totalBytes))
+                    }
+                    Text(totalLabel, style = MaterialTheme.typography.titleSmall)
+                    preview.message?.let { message ->
+                        Text(
+                            message,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (
+                                preview.access == MediaSyncFolderAccess.LimitedSelection ||
+                                preview.state != MediaSyncFolderPreviewState.Available
+                            ) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        )
+                    }
+                    if (preview.access == MediaSyncFolderAccess.LimitedSelection) {
+                        Text(
+                            "Grant full access for this folder’s media types before enabling automatic upload.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                    if (preview.items.isNotEmpty()) {
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                            contentPadding = PaddingValues(vertical = NextcloudSpacing.XSmall),
+                        ) {
+                            items(
+                                items = preview.items,
+                                key = MediaSyncFolderPreviewItem::stableId,
+                            ) { item ->
+                                MediaFolderPreviewTile(item)
+                            }
+                        }
+                        if (preview.totalItems > preview.items.size) {
+                            Text(
+                                "Showing ${preview.items.size} recent items. " +
+                                    "${preview.totalItems - preview.items.size} more are included.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else if (
+                        preview.state == MediaSyncFolderPreviewState.Available ||
+                        preview.state == MediaSyncFolderPreviewState.Changed
+                    ) {
+                        Text(
+                            "No representative thumbnails are available, but the folder metadata was verified.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                else -> Text(
+                    "${suggestion.imageCount.toLong() + suggestion.videoCount.toLong()} detected items",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MediaFolderPreviewTile(item: MediaSyncFolderPreviewItem) {
+    Column(
+        modifier = Modifier.size(width = 112.dp, height = 142.dp),
+        verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.XSmall),
+    ) {
+        val image = remember(item.stableId, item.thumbnailBytes) {
+            item.thumbnailBytes?.let(::decodePlatformImage)
+        }
+        Surface(
+            modifier = Modifier.size(112.dp, 96.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            shape = RoundedCornerShape(NextcloudRadii.Small),
+        ) {
+            if (image != null) {
+                Image(
+                    bitmap = image,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(NextcloudRadii.Small)),
+                    contentScale = ContentScale.Crop,
+                )
+            } else {
+                Column(
+                    modifier = Modifier.fillMaxSize().padding(NextcloudSpacing.Small),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        if (item.mimeType?.startsWith("video/") == true) "Video" else "Photo",
+                        style = MaterialTheme.typography.labelMedium,
+                    )
+                }
+            }
+        }
+        Text(
+            item.displayName,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.labelSmall,
+        )
+        Text(
+            buildString {
+                append(if (item.mimeType?.startsWith("video/") == true) "Video" else "Photo")
+                item.sizeBytes?.let { append(" · ").append(formatOfflineBytes(it)) }
+            },
+            maxLines = 1,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
 private fun AddFolderSyncDialog(
     localRoot: FileSyncLocalRoot,
     mediaSuggestion: MediaSyncFolderSuggestion?,
     remotePath: String,
     configuration: FileSyncConfiguration,
+    mediaPreview: MediaSyncFolderPreview?,
+    mediaPreviewLoading: Boolean,
+    mediaPreviewError: String?,
     busy: Boolean,
     onDismiss: () -> Unit,
     onChooseDestination: () -> Unit,
@@ -786,6 +990,14 @@ private fun AddFolderSyncDialog(
                 verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
             ) {
                 Text("Local folder: ${mediaSuggestion?.relativePath ?: localRoot.displayName}")
+                if (mediaSuggestion != null) {
+                    MediaFolderPreview(
+                        suggestion = mediaSuggestion,
+                        preview = mediaPreview,
+                        loading = mediaPreviewLoading,
+                        error = mediaPreviewError,
+                    )
+                }
                 Surface(
                     modifier = Modifier.fillMaxWidth(),
                     color = NextcloudTheme.colors.appTile,
@@ -859,8 +1071,17 @@ private fun AddFolderSyncDialog(
             }
         },
         confirmButton = {
+            val mediaPreviewReady = mediaSuggestion == null ||
+                (
+                    mediaPreview != null &&
+                        mediaPreview.access == MediaSyncFolderAccess.FullLibrary &&
+                        mediaPreview.state in setOf(
+                            MediaSyncFolderPreviewState.Available,
+                            MediaSyncFolderPreviewState.Changed,
+                        )
+                )
             Button(
-                enabled = !busy && configuration.deviceLabel.isNotBlank(),
+                enabled = !busy && configuration.deviceLabel.isNotBlank() && mediaPreviewReady,
                 onClick = onAdd,
             ) {
                 if (busy) CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt
@@ -35,6 +35,11 @@ enum class MediaSyncFolderKind {
     Mixed,
 }
 
+enum class MediaSyncFolderAccess {
+    FullLibrary,
+    LimitedSelection,
+}
+
 /**
  * A platform-discovered local media folder that can be proposed without another folder browser.
  *
@@ -49,12 +54,14 @@ data class MediaSyncFolderSuggestion(
     val imageCount: Int,
     val videoCount: Int,
     val suggestedRemoteRootPath: String,
+    val totalBytes: Long = 0L,
 ) {
     init {
         require(localRootHint.isSafeFileSyncCenterText(2_048))
         require(displayName.isSafeFileSyncCenterText(256))
         require(relativePath.isSafeFileSyncCenterText(1_024))
-        require(imageCount >= 0 && videoCount >= 0 && imageCount + videoCount > 0)
+        require(imageCount >= 0 && videoCount >= 0 && imageCount.toLong() + videoCount.toLong() > 0L)
+        require(totalBytes >= 0L)
         requireValidSyncPath(suggestedRemoteRootPath)
     }
 
@@ -66,14 +73,74 @@ data class MediaSyncFolderDiscovery(
     val support: MediaSyncFolderDiscoverySupport,
     val suggestions: List<MediaSyncFolderSuggestion>,
     val message: String? = null,
+    val access: MediaSyncFolderAccess? =
+        if (support == MediaSyncFolderDiscoverySupport.Available) {
+            MediaSyncFolderAccess.FullLibrary
+        } else {
+            null
+        },
 ) {
     init {
         require(suggestions.size <= 128)
         require(suggestions.map(MediaSyncFolderSuggestion::localRootHint).distinct().size == suggestions.size)
         require(support == MediaSyncFolderDiscoverySupport.Available || suggestions.isEmpty())
         require(message == null || message.isSafeFileSyncCenterText(1_024))
+        require((support == MediaSyncFolderDiscoverySupport.Available) == (access != null))
     }
 }
+
+enum class MediaSyncFolderPreviewState {
+    Available,
+    Empty,
+    Inaccessible,
+    Changed,
+    Removed,
+}
+
+data class MediaSyncFolderPreviewItem(
+    val stableId: String,
+    val displayName: String,
+    val mimeType: String?,
+    val sizeBytes: Long?,
+    val modifiedAtEpochMillis: Long?,
+    val thumbnailBytes: ByteArray?,
+) {
+    init {
+        require(stableId.isSafeFileSyncCenterText(256))
+        require(displayName.isSafeFileSyncCenterText(512))
+        require(mimeType == null || mimeType.isSafeFileSyncCenterText(256))
+        require(sizeBytes == null || sizeBytes >= 0L)
+        require(modifiedAtEpochMillis == null || modifiedAtEpochMillis >= 0L)
+        require(thumbnailBytes == null || thumbnailBytes.size <= MAX_MEDIA_PREVIEW_THUMBNAIL_BYTES)
+    }
+}
+
+data class MediaSyncFolderPreview(
+    val localRootHint: String,
+    val state: MediaSyncFolderPreviewState,
+    val access: MediaSyncFolderAccess,
+    val totalItems: Int,
+    val totalBytes: Long,
+    val items: List<MediaSyncFolderPreviewItem>,
+    val message: String? = null,
+) {
+    init {
+        require(localRootHint.isSafeFileSyncCenterText(2_048))
+        require(totalItems >= 0)
+        require(totalBytes >= 0L)
+        require(items.size <= MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS)
+        require(items.map(MediaSyncFolderPreviewItem::stableId).distinct().size == items.size)
+        require(message == null || message.isSafeFileSyncCenterText(1_024))
+        require(
+            state == MediaSyncFolderPreviewState.Available ||
+                state == MediaSyncFolderPreviewState.Changed ||
+                items.isEmpty(),
+        )
+    }
+}
+
+const val MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS = 12
+const val MAX_MEDIA_PREVIEW_THUMBNAIL_BYTES = 256 * 1_024
 
 data class FileSyncPairSummary(
     val id: String,

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
@@ -441,6 +441,18 @@ interface NextcloudPlatformServices {
         message = "Automatic media folder discovery is not available on this platform.",
     )
 
+    suspend fun previewMediaSyncFolder(
+        suggestion: MediaSyncFolderSuggestion,
+    ): MediaSyncFolderPreview = MediaSyncFolderPreview(
+        localRootHint = suggestion.localRootHint,
+        state = MediaSyncFolderPreviewState.Inaccessible,
+        access = MediaSyncFolderAccess.LimitedSelection,
+        totalItems = 0,
+        totalBytes = 0L,
+        items = emptyList(),
+        message = "Media folder previews are not available on this platform.",
+    )
+
     suspend fun loadFileSyncCenter(
         session: NextcloudSession,
         userId: String,

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenterTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenterTest.kt
@@ -2,6 +2,7 @@ package dev.obiente.nextcloudnative.app
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class FileSyncCenterTest {
     @Test
@@ -20,6 +21,40 @@ class FileSyncCenterTest {
             FileSyncLocalRoot("media-store://primary/DCIM/Camera", "Camera"),
             suggestion.localRoot,
         )
+    }
+
+    @Test
+    fun previewModelBoundsThumbnailPayloadsAndItemCount() {
+        assertFailsWith<IllegalArgumentException> {
+            MediaSyncFolderPreviewItem(
+                stableId = "media:1",
+                displayName = "Photo.jpg",
+                mimeType = "image/jpeg",
+                sizeBytes = 10L,
+                modifiedAtEpochMillis = 1L,
+                thumbnailBytes = ByteArray(MAX_MEDIA_PREVIEW_THUMBNAIL_BYTES + 1),
+            )
+        }
+        val item = MediaSyncFolderPreviewItem(
+            stableId = "media:1",
+            displayName = "Photo.jpg",
+            mimeType = "image/jpeg",
+            sizeBytes = 10L,
+            modifiedAtEpochMillis = 1L,
+            thumbnailBytes = null,
+        )
+        assertFailsWith<IllegalArgumentException> {
+            MediaSyncFolderPreview(
+                localRootHint = "media-store://primary/DCIM/Camera",
+                state = MediaSyncFolderPreviewState.Available,
+                access = MediaSyncFolderAccess.FullLibrary,
+                totalItems = MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS + 1,
+                totalBytes = 100L,
+                items = List(MAX_MEDIA_SYNC_FOLDER_PREVIEW_ITEMS + 1) { index ->
+                    item.copy(stableId = "media:$index")
+                },
+            )
+        }
     }
 
     @Test

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenterTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenterTest.kt
@@ -58,6 +58,52 @@ class FileSyncCenterTest {
     }
 
     @Test
+    fun automaticMediaSyncRequiresCompleteLibraryVisibilityAndAUsablePreview() {
+        val suggestion = MediaSyncFolderSuggestion(
+            localRootHint = "media-store://primary/DCIM/Camera",
+            displayName = "Camera",
+            relativePath = "DCIM/Camera",
+            kind = MediaSyncFolderKind.Camera,
+            imageCount = 1,
+            videoCount = 1,
+            suggestedRemoteRootPath = "Photos/Camera",
+        )
+        fun preview(access: MediaSyncFolderAccess, state: MediaSyncFolderPreviewState) =
+            MediaSyncFolderPreview(
+                localRootHint = suggestion.localRootHint,
+                state = state,
+                access = access,
+                totalItems = if (state == MediaSyncFolderPreviewState.Empty) 0 else 2,
+                totalBytes = 20L,
+                items = emptyList(),
+                message = null,
+            )
+
+        assertEquals(
+            false,
+            isMediaFolderPreviewReady(
+                suggestion,
+                preview(MediaSyncFolderAccess.LimitedSelection, MediaSyncFolderPreviewState.Available),
+            ),
+        )
+        assertEquals(
+            false,
+            isMediaFolderPreviewReady(
+                suggestion,
+                preview(MediaSyncFolderAccess.FullLibrary, MediaSyncFolderPreviewState.Empty),
+            ),
+        )
+        assertEquals(
+            true,
+            isMediaFolderPreviewReady(
+                suggestion,
+                preview(MediaSyncFolderAccess.FullLibrary, MediaSyncFolderPreviewState.Changed),
+            ),
+        )
+        assertEquals(true, isMediaFolderPreviewReady(null, null))
+    }
+
+    @Test
     fun `summary exposes actionable work counts without leaking the root grant`() {
         val pair = FileSyncPair(
             id = "pair",


### PR DESCRIPTION
## Summary

- show detected media-folder contents before enabling backup
- keep preview and upload enumeration within the same bounded scope
- handle partial Android media permissions accurately
- enforce upload-only behavior for MediaStore-backed folders
- fail closed on unsupported local mutations and destructive conflict paths
- stop enumeration at the configured limit instead of collecting an unbounded list

## Impact

People can inspect representative contents and counts before enabling a media folder, while the sync engine prevents download or mutation paths that could damage local media.

## Validation

- independent read-only safety review
- `AndroidMediaFolderSyncScopeTest`
- `AndroidMediaSyncFolderDetectorTest`
- Android unit tests and Kotlin compilation
- repository hygiene and diff checks

Closes #170