### PR TITLE
fix(sync): recover missing remote destinations

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
@@ -25,6 +25,7 @@ import dev.obiente.nextcloudnative.app.NextcloudActivity
 import dev.obiente.nextcloudnative.app.NextcloudFile
 import dev.obiente.nextcloudnative.app.NextcloudFileContent
 import dev.obiente.nextcloudnative.app.NextcloudFileListing
+import dev.obiente.nextcloudnative.app.NextcloudFileListingHttpException
 import dev.obiente.nextcloudnative.app.NextcloudFileListingSource
 import dev.obiente.nextcloudnative.app.FileVersionDavRecord
 import dev.obiente.nextcloudnative.app.FileVersionHistory
@@ -330,7 +331,7 @@ internal class AndroidNextcloudServices(
                         return@withContext NextcloudFileListing(it, NextcloudFileListingSource.Cache)
                     }
                 }
-                error("WebDAV folder listing failed (HTTP ${response.status}).")
+                throw NextcloudFileListingHttpException(response.status)
             }
         } catch (failure: IOException) {
             fileReadCache.cachedListing(accountId, path)?.files

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileListingFailureTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileListingFailureTest.kt
@@ -1,0 +1,12 @@
+package dev.obiente.nextcloudnative
+
+import dev.obiente.nextcloudnative.app.NextcloudFileListingHttpException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NextcloudFileListingFailureTest {
+    @Test
+    fun `android folder listing failures expose a typed status to shared UI`() {
+        assertEquals(404, NextcloudFileListingHttpException(404).status)
+    }
+}

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudFileListing.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudFileListing.kt
@@ -10,6 +10,22 @@ data class NextcloudFileListing(
     val source: NextcloudFileListingSource,
 )
 
+/**
+ * A WebDAV folder listing was rejected by the server.
+ *
+ * The typed status lets shared UI distinguish a missing folder from permission and server failures
+ * without inspecting platform-specific exception messages.
+ */
+class NextcloudFileListingHttpException(
+    val status: Int,
+) : Exception("WebDAV folder listing failed (HTTP $status).") {
+    init {
+        require(status in 100..599 && status !in 200..299) {
+            "A folder-listing HTTP failure requires a non-success status."
+        }
+    }
+}
+
 internal fun nextcloudFileListingSummary(
     source: NextcloudFileListingSource?,
     visibleCount: Int,

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
@@ -191,16 +191,30 @@ internal fun remoteFolderSelectionStatus(
     missingDestinationPath: String? = null,
 ): String = when {
     loading -> "Loading this Nextcloud folder before it can be selected."
-    missingDestinationPath != null ->
-        "/$missingDestinationPath will be created when you confirm."
     manualPathVisible && normalizeRemoteFolderInput(manualPathDraft) != currentPath ->
         "Open and verify the advanced path before selecting it."
+    missingDestinationPath != null ->
+        "/$missingDestinationPath will be created when you confirm."
     canConfirm && currentPath.isEmpty() -> "The Files root is ready to select."
     canConfirm -> "/$currentPath is ready to select."
     listingSource == NextcloudFileListingSource.Cache ->
         "This cached destination must be confirmed online before selection."
     else -> "Open an accessible folder before confirming."
 }
+
+internal fun canCreateMissingRemoteFolderDestination(
+    missingDestination: MissingRemoteFolderDestination?,
+    networkConfirmedPath: String?,
+    currentPath: String,
+    manualPathVisible: Boolean,
+    manualPathDraft: String,
+    busy: Boolean,
+): Boolean = !busy &&
+    missingDestination?.accessibleParentPath == networkConfirmedPath &&
+    (
+        !manualPathVisible ||
+            normalizeRemoteFolderInput(manualPathDraft) == currentPath
+        )
 
 @Composable
 internal fun RemoteFolderPickerDialog(
@@ -664,10 +678,14 @@ internal fun RemoteFolderPickerDialog(
         },
         confirmButton = {
             Button(
-                enabled = canConfirm || (
-                    !createRunning &&
-                        missingDestination?.accessibleParentPath == networkConfirmedPath
-                    ),
+                enabled = canConfirm || canCreateMissingRemoteFolderDestination(
+                    missingDestination = missingDestination,
+                    networkConfirmedPath = networkConfirmedPath,
+                    currentPath = currentPath,
+                    manualPathVisible = manualVisible,
+                    manualPathDraft = manualPath,
+                    busy = createRunning,
+                ),
                 onClick = {
                     val destination = missingDestination
                     if (destination == null) {
@@ -677,18 +695,21 @@ internal fun RemoteFolderPickerDialog(
                     createRunning = true
                     createError = null
                     scope.launch {
-                        runCatching {
-                            destination.pathsToCreate.forEach { path ->
-                                services.createDirectoryIfAbsent(session, userId, path)
+                        try {
+                            runCatching {
+                                destination.pathsToCreate.forEach { path ->
+                                    services.createDirectoryIfAbsent(session, userId, path)
+                                }
+                            }.rethrowRemoteFolderCancellation().onSuccess {
+                                recoveryTarget = null
+                                missingDestination = null
+                                onSelected(destination.intendedPath)
+                            }.onFailure { failure ->
+                                createError = failure.message ?: "Could not create this destination."
                             }
-                        }.rethrowRemoteFolderCancellation().onSuccess {
-                            recoveryTarget = null
-                            missingDestination = null
-                            onSelected(destination.intendedPath)
-                        }.onFailure { failure ->
-                            createError = failure.message ?: "Could not create this destination."
+                        } finally {
+                            createRunning = false
                         }
-                        createRunning = false
                     }
                 },
             ) {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
@@ -268,6 +268,7 @@ internal fun RemoteFolderPickerDialog(
         refreshing = false
         error = null
         query = ""
+        missingDestination = null
         val cached = runCatching {
             services.listFilesCachedWithSource(session, userId, currentPath)
         }.rethrowRemoteFolderCancellation().getOrNull()
@@ -298,7 +299,7 @@ internal fun RemoteFolderPickerDialog(
             .onFailure { failure ->
                 loading = false
                 refreshing = false
-                val recoveryParent = recoveryTarget?.let {
+                val recoveryParent = recoveryTarget?.let { _ ->
                     missingRemoteFolderParentAfter(failure, currentPath)
                 }
                 if (recoveryParent != null) {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPicker.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -141,6 +142,39 @@ internal fun newRemoteFolderPath(parentPath: String, name: String): String? {
     return canonicalRemoteFolderPath(if (parent.isEmpty()) name else "$parent/$name")
 }
 
+internal data class MissingRemoteFolderDestination(
+    val intendedPath: String,
+    val accessibleParentPath: String,
+    val pathsToCreate: List<String>,
+)
+
+internal fun missingRemoteFolderDestination(
+    intendedPath: String,
+    accessibleParentPath: String,
+): MissingRemoteFolderDestination? {
+    val intended = canonicalRemoteFolderPath(intendedPath) ?: return null
+    val parent = canonicalRemoteFolderPath(accessibleParentPath) ?: return null
+    if (intended.isEmpty() || intended == parent) return null
+    if (parent.isNotEmpty() && !intended.startsWith("$parent/")) return null
+
+    val parentSegmentCount = parent.split('/').count(String::isNotEmpty)
+    val intendedSegments = intended.split('/')
+    val paths = intendedSegments.indices
+        .drop(parentSegmentCount)
+        .map { index -> intendedSegments.take(index + 1).joinToString("/") }
+    if (paths.isEmpty() || paths.any { canonicalRemoteFolderPath(it) != it }) return null
+    return MissingRemoteFolderDestination(
+        intendedPath = intended,
+        accessibleParentPath = parent,
+        pathsToCreate = paths,
+    )
+}
+
+internal fun missingRemoteFolderParentAfter(failure: Throwable, path: String): String? {
+    if (failure !is NextcloudFileListingHttpException || failure.status != 404) return null
+    return remoteFolderParentPath(path)
+}
+
 internal fun <T> Result<T>.rethrowRemoteFolderCancellation(): Result<T> {
     val failure = exceptionOrNull()
     if (failure is CancellationException) throw failure
@@ -154,8 +188,11 @@ internal fun remoteFolderSelectionStatus(
     listingSource: NextcloudFileListingSource?,
     manualPathVisible: Boolean,
     manualPathDraft: String,
+    missingDestinationPath: String? = null,
 ): String = when {
     loading -> "Loading this Nextcloud folder before it can be selected."
+    missingDestinationPath != null ->
+        "/$missingDestinationPath will be created when you confirm."
     manualPathVisible && normalizeRemoteFolderInput(manualPathDraft) != currentPath ->
         "Open and verify the advanced path before selecting it."
     canConfirm && currentPath.isEmpty() -> "The Files root is ready to select."
@@ -175,7 +212,14 @@ internal fun RemoteFolderPickerDialog(
     onSelected: (String) -> Unit,
 ) {
     val safeInitialPath = remember(initialPath) { normalizeRemoteFolderInput(initialPath).orEmpty() }
-    var currentPath by remember(session, userId, safeInitialPath) { mutableStateOf(safeInitialPath) }
+    var currentPath by rememberSaveable(
+        session.serverUrl,
+        session.loginName,
+        userId,
+        safeInitialPath,
+    ) {
+        mutableStateOf(safeInitialPath)
+    }
     var files by remember(session, userId) { mutableStateOf<List<NextcloudFile>?>(null) }
     var listingSource by remember(session, userId) {
         mutableStateOf<NextcloudFileListingSource?>(null)
@@ -184,15 +228,36 @@ internal fun RemoteFolderPickerDialog(
     var loading by remember(session, userId) { mutableStateOf(true) }
     var refreshing by remember(session, userId) { mutableStateOf(false) }
     var error by remember(session, userId) { mutableStateOf<String?>(null) }
-    var query by remember(session, userId) { mutableStateOf("") }
-    var loadAttempt by remember(session, userId) { mutableStateOf(0) }
-    var createVisible by remember(session, userId) { mutableStateOf(false) }
-    var createName by remember(session, userId) { mutableStateOf("") }
+    var query by rememberSaveable(session.serverUrl, session.loginName, userId) { mutableStateOf("") }
+    var loadAttempt by rememberSaveable(session.serverUrl, session.loginName, userId) {
+        mutableStateOf(0)
+    }
+    var createVisible by rememberSaveable(session.serverUrl, session.loginName, userId) {
+        mutableStateOf(false)
+    }
+    var createName by rememberSaveable(session.serverUrl, session.loginName, userId) {
+        mutableStateOf("")
+    }
     var createError by remember(session, userId) { mutableStateOf<String?>(null) }
     var createRunning by remember(session, userId) { mutableStateOf(false) }
-    var manualVisible by remember(session, userId) { mutableStateOf(false) }
-    var manualPath by remember(session, userId) { mutableStateOf(safeInitialPath) }
+    var manualVisible by rememberSaveable(session.serverUrl, session.loginName, userId) {
+        mutableStateOf(false)
+    }
+    var manualPath by rememberSaveable(session.serverUrl, session.loginName, userId) {
+        mutableStateOf(safeInitialPath)
+    }
     var manualError by remember(session, userId) { mutableStateOf<String?>(null) }
+    var recoveryTarget by rememberSaveable(
+        session.serverUrl,
+        session.loginName,
+        userId,
+        safeInitialPath,
+    ) {
+        mutableStateOf(safeInitialPath.takeIf(String::isNotEmpty))
+    }
+    var missingDestination by remember(session, userId, safeInitialPath) {
+        mutableStateOf<MissingRemoteFolderDestination?>(null)
+    }
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(session, userId, currentPath, loadAttempt) {
@@ -224,11 +289,23 @@ internal fun RemoteFolderPickerDialog(
                 refreshing = false
                 if (listing.source != NextcloudFileListingSource.Network) {
                     error = "Connect to Nextcloud to confirm this destination."
+                } else {
+                    missingDestination = recoveryTarget?.let { intended ->
+                        missingRemoteFolderDestination(intended, currentPath)
+                    }
                 }
             }
             .onFailure { failure ->
                 loading = false
                 refreshing = false
+                val recoveryParent = recoveryTarget?.let {
+                    missingRemoteFolderParentAfter(failure, currentPath)
+                }
+                if (recoveryParent != null) {
+                    currentPath = recoveryParent
+                    manualPath = recoveryParent
+                    return@onFailure
+                }
                 error = if (files == null) {
                     failure.message ?: "Could not open this Nextcloud folder."
                 } else {
@@ -274,6 +351,8 @@ internal fun RemoteFolderPickerDialog(
                             TextButton(
                                 enabled = !createRunning && breadcrumb.path != currentPath,
                                 onClick = {
+                                    recoveryTarget = null
+                                    missingDestination = null
                                     currentPath = breadcrumb.path
                                     manualPath = breadcrumb.path
                                 },
@@ -369,6 +448,8 @@ internal fun RemoteFolderPickerDialog(
                                     modifier = Modifier
                                         .fillMaxWidth()
                                         .clickable(enabled = !createRunning) {
+                                            recoveryTarget = null
+                                            missingDestination = null
                                             currentPath = directory.path
                                             manualPath = directory.path
                                         }
@@ -394,6 +475,45 @@ internal fun RemoteFolderPickerDialog(
                         }
                     }
                 }
+                missingDestination?.let { destination ->
+                    item(key = "missing-destination") {
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            shape = RoundedCornerShape(NextcloudRadii.Small),
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(NextcloudSpacing.Large),
+                                verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                            ) {
+                                Text(
+                                    "/${destination.intendedPath}",
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                )
+                                Text(
+                                    "This folder will be created when you confirm it here.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                )
+                                if (destination.pathsToCreate.size > 1) {
+                                    Text(
+                                        "${destination.pathsToCreate.size} missing folders will be created safely.",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                }
+                                createError?.let { message ->
+                                    Text(
+                                        message,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.error,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
                 item(key = "folder-actions") {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -402,6 +522,8 @@ internal fun RemoteFolderPickerDialog(
                         OutlinedButton(
                             enabled = !createRunning && networkConfirmedPath == currentPath,
                             onClick = {
+                                recoveryTarget = null
+                                missingDestination = null
                                 createVisible = !createVisible
                                 manualVisible = false
                                 createError = null
@@ -504,6 +626,8 @@ internal fun RemoteFolderPickerDialog(
                                     if (target == null) {
                                         manualError = "Enter a valid relative Nextcloud path."
                                     } else {
+                                        recoveryTarget = null
+                                        missingDestination = null
                                         manualVisible = false
                                         currentPath = target
                                         manualPath = target
@@ -524,6 +648,7 @@ internal fun RemoteFolderPickerDialog(
                             listingSource = listingSource,
                             manualPathVisible = manualVisible,
                             manualPathDraft = manualPath,
+                            missingDestinationPath = missingDestination?.intendedPath,
                         ),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = if (canConfirm) FontWeight.Medium else FontWeight.Normal,
@@ -538,10 +663,41 @@ internal fun RemoteFolderPickerDialog(
         },
         confirmButton = {
             Button(
-                enabled = canConfirm,
-                onClick = { onSelected(currentPath) },
+                enabled = canConfirm || (
+                    !createRunning &&
+                        missingDestination?.accessibleParentPath == networkConfirmedPath
+                    ),
+                onClick = {
+                    val destination = missingDestination
+                    if (destination == null) {
+                        onSelected(currentPath)
+                        return@Button
+                    }
+                    createRunning = true
+                    createError = null
+                    scope.launch {
+                        runCatching {
+                            destination.pathsToCreate.forEach { path ->
+                                services.createDirectoryIfAbsent(session, userId, path)
+                            }
+                        }.rethrowRemoteFolderCancellation().onSuccess {
+                            recoveryTarget = null
+                            missingDestination = null
+                            onSelected(destination.intendedPath)
+                        }.onFailure { failure ->
+                            createError = failure.message ?: "Could not create this destination."
+                        }
+                        createRunning = false
+                    }
+                },
             ) {
-                Text(if (currentPath.isEmpty()) "Use Files root" else "Use this folder")
+                Text(
+                    when {
+                        missingDestination != null -> "Create and use this folder"
+                        currentPath.isEmpty() -> "Use Files root"
+                        else -> "Use this folder"
+                    },
+                )
             }
         },
         dismissButton = {

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class RemoteFolderPickerTest {
     @Test
@@ -169,6 +170,69 @@ class RemoteFolderPickerTest {
     }
 
     @Test
+    fun `missing suggested destinations recover through ancestors and retain all segments`() {
+        val missing = NextcloudFileListingHttpException(404)
+
+        assertEquals("Photos", missingRemoteFolderParentAfter(missing, "Photos/Camera"))
+        assertEquals("", missingRemoteFolderParentAfter(missing, "Photos"))
+        assertNull(missingRemoteFolderParentAfter(missing, ""))
+
+        assertEquals(
+            MissingRemoteFolderDestination(
+                intendedPath = "Photos/Camera",
+                accessibleParentPath = "",
+                pathsToCreate = listOf("Photos", "Photos/Camera"),
+            ),
+            missingRemoteFolderDestination("Photos/Camera", ""),
+        )
+        assertEquals(
+            MissingRemoteFolderDestination(
+                intendedPath = "Photos/Camera/2026",
+                accessibleParentPath = "Photos",
+                pathsToCreate = listOf("Photos/Camera", "Photos/Camera/2026"),
+            ),
+            missingRemoteFolderDestination("Photos/Camera/2026", "Photos"),
+        )
+        assertEquals(
+            MissingRemoteFolderDestination(
+                intendedPath = "Photos",
+                accessibleParentPath = "",
+                pathsToCreate = listOf("Photos"),
+            ),
+            missingRemoteFolderDestination("Photos", ""),
+        )
+    }
+
+    @Test
+    fun `only typed not found responses trigger suggested destination recovery`() {
+        assertNull(
+            missingRemoteFolderParentAfter(
+                NextcloudFileListingHttpException(403),
+                "Photos/Camera",
+            ),
+        )
+        assertNull(
+            missingRemoteFolderParentAfter(
+                IllegalStateException("WebDAV folder listing failed (HTTP 404)."),
+                "Photos/Camera",
+            ),
+        )
+        assertNull(missingRemoteFolderDestination("Photos/Camera", "Documents"))
+        assertNull(missingRemoteFolderDestination("../Photos", ""))
+    }
+
+    @Test
+    fun `folder listing HTTP errors retain validated status`() {
+        val failure = NextcloudFileListingHttpException(404)
+
+        assertEquals(404, failure.status)
+        assertTrue(failure.message.orEmpty().contains("404"))
+        assertFailsWith<IllegalArgumentException> {
+            NextcloudFileListingHttpException(207)
+        }
+    }
+
+    @Test
     fun `folder operations preserve coroutine cancellation`() {
         val cancellation = CancellationException("folder changed")
 
@@ -195,6 +259,18 @@ class RemoteFolderPickerTest {
                 listingSource = null,
                 manualPathVisible = false,
                 manualPathDraft = "Photos",
+            ),
+        )
+        assertEquals(
+            "/Photos/Camera will be created when you confirm.",
+            remoteFolderSelectionStatus(
+                loading = false,
+                currentPath = "Photos",
+                canConfirm = true,
+                listingSource = NextcloudFileListingSource.Network,
+                manualPathVisible = false,
+                manualPathDraft = "Photos",
+                missingDestinationPath = "Photos/Camera",
             ),
         )
     }

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RemoteFolderPickerTest.kt
@@ -273,6 +273,61 @@ class RemoteFolderPickerTest {
                 missingDestinationPath = "Photos/Camera",
             ),
         )
+        assertEquals(
+            "Open and verify the advanced path before selecting it.",
+            remoteFolderSelectionStatus(
+                loading = false,
+                currentPath = "Photos",
+                canConfirm = false,
+                listingSource = NextcloudFileListingSource.Network,
+                manualPathVisible = true,
+                manualPathDraft = "Documents",
+                missingDestinationPath = "Photos/Camera",
+            ),
+        )
+    }
+
+    @Test
+    fun `missing destination creation requires the verified path and matching manual draft`() {
+        val missing = requireNotNull(
+            missingRemoteFolderDestination(
+                intendedPath = "Photos/Camera",
+                accessibleParentPath = "Photos",
+            ),
+        )
+
+        assertTrue(
+            canCreateMissingRemoteFolderDestination(
+                missingDestination = missing,
+                networkConfirmedPath = "Photos",
+                currentPath = "Photos",
+                manualPathVisible = false,
+                manualPathDraft = "Photos",
+                busy = false,
+            ),
+        )
+        assertEquals(
+            false,
+            canCreateMissingRemoteFolderDestination(
+                missingDestination = missing,
+                networkConfirmedPath = "Photos",
+                currentPath = "Photos",
+                manualPathVisible = true,
+                manualPathDraft = "Documents",
+                busy = false,
+            ),
+        )
+        assertEquals(
+            false,
+            canCreateMissingRemoteFolderDestination(
+                missingDestination = missing,
+                networkConfirmedPath = null,
+                currentPath = "Photos",
+                manualPathVisible = false,
+                manualPathDraft = "Photos",
+                busy = false,
+            ),
+        )
     }
 
     private fun directory(path: String, name: String) = nextcloudFile(path, name, isDirectory = true)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -425,7 +425,7 @@ class DesktopNextcloudServices(
                         return@withContext NextcloudFileListing(it, NextcloudFileListingSource.Cache)
                     }
                 }
-                error("WebDAV folder listing failed (HTTP ${response.status}).")
+                throw NextcloudFileListingHttpException(response.status)
             }
         } catch (failure: IOException) {
             fileReadCache.cachedListing(accountId, path)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/NextcloudFileListingFailureTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/NextcloudFileListingFailureTest.kt
@@ -1,0 +1,11 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NextcloudFileListingFailureTest {
+    @Test
+    fun `desktop folder listing failures expose a typed status to shared UI`() {
+        assertEquals(404, NextcloudFileListingHttpException(404).status)
+    }
+}


### PR DESCRIPTION
## Summary
- expose typed WebDAV folder-listing status failures on Android and desktop
- recover missing suggested destinations to the nearest network-confirmed parent
- create all missing nested segments only after explicit picker confirmation
- retain picker path state across recreation and preserve cache, cancellation, and path-safety behavior

## Validation
- `:ui:desktopTest` focused picker and desktop status tests
- `:androidApp:testDebugUnitTest` focused Android status test
- `:androidApp:assembleDebug`
- repository hygiene and diff checks

Closes #192