### PR TITLE
ci: avoid duplicate branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Build and test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 
@@ -29,6 +31,17 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies and build output
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-v1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-v1-
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 android.useAndroidX=true
+org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 ncVersionName=0.1.0-alpha.1
 ncVersionCode=10000001

--- a/tools/check-repository.sh
+++ b/tools/check-repository.sh
@@ -8,6 +8,20 @@ generated_pattern='(^|/)(build|target|\.gradle|\.kotlin)/|(^|/)(local\.propertie
 machine_pattern='(/home/[^/[:space:]]+|/Users/[^/[:space:]]+|[A-Za-z]:\\Users\\|192\.168\.[0-9]+\.[0-9]+)'
 credential_pattern='BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z_-]{35}|xox[baprs]-[A-Za-z0-9-]+'
 
+gradle_caching="$(
+    awk -F= '
+        /^[[:space:]]*org\.gradle\.caching[[:space:]]*=/ {
+            value = $2
+            gsub(/[[:space:]]/, "", value)
+        }
+        END { print value }
+    ' gradle.properties
+)"
+if [[ "$gradle_caching" != "true" ]]; then
+    printf 'Gradle task-output caching must stay enabled in gradle.properties.\n' >&2
+    exit 1
+fi
+
 mapfile -d '' candidate_files < <(git ls-files -z --cached --others --exclude-standard)
 if [[ "${#candidate_files[@]}" -eq 0 ]]; then
     printf 'No repository files were found.\n' >&2

--- a/tools/check-repository.sh
+++ b/tools/check-repository.sh
@@ -8,20 +8,6 @@ generated_pattern='(^|/)(build|target|\.gradle|\.kotlin)/|(^|/)(local\.propertie
 machine_pattern='(/home/[^/[:space:]]+|/Users/[^/[:space:]]+|[A-Za-z]:\\Users\\|192\.168\.[0-9]+\.[0-9]+)'
 credential_pattern='BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|AIza[0-9A-Za-z_-]{35}|xox[baprs]-[A-Za-z0-9-]+'
 
-gradle_caching="$(
-    awk -F= '
-        /^[[:space:]]*org\.gradle\.caching[[:space:]]*=/ {
-            value = $2
-            gsub(/[[:space:]]/, "", value)
-        }
-        END { print value }
-    ' gradle.properties
-)"
-if [[ "$gradle_caching" != "true" ]]; then
-    printf 'Gradle task-output caching must stay enabled in gradle.properties.\n' >&2
-    exit 1
-fi
-
 mapfile -d '' candidate_files < <(git ls-files -z --cached --others --exclude-standard)
 if [[ "${#candidate_files[@]}" -eq 0 ]]; then
     printf 'No repository files were found.\n' >&2


### PR DESCRIPTION
## Summary

- run the full build-and-test workflow for pull requests, manual dispatches, and pushes to `main`
- avoid duplicate same-commit builds from feature-branch pushes when a pull request is open
- cache Cargo dependencies and build output with the official cache action and a `Cargo.lock`-based key
- enable Gradle task-output caching so the existing `setup-java` Gradle cache can reuse cacheable task results
- keep Android SDK setup, validation tasks, packaging, and artifact uploads unchanged

## Impact

Pull requests keep the complete validation gate and downloadable Linux and Android artifacts, while same-repository feature branches no longer trigger an identical second workflow run. Rust dependencies, Rust build output, and cacheable Gradle task output can be reused across compatible runs without caching the Android SDK.

## Validation

- `actionlint` 1.7.12
- targeted workflow trigger, Cargo cache, Gradle cache, validation-task, and artifact assertions
- Gradle `help --info` smoke test confirming the local task-output build cache is active
- `bash -n tools/check-repository.sh`
- `bash tools/check-repository.sh`
- `git diff --check`

Relates to #18