### PR TITLE
fix(dynamic): make recipe workflows actionable

### DIFF
--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
@@ -1188,7 +1188,12 @@ private fun semanticFilteredCollectionResourceId(
 ): String? {
     if (method != HttpMethod.GET) return null
     val taxonomyFilter = path.stableId().let { stablePath ->
-        ("category" in stablePath || "tag" in stablePath || "keyword" in stablePath) &&
+        (
+            "category" in stablePath ||
+                "tag" in stablePath ||
+                "keyword" in stablePath ||
+                "label" in stablePath
+            ) &&
             path.pathPlaceholders().isNotEmpty()
     }
     if (!taxonomyFilter) return null
@@ -1211,8 +1216,11 @@ private fun semanticActionBody(
     declared: HttpBody?,
 ): HttpBody? {
     if (method == HttpMethod.GET || method == HttpMethod.DELETE) return declared
-    val declaredProperties = (declared?.schema as? JsonObject)
-        ?.get("properties") as? JsonObject
+    val declaredBody = declared ?: return null
+    val declaredSchema = declaredBody.schema as? JsonObject ?: return declared
+    val declaredType = declaredSchema.string("type")
+    if (declaredType != null && declaredType != "object") return declared
+    val declaredProperties = declaredSchema["properties"] as? JsonObject
     if (!declaredProperties.isNullOrEmpty()) return declared
 
     val semantics = "$operationId $label $path".lowercase()
@@ -1235,8 +1243,8 @@ private fun semanticActionBody(
     }
     val required = if ("url" in properties) listOf("url") else listOf("name")
     return HttpBody(
-        contentType = declared?.contentType ?: "application/json",
-        required = declared?.required ?: true,
+        contentType = declaredBody.contentType,
+        required = declaredBody.required,
         schema = JsonObject(
             mapOf(
                 "type" to JsonPrimitive("object"),

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
@@ -393,9 +393,12 @@ private class KotlinCompilerState(
         if (readFallbackOperationIds.isNotEmpty()) {
             fallbackOperationIds[actionId] = readFallbackOperationIds
         }
-        val resourceId = resourceId(operation, path, operationId)
+        val resourceId = resourceId(operation, path, operationId, method)
         val response = responseSchema(operation)
-        val (itemSchema, collection) = responseItemSchema(response)
+        val binaryRead = method == HttpMethod.GET && operation.hasSuccessfulBinaryResponse()
+        val (itemSchema, responseCollection) = responseItemSchema(response)
+        val collection = responseCollection ||
+            semanticFilteredCollectionResourceId(operation, path, operationId, method) != null
         val resource = resources.getOrPut(resourceId) { KotlinResourceBuilder(resourceId) }
         resource.collection = resource.collection || collection
         itemSchema?.let { resource.mergeFields(fieldsFromSchema(it)) }
@@ -417,7 +420,14 @@ private class KotlinCompilerState(
             defaultPathParameters,
             collection,
         )
-        val body = body(operation)
+        val label = operation.string("summary") ?: operationId.humanize()
+        val body = semanticActionBody(
+            method = method,
+            path = boundPath,
+            operationId = operationId,
+            label = label,
+            declared = body(operation),
+        )
         val auth = auth(operation)
         val permissionIds = auth.map { requirement ->
             val permissionId = "auth.${requirement.scheme.stableId()}"
@@ -438,7 +448,6 @@ private class KotlinCompilerState(
             )
             permissionId
         }
-        val label = operation.string("summary") ?: operationId.humanize()
         val action = DynamicAction(
             id = actionId,
             label = label,
@@ -471,9 +480,13 @@ private class KotlinCompilerState(
         actions[actionId] = action
 
         if (method == HttpMethod.GET) {
-            if (fallbackForOperationId == null) {
+            if (fallbackForOperationId == null && !binaryRead) {
                 val kind = if (collection) LayoutKind.list else LayoutKind.detail
-                val layoutId = "$resourceId.${kind.name}"
+                val layoutId = if (kind == LayoutKind.list && pathParameters.isNotEmpty()) {
+                    "$resourceId.${kind.name}.${operationId.stableId()}"
+                } else {
+                    "$resourceId.${kind.name}"
+                }
                 layoutPreference(resourceId, boundPath, operationId, kind, pathParameters)?.let { preference ->
                     val candidate = KotlinLayoutSeed(
                         id = layoutId,
@@ -1077,17 +1090,31 @@ private fun String.toHttpMethod(): HttpMethod? = when (lowercase()) {
     else -> null
 }
 
-private fun resourceId(operation: JsonObject, path: String, operationId: String): String {
+private fun resourceId(
+    operation: JsonObject,
+    path: String,
+    operationId: String,
+    method: HttpMethod,
+): String {
     operation.string(RESOURCE_ID_EXTENSION)
         ?.stableId()
         ?.takeIf { it.isNotBlank() && it.length <= 64 }
         ?.let { return it }
+    semanticFilteredCollectionResourceId(operation, path, operationId, method)?.let { return it }
     val rawTag = (operation["tags"] as? JsonArray)
         ?.firstOrNull()
         ?.let { it as? JsonPrimitive }
         ?.contentOrNull
     val tagResource = rawTag?.semanticTagResourceId()
     val pathResource = path.semanticPathResourceId()
+    if (
+        method != HttpMethod.GET &&
+        pathResource in setOf("import", "export") &&
+        tagResource != null &&
+        operation.referencesSemanticResource(tagResource, operationId)
+    ) {
+        return tagResource
+    }
     if (tagResource in ROOT_RESOURCE_WORDS && pathResource == null) return "overview"
     if (tagResource == null) {
         return pathResource ?: operationId.split('.', '_', '-').firstOrNull {
@@ -1105,6 +1132,154 @@ private fun resourceId(operation: JsonObject, path: String, operationId: String)
     if (operationId.provesResource(pathResource)) return pathResource
     return tagResource
 }
+
+private fun JsonObject.referencesSemanticResource(resourceId: String, operationId: String): Boolean {
+    val evidence = listOfNotNull(
+        operationId,
+        string("summary"),
+        string("description"),
+    ).joinToString(" ").stableId()
+    return resourceId.semanticBaseVariants().any { variant ->
+        variant.length >= 4 && evidence.contains(variant)
+    }
+}
+
+/**
+ * Binary reads are valid API capabilities, but they are not record/detail layouts. Their bytes are
+ * consumed by native artwork/media loaders instead of being sent through the JSON record parser.
+ */
+private fun JsonObject.hasSuccessfulBinaryResponse(): Boolean {
+    val responseContent = objectValue("responses")
+        ?.entries
+        ?.filter { (status, _) -> status.startsWith('2') }
+        ?.mapNotNull { (_, response) -> (response as? JsonObject)?.objectValue("content") }
+        .orEmpty()
+    if (responseContent.isEmpty()) return false
+    val contentTypes = responseContent.flatMap { it.keys }.map { it.substringBefore(';').lowercase() }
+    return contentTypes.isNotEmpty() &&
+        contentTypes.none { type -> type.contains("json") } &&
+        contentTypes.all { type ->
+            type.startsWith("image/") ||
+                type.startsWith("audio/") ||
+                type.startsWith("video/") ||
+                type == "application/octet-stream"
+        }
+}
+
+/**
+ * Filter endpoints often use a taxonomy noun in their route even though their response is a
+ * collection of the filtered subject. Prefer the subject proven by operation metadata so records
+ * open with the subject's renderer and detail actions instead of as raw category/tag records.
+ */
+private fun semanticFilteredCollectionResourceId(
+    operation: JsonObject,
+    path: String,
+    operationId: String,
+    method: HttpMethod,
+): String? {
+    if (method != HttpMethod.GET) return null
+    val taxonomyFilter = path.stableId().let { stablePath ->
+        ("category" in stablePath || "tag" in stablePath || "keyword" in stablePath) &&
+            path.pathPlaceholders().isNotEmpty()
+    }
+    if (!taxonomyFilter) return null
+    val operationText = listOfNotNull(
+        operationId,
+        operation.string("summary"),
+        operation.string("description"),
+    ).joinToString(" ").lowercase()
+    return when {
+        "recipe" in operationText -> "recipes"
+        else -> null
+    }
+}
+
+private fun semanticActionBody(
+    method: HttpMethod,
+    path: String,
+    operationId: String,
+    label: String,
+    declared: HttpBody?,
+): HttpBody? {
+    if (method == HttpMethod.GET || method == HttpMethod.DELETE) return declared
+    val declaredProperties = (declared?.schema as? JsonObject)
+        ?.get("properties") as? JsonObject
+    if (!declaredProperties.isNullOrEmpty()) return declared
+
+    val semantics = "$operationId $label $path".lowercase()
+    val recipeAction = "recipe" in semantics
+    if (!recipeAction) return declared
+
+    val properties = when {
+        "import" in semantics && ("url" in semantics || "website" in semantics) -> JsonObject(
+            mapOf(
+                "url" to semanticStringSchema(
+                    title = "Recipe URL",
+                    description = "Link to a webpage containing a recipe",
+                    format = "uri",
+                ),
+            ),
+        )
+        method in setOf(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH) &&
+            listOf("create", "new", "update", "edit").any(semantics::contains) -> recipeEditProperties()
+        else -> return declared
+    }
+    val required = if ("url" in properties) listOf("url") else listOf("name")
+    return HttpBody(
+        contentType = declared?.contentType ?: "application/json",
+        required = declared?.required ?: true,
+        schema = JsonObject(
+            mapOf(
+                "type" to JsonPrimitive("object"),
+                "properties" to properties,
+                "required" to JsonArray(required.map(::JsonPrimitive)),
+            ),
+        ),
+    )
+}
+
+private fun recipeEditProperties(): JsonObject = JsonObject(
+    mapOf(
+        "name" to semanticStringSchema("Recipe name"),
+        "description" to semanticStringSchema("Description"),
+        "recipeYield" to JsonObject(
+            mapOf(
+                "type" to JsonPrimitive("integer"),
+                "title" to JsonPrimitive("Servings"),
+                "minimum" to JsonPrimitive(1),
+            ),
+        ),
+        "recipeCategory" to semanticStringSchema("Category"),
+        "keywords" to semanticStringSchema("Tags", "Separate tags with commas"),
+        "prepTime" to semanticStringSchema("Preparation time", "For example: PT20M"),
+        "cookTime" to semanticStringSchema("Cooking time", "For example: PT45M"),
+        "recipeIngredient" to semanticStringArraySchema("Ingredients"),
+        "recipeInstructions" to semanticStringArraySchema("Instructions"),
+        "tool" to semanticStringArraySchema("Tools"),
+    ),
+)
+
+private fun semanticStringSchema(
+    title: String,
+    description: String? = null,
+    format: String? = null,
+): JsonObject = JsonObject(
+    buildMap {
+        put("type", JsonPrimitive("string"))
+        put("title", JsonPrimitive(title))
+        description?.let { put("description", JsonPrimitive(it)) }
+        format?.let { put("format", JsonPrimitive(it)) }
+    },
+)
+
+private fun semanticStringArraySchema(title: String): JsonObject = JsonObject(
+    mapOf(
+        "type" to JsonPrimitive("array"),
+        "title" to JsonPrimitive(title),
+        "items" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
+        "format" to JsonPrimitive(DYNAMIC_STRING_ARRAY_FORMAT),
+    ),
+)
 
 private const val RESOURCE_ID_EXTENSION = "x-nextcloud-native-resource-id"
 
@@ -1189,6 +1364,19 @@ private fun DynamicAction.navigationParent(
     childResourceId: String,
     resources: List<DynamicResource>,
 ): DynamicResource? = binding.path.hierarchyParent(childResourceId, resources)
+    ?: (binding.pathParameters + binding.queryParameters)
+        .asSequence()
+        .filter(HttpParameter::required)
+        .map { parameter -> parameter.name.stableId() }
+        .mapNotNull { stem ->
+            val variants = stem.semanticBaseVariants()
+            resources.firstOrNull { resource ->
+                resource.collection &&
+                    resource.id.semanticBaseVariants().intersect(variants).isNotEmpty() &&
+                    resource.id.semanticBaseVariants().intersect(childResourceId.semanticBaseVariants()).isEmpty()
+            }
+        }
+        .firstOrNull()
     ?: (binding.pathParameters + binding.queryParameters)
         .asSequence()
         .filter(HttpParameter::required)

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
@@ -393,12 +393,19 @@ private class KotlinCompilerState(
         if (readFallbackOperationIds.isNotEmpty()) {
             fallbackOperationIds[actionId] = readFallbackOperationIds
         }
-        val resourceId = resourceId(operation, path, operationId, method)
+        val filteredCollectionResourceId =
+            semanticFilteredCollectionResourceId(operation, path, operationId, method)
+        val resourceId = resourceId(
+            operation = operation,
+            path = path,
+            operationId = operationId,
+            method = method,
+            filteredCollectionResourceId = filteredCollectionResourceId,
+        )
         val response = responseSchema(operation)
         val binaryRead = method == HttpMethod.GET && operation.hasSuccessfulBinaryResponse()
         val (itemSchema, responseCollection) = responseItemSchema(response)
-        val collection = responseCollection ||
-            semanticFilteredCollectionResourceId(operation, path, operationId, method) != null
+        val collection = responseCollection || filteredCollectionResourceId != null
         val resource = resources.getOrPut(resourceId) { KotlinResourceBuilder(resourceId) }
         resource.collection = resource.collection || collection
         itemSchema?.let { resource.mergeFields(fieldsFromSchema(it)) }
@@ -482,7 +489,7 @@ private class KotlinCompilerState(
         if (method == HttpMethod.GET) {
             if (fallbackForOperationId == null && !binaryRead) {
                 val kind = if (collection) LayoutKind.list else LayoutKind.detail
-                val layoutId = if (kind == LayoutKind.list && pathParameters.isNotEmpty()) {
+                val layoutId = if (kind == LayoutKind.list && filteredCollectionResourceId != null) {
                     "$resourceId.${kind.name}.${operationId.stableId()}"
                 } else {
                     "$resourceId.${kind.name}"
@@ -1095,12 +1102,14 @@ private fun resourceId(
     path: String,
     operationId: String,
     method: HttpMethod,
+    filteredCollectionResourceId: String? =
+        semanticFilteredCollectionResourceId(operation, path, operationId, method),
 ): String {
     operation.string(RESOURCE_ID_EXTENSION)
         ?.stableId()
         ?.takeIf { it.isNotBlank() && it.length <= 64 }
         ?.let { return it }
-    semanticFilteredCollectionResourceId(operation, path, operationId, method)?.let { return it }
+    filteredCollectionResourceId?.let { return it }
     val rawTag = (operation["tags"] as? JsonArray)
         ?.firstOrNull()
         ?.let { it as? JsonPrimitive }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompiler.kt
@@ -1187,15 +1187,9 @@ private fun semanticFilteredCollectionResourceId(
     method: HttpMethod,
 ): String? {
     if (method != HttpMethod.GET) return null
-    val taxonomyFilter = path.stableId().let { stablePath ->
-        (
-            "category" in stablePath ||
-                "tag" in stablePath ||
-                "keyword" in stablePath ||
-                "label" in stablePath
-            ) &&
+    val taxonomyFilter =
+        path.hasAnySemanticConcept(SEMANTIC_TAXONOMY_CONCEPTS) &&
             path.pathPlaceholders().isNotEmpty()
-    }
     if (!taxonomyFilter) return null
     val operationText = listOfNotNull(
         operationId,

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlanner.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlanner.kt
@@ -123,6 +123,7 @@ private fun preferredSemanticChildScore(
     val parent = parentResourceId.navigationSemanticIdentity()
     val parentIsAccount = parent.hasNavigationConcept("account") || parent.hasNavigationConcept("container")
     val parentIsMailbox = parent.hasNavigationConcept("mailbox") || parent.hasNavigationConcept("folder")
+    val parentIsTaxonomy = listOf("category", "tag", "keyword", "label").any(parent::hasNavigationConcept)
     val mailboxEvidence = destination.semanticConceptEvidence("mailbox")
     val folderEvidence = destination.semanticConceptEvidence("folder")
     val messageEvidence = maxOf(
@@ -133,6 +134,7 @@ private fun preferredSemanticChildScore(
         parentIsAccount && mailboxEvidence > 0 -> 400 + mailboxEvidence
         parentIsAccount && folderEvidence > 0 -> 300 + folderEvidence
         parentIsMailbox && messageEvidence > 0 -> 400 + messageEvidence
+        parentIsTaxonomy -> 350
         else -> 0
     }
 }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlanner.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlanner.kt
@@ -123,7 +123,8 @@ private fun preferredSemanticChildScore(
     val parent = parentResourceId.navigationSemanticIdentity()
     val parentIsAccount = parent.hasNavigationConcept("account") || parent.hasNavigationConcept("container")
     val parentIsMailbox = parent.hasNavigationConcept("mailbox") || parent.hasNavigationConcept("folder")
-    val parentIsTaxonomy = listOf("category", "tag", "keyword", "label").any(parent::hasNavigationConcept)
+    val parentIsTaxonomy =
+        parentResourceId.hasAnySemanticConcept(SEMANTIC_TAXONOMY_CONCEPTS)
     val mailboxEvidence = destination.semanticConceptEvidence("mailbox")
     val folderEvidence = destination.semanticConceptEvidence("folder")
     val messageEvidence = maxOf(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/SemanticConceptTokens.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/nativeui/model/SemanticConceptTokens.kt
@@ -1,0 +1,57 @@
+package dev.obiente.nextcloudnative.nativeui.model
+
+internal val SEMANTIC_TAXONOMY_CONCEPTS: Set<String> = setOf(
+    "category",
+    "tag",
+    "keyword",
+    "label",
+)
+
+/**
+ * Matches semantic concepts as complete identifier words, never as arbitrary substrings.
+ *
+ * Contract identifiers commonly mix route separators, camel case, and plural nouns. Tokens are
+ * split at all of those boundaries and normalized to a singular concept so `category` and
+ * `categories` match while unrelated words such as `staging` never become `tag`.
+ */
+internal fun String.hasAnySemanticConcept(concepts: Set<String>): Boolean =
+    semanticConceptTokens().any(concepts::contains)
+
+internal fun String.semanticConceptTokens(): Set<String> {
+    val tokens = linkedSetOf<String>()
+    val current = StringBuilder()
+
+    fun flush() {
+        if (current.isEmpty()) return
+        tokens += current.toString().semanticConceptSingular()
+        current.clear()
+    }
+
+    forEachIndexed { index, character ->
+        if (!character.isLetterOrDigit()) {
+            flush()
+            return@forEachIndexed
+        }
+        val previous = getOrNull(index - 1)
+        val next = getOrNull(index + 1)
+        val startsWord = character.isUpperCase() &&
+            current.isNotEmpty() &&
+            (
+                previous?.isLowerCase() == true ||
+                    previous?.isDigit() == true ||
+                    (previous?.isUpperCase() == true && next?.isLowerCase() == true)
+                )
+        if (startsWord) flush()
+        current.append(character.lowercaseChar())
+    }
+    flush()
+    return tokens
+}
+
+private fun String.semanticConceptSingular(): String = when {
+    endsWith("ies") && length > 3 -> dropLast(3) + "y"
+    endsWith("ches") || endsWith("shes") -> dropLast(2)
+    endsWith("ses") || endsWith("xes") || endsWith("zes") -> dropLast(2)
+    endsWith('s') && length > 1 && !endsWith("ss") -> dropLast(1)
+    else -> this
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompilerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompilerTest.kt
@@ -225,6 +225,192 @@ class DynamicAppDescriptorCompilerTest {
     }
 
     @Test
+    fun `recipe actions recover useful forms when an external schema is unavailable`() {
+        val document = """
+            {
+              "openapi":"3.0.3",
+              "info":{"title":"Recipes","version":"1"},
+              "paths":{
+                "/apps/example/api/v1/recipes":{
+                  "get":{
+                    "operationId":"getAllRecipes",
+                    "summary":"Get all recipes",
+                    "tags":["Recipes"],
+                    "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{
+                      "type":"array","items":{"type":"object","properties":{"id":{"type":"string"}}}
+                    }}}}}
+                  },
+                  "post":{
+                    "operationId":"newRecipe",
+                    "summary":"Create a new recipe",
+                    "tags":["Recipes"],
+                    "requestBody":{"required":true,"content":{"application/json":{"schema":{}}}},
+                    "responses":{"201":{"description":"Created"}}
+                  }
+                },
+                "/apps/example/api/v1/import":{
+                  "post":{
+                    "operationId":"import",
+                    "summary":"Import a recipe using schema.org metadata from a website URL",
+                    "tags":["Recipes"],
+                    "requestBody":{"required":true,"content":{"application/json":{"schema":{}}}},
+                    "responses":{"201":{"description":"Created"}}
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val descriptor = DynamicAppDescriptorCompiler().compile(exampleInput(document))
+        val create = descriptor.actions.single { it.id == "newrecipe" }
+        val import = descriptor.actions.single { it.id == "import" }
+
+        assertEquals(
+            listOf(
+                "cookTime",
+                "description",
+                "keywords",
+                "name",
+                "prepTime",
+                "recipeCategory",
+                "recipeIngredient",
+                "recipeInstructions",
+                "recipeYield",
+                "tool",
+            ),
+            descriptor.forms.single { it.actionId == create.id }.fields.map(FormField::fieldId),
+        )
+        assertEquals(
+            listOf("url"),
+            descriptor.forms.single { it.actionId == import.id }.fields.map(FormField::fieldId),
+        )
+        assertTrue((assertNotNull(create.binding.body).schema as JsonObject).containsKey("properties"))
+        assertTrue((assertNotNull(import.binding.body).schema as JsonObject).containsKey("properties"))
+        assertEquals("recipes", import.resourceId)
+        assertEquals(
+            setOf("import", "newrecipe"),
+            descriptor.planDynamicNavigation().rootFormActions.map { it.actionId }.toSet(),
+        )
+        assertTrue(descriptor.validationErrors().isEmpty())
+    }
+
+    @Test
+    fun `taxonomy filter responses use the filtered subject resource`() {
+        val document = """
+            {
+              "openapi":"3.0.3",
+              "info":{"title":"Recipes","version":"1"},
+              "paths":{
+                "/apps/example/api/v1/categories":{
+                  "get":{
+                    "operationId":"getAllCategories",
+                    "summary":"Get all categories",
+                    "tags":["Categories"],
+                    "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{
+                      "type":"array","items":{"type":"string"}
+                    }}}}}
+                  }
+                },
+                "/apps/example/api/v1/keywords":{
+                  "get":{
+                    "operationId":"getAllKeywords",
+                    "summary":"Get all keywords",
+                    "tags":["Tags"],
+                    "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{
+                      "type":"array","items":{"type":"string"}
+                    }}}}}
+                  }
+                },
+                "/apps/example/api/v1/category/{category}":{
+                  "parameters":[
+                    {"name":"category","in":"path","required":true,"schema":{"type":"string"}}
+                  ],
+                  "get":{
+                    "operationId":"recipesInCategory",
+                    "summary":"Get all recipes in a category",
+                    "tags":["Categories"],
+                    "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}}
+                  }
+                },
+                "/apps/example/api/v1/tags/{keywords}":{
+                  "parameters":[
+                    {"name":"keywords","in":"path","required":true,"schema":{"type":"string"}}
+                  ],
+                  "get":{
+                    "operationId":"recipesWithKeyword",
+                    "summary":"Get all recipes with a keyword",
+                    "tags":["Tags"],
+                    "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}}
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val descriptor = DynamicAppDescriptorCompiler().compile(exampleInput(document))
+
+        assertEquals(
+            setOf("recipes"),
+            descriptor.actions
+                .filter { it.id in setOf("recipesincategory", "recipeswithkeyword") }
+                .map(DynamicAction::resourceId)
+                .toSet(),
+        )
+        assertEquals(
+            setOf("categories.recipes.collection", "keywords.recipes.collection"),
+            descriptor.links.map(DynamicLink::id).toSet(),
+        )
+        assertEquals(
+            setOf("recipesincategory", "recipeswithkeyword"),
+            descriptor.layouts
+                .filter { it.resourceId == "recipes" }
+                .mapNotNull(DynamicLayout::sourceActionId)
+                .toSet(),
+        )
+        val keywordRecipes = descriptor.planDynamicNavigation(
+            DynamicResourceRecordContext(
+                resourceId = "keywords",
+                recordId = "sweet",
+                actionSafeIdentity = false,
+            ),
+        ).contextualChildDestinations.single()
+        assertEquals("recipeswithkeyword", keywordRecipes.actionId)
+        assertEquals(mapOf("keywords" to "sweet"), keywordRecipes.pathParameterValues)
+        assertTrue(descriptor.validationErrors().isEmpty())
+    }
+
+    @Test
+    fun `binary artwork reads are not exposed as JSON detail views`() {
+        val document = """
+            {
+              "openapi":"3.0.3",
+              "info":{"title":"Recipes","version":"1"},
+              "paths":{
+                "/apps/example/api/v1/recipes/{id}/image":{
+                  "parameters":[
+                    {"name":"id","in":"path","required":true,"schema":{"type":"string"}}
+                  ],
+                  "get":{
+                    "operationId":"getRecipeImage",
+                    "summary":"Get the recipe image",
+                    "tags":["Recipes"],
+                    "responses":{"200":{"description":"Image","content":{
+                      "image/jpeg":{"schema":{"type":"string","format":"binary"}}
+                    }}}
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val descriptor = DynamicAppDescriptorCompiler().compile(exampleInput(document))
+
+        assertEquals(listOf("getrecipeimage"), descriptor.actions.map(DynamicAction::id))
+        assertTrue(descriptor.layouts.isEmpty())
+        assertTrue(descriptor.validationErrors().isEmpty())
+    }
+
+    @Test
     fun terminalIdentityPathOverridesPluralDetailNameWithoutBreakingFilteredCollections() {
         val document = """
             {
@@ -551,6 +737,19 @@ class DynamicAppDescriptorCompilerTest {
             documentUrl = documentUrl,
             document = Json.parseToJsonElement(openApi),
             trust = trust,
+        ),
+    )
+
+    private fun exampleInput(openApi: String) = DynamicDiscoveryInput(
+        app = AppIdentity("example", "Example", "1"),
+        endpointPolicy = EndpointPolicy(
+            serverOrigin = "https://cloud.example.test",
+            approvedApiPrefixes = listOf("/apps/example/api"),
+        ),
+        advertisedOpenApi = AdvertisedOpenApi(
+            documentUrl = "/apps/example/openapi.json",
+            document = Json.parseToJsonElement(openApi),
+            trust = OpenApiTrust.sameOriginAdvertisement,
         ),
     )
 

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompilerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompilerTest.kt
@@ -3,10 +3,12 @@ package dev.obiente.nextcloudnative.nativeui.model
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DynamicAppDescriptorCompilerTest {
@@ -295,6 +297,48 @@ class DynamicAppDescriptorCompilerTest {
     }
 
     @Test
+    fun `recipe action recovery preserves undeclared and non object bodies`() {
+        val document = """
+            {
+              "openapi":"3.0.3",
+              "info":{"title":"Recipes","version":"1"},
+              "paths":{
+                "/apps/example/api/v1/recipes/draft":{
+                  "post":{
+                    "operationId":"createRecipeDraft",
+                    "summary":"Create a recipe draft",
+                    "tags":["Recipes"],
+                    "responses":{"201":{"description":"Created"}}
+                  }
+                },
+                "/apps/example/api/v1/recipes/batch":{
+                  "post":{
+                    "operationId":"createRecipeBatch",
+                    "summary":"Create recipes in a batch",
+                    "tags":["Recipes"],
+                    "requestBody":{"required":true,"content":{"application/json":{"schema":{
+                      "type":"array","items":{"type":"string"}
+                    }}}},
+                    "responses":{"201":{"description":"Created"}}
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val descriptor = DynamicAppDescriptorCompiler().compile(exampleInput(document))
+
+        assertNull(descriptor.actions.single { it.id == "createrecipedraft" }.binding.body)
+        assertEquals(
+            "array",
+            (assertNotNull(
+                descriptor.actions.single { it.id == "createrecipebatch" }.binding.body,
+            ).schema as JsonObject)["type"]?.jsonPrimitive?.content,
+        )
+        assertTrue(descriptor.validationErrors().isEmpty())
+    }
+
+    @Test
     fun `taxonomy filter responses use the filtered subject resource`() {
         val document = """
             {
@@ -342,6 +386,17 @@ class DynamicAppDescriptorCompilerTest {
                     "tags":["Tags"],
                     "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}}
                   }
+                },
+                "/apps/example/api/v1/labels/{label}":{
+                  "parameters":[
+                    {"name":"label","in":"path","required":true,"schema":{"type":"string"}}
+                  ],
+                  "get":{
+                    "operationId":"recipesWithLabel",
+                    "summary":"Get all recipes with a label",
+                    "tags":["Labels"],
+                    "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}}
+                  }
                 }
               }
             }
@@ -352,7 +407,7 @@ class DynamicAppDescriptorCompilerTest {
         assertEquals(
             setOf("recipes"),
             descriptor.actions
-                .filter { it.id in setOf("recipesincategory", "recipeswithkeyword") }
+                .filter { it.id in setOf("recipesincategory", "recipeswithkeyword", "recipeswithlabel") }
                 .map(DynamicAction::resourceId)
                 .toSet(),
         )
@@ -361,7 +416,7 @@ class DynamicAppDescriptorCompilerTest {
             descriptor.links.map(DynamicLink::id).toSet(),
         )
         assertEquals(
-            setOf("recipesincategory", "recipeswithkeyword"),
+            setOf("recipesincategory", "recipeswithkeyword", "recipeswithlabel"),
             descriptor.layouts
                 .filter { it.resourceId == "recipes" }
                 .mapNotNull(DynamicLayout::sourceActionId)

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompilerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicAppDescriptorCompilerTest.kt
@@ -365,7 +365,7 @@ class DynamicAppDescriptorCompilerTest {
                     }}}}}
                   }
                 },
-                "/apps/example/api/v1/category/{category}":{
+                "/apps/example/api/v1/categories/{category}":{
                   "parameters":[
                     {"name":"category","in":"path","required":true,"schema":{"type":"string"}}
                   ],
@@ -397,6 +397,17 @@ class DynamicAppDescriptorCompilerTest {
                     "tags":["Labels"],
                     "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}}
                   }
+                },
+                "/apps/example/api/v1/staging/{id}":{
+                  "parameters":[
+                    {"name":"id","in":"path","required":true,"schema":{"type":"string"}}
+                  ],
+                  "get":{
+                    "operationId":"recipesInStaging",
+                    "summary":"Get a recipe from staging",
+                    "tags":["Staging"],
+                    "responses":{"200":{"description":"OK","content":{"application/json":{"schema":{}}}}}
+                  }
                 }
               }
             }
@@ -421,6 +432,10 @@ class DynamicAppDescriptorCompilerTest {
                 .filter { it.resourceId == "recipes" }
                 .mapNotNull(DynamicLayout::sourceActionId)
                 .toSet(),
+        )
+        assertEquals(
+            "staging",
+            descriptor.actions.single { it.id == "recipesinstaging" }.resourceId,
         )
         val keywordRecipes = descriptor.planDynamicNavigation(
             DynamicResourceRecordContext(

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlannerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlannerTest.kt
@@ -515,6 +515,41 @@ class DynamicNavigationPlannerTest {
     }
 
     @Test
+    fun `taxonomy records prefer their filtered content collection over raw detail`() {
+        val descriptor = hierarchyDescriptor().copy(
+            app = AppIdentity("library", "Library", "test"),
+            resources = listOf(resource("keywords"), resource("recipes")),
+            layouts = listOf(
+                layout("keywords", "list-keywords"),
+                layout("recipes", "list-recipes-with-keyword"),
+            ),
+            links = listOf(
+                actionLink(
+                    "keywords.recipes",
+                    "Recipes",
+                    "keywords",
+                    "list-recipes-with-keyword",
+                ),
+            ),
+            forms = emptyList(),
+            actions = listOf(
+                action("list-keywords", "keywords", ActionIntent.list),
+                action("list-recipes-with-keyword", "recipes", ActionIntent.list, "keywords"),
+            ),
+        )
+        val context = DynamicResourceRecordContext(
+            resourceId = "keywords",
+            recordId = "sweet",
+            actionSafeIdentity = false,
+        )
+
+        val preferred = assertNotNull(descriptor.preferredSemanticContextualChild(context))
+
+        assertEquals("recipes", preferred.resourceId)
+        assertEquals(mapOf("keywords" to "sweet"), preferred.pathParameterValues)
+    }
+
+    @Test
     fun `message protocol helpers are secondary while useful content stays primary`() {
         val descriptor = hierarchyDescriptor().copy(
             app = AppIdentity("communications", "Communications", "test"),

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlannerTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/DynamicNavigationPlannerTest.kt
@@ -518,27 +518,27 @@ class DynamicNavigationPlannerTest {
     fun `taxonomy records prefer their filtered content collection over raw detail`() {
         val descriptor = hierarchyDescriptor().copy(
             app = AppIdentity("library", "Library", "test"),
-            resources = listOf(resource("keywords"), resource("recipes")),
+            resources = listOf(resource("categories"), resource("recipes")),
             layouts = listOf(
-                layout("keywords", "list-keywords"),
-                layout("recipes", "list-recipes-with-keyword"),
+                layout("categories", "list-categories"),
+                layout("recipes", "list-recipes-in-category"),
             ),
             links = listOf(
                 actionLink(
-                    "keywords.recipes",
+                    "categories.recipes",
                     "Recipes",
-                    "keywords",
-                    "list-recipes-with-keyword",
+                    "categories",
+                    "list-recipes-in-category",
                 ),
             ),
             forms = emptyList(),
             actions = listOf(
-                action("list-keywords", "keywords", ActionIntent.list),
-                action("list-recipes-with-keyword", "recipes", ActionIntent.list, "keywords"),
+                action("list-categories", "categories", ActionIntent.list),
+                action("list-recipes-in-category", "recipes", ActionIntent.list, "category"),
             ),
         )
         val context = DynamicResourceRecordContext(
-            resourceId = "keywords",
+            resourceId = "categories",
             recordId = "sweet",
             actionSafeIdentity = false,
         )
@@ -546,7 +546,7 @@ class DynamicNavigationPlannerTest {
         val preferred = assertNotNull(descriptor.preferredSemanticContextualChild(context))
 
         assertEquals("recipes", preferred.resourceId)
-        assertEquals(mapOf("keywords" to "sweet"), preferred.pathParameterValues)
+        assertEquals(mapOf("category" to "sweet"), preferred.pathParameterValues)
     }
 
     @Test

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/SemanticConceptTokensTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/nativeui/model/SemanticConceptTokensTest.kt
@@ -1,0 +1,38 @@
+package dev.obiente.nextcloudnative.nativeui.model
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SemanticConceptTokensTest {
+    @Test
+    fun `taxonomy concepts recognize singular plural and identifier boundaries`() {
+        listOf(
+            "category",
+            "categories",
+            "tag",
+            "tags",
+            "keyword",
+            "keywords",
+            "label",
+            "labels",
+            "recipeCategories",
+            "/api/v1/recipe-keywords/{keyword}",
+        ).forEach { identifier ->
+            assertTrue(
+                identifier.hasAnySemanticConcept(SEMANTIC_TAXONOMY_CONCEPTS),
+                identifier,
+            )
+        }
+    }
+
+    @Test
+    fun `taxonomy concepts reject substrings inside unrelated words`() {
+        listOf("staging", "tagline", "categorically", "/api/v1/staging/{id}").forEach { identifier ->
+            assertFalse(
+                identifier.hasAnySemanticConcept(SEMANTIC_TAXONOMY_CONCEPTS),
+                identifier,
+            )
+        }
+    }
+}


### PR DESCRIPTION
Closes #55

## What changed

- Recover typed recipe create/edit fields when a verified OpenAPI contract references an unavailable split schema.
- Expose URL import as a Recipes action with a required validated URL field.
- Keep category and keyword filter routes as distinct contextual recipe collections instead of collapsing both into one layout.
- Prefer filtered content when a category, tag, keyword, or label record is selected.
- Prevent binary image/audio/video endpoints from being rendered through the JSON detail viewer.
- Preserve safe generic behavior through semantic operation, response, taxonomy, and resource inference rather than an app-ID check.

## Root cause

Cookbook's split schema left write bodies without properties, route tags classified filtered results as taxonomy records, contextual routes shared one layout ID, and binary image responses were treated as JSON detail screens.

## User impact

Recipe creation now has useful native fields, URL import is available from Recipes, Categories and Keywords open their matching recipe lists, and the unusable binary Image detail view is no longer exposed.

## Validation

- Focused descriptor compiler and navigation planner desktop tests
- Android debug assembly
- Repository hygiene and diff checks
- Installed and verified on a OnePlus 15 against a real Cookbook instance