### PR TITLE
feat(home): add customizable workspace dashboard

### DIFF
--- a/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.android.kt
+++ b/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.android.kt
@@ -1,0 +1,47 @@
+package dev.obiente.nextcloudnative.app
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+internal actual fun rememberHomeWorkspaceLayoutStorage(): HomeWorkspaceLayoutStorage {
+    val applicationContext = LocalContext.current.applicationContext
+    return remember(applicationContext) {
+        val preferences = applicationContext.getSharedPreferences(
+            HOME_WORKSPACE_PREFERENCES,
+            Context.MODE_PRIVATE,
+        )
+        object : HomeWorkspaceLayoutStorage {
+            override fun read(persistenceKey: String): String? =
+                preferences.getString(persistenceKey, null)
+
+            override fun write(persistenceKey: String, encodedSnapshot: String) {
+                check(preferences.edit().putString(persistenceKey, encodedSnapshot).commit()) {
+                    "The home workspace could not be persisted."
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal actual fun rememberHomeFormFactor(): HomeFormFactor {
+    val configuration = LocalConfiguration.current
+    return remember(configuration.smallestScreenWidthDp) {
+        if (
+            configuration.smallestScreenWidthDp != Configuration.SMALLEST_SCREEN_WIDTH_DP_UNDEFINED &&
+            configuration.smallestScreenWidthDp >= TABLET_SMALLEST_WIDTH_DP
+        ) {
+            HomeFormFactor.Tablet
+        } else {
+            HomeFormFactor.Phone
+        }
+    }
+}
+
+private const val HOME_WORKSPACE_PREFERENCES = "nextcloud_native_home_workspace"
+private const val TABLET_SMALLEST_WIDTH_DP = 600

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 
-private sealed interface DashboardSurfaceState {
+internal sealed interface DashboardSurfaceState {
     data object Loading : DashboardSurfaceState
     data class Available(
         val snapshot: NativeDashboardSnapshot,
@@ -74,9 +74,145 @@ internal fun NativeDashboardScreen(
     onOpenStatus: (() -> Unit)?,
     onBack: () -> Unit,
 ) {
-    var state by remember(session) { mutableStateOf<DashboardSurfaceState>(DashboardSurfaceState.Loading) }
     var refreshAttempt by remember(session) { mutableStateOf(0) }
+    var customizeWorkspace by remember(session) { mutableStateOf(false) }
+    var workspacePersistenceError by remember(session) { mutableStateOf<String?>(null) }
+    val state = rememberNativeDashboardState(
+        services = services,
+        session = session,
+        refreshAttempt = refreshAttempt,
+    )
+    val formFactor = rememberHomeFormFactor()
+    val workspaceStorage = rememberHomeWorkspaceLayoutStorage()
+    val workspaceRepository = remember(workspaceStorage) {
+        HomeWorkspaceLayoutRepository(workspaceStorage)
+    }
+    val workspaceScope = remember(session.serverUrl, session.loginName, formFactor) {
+        HomeWorkspaceScope(
+            accountScopeDigest = previewCacheDigest(session),
+            formFactor = formFactor,
+        )
+    }
+    var workspaceLayout by remember(workspaceScope) {
+        mutableStateOf(workspaceRepository.load(workspaceScope))
+    }
 
+    Column(modifier = Modifier.fillMaxSize()) {
+        DashboardHeader(
+            title = "Home",
+            subtitle = "Your cloud at a glance",
+            onBack = onBack,
+            onRefresh = { refreshAttempt += 1 },
+            onCustomize = { customizeWorkspace = true },
+        )
+        when (val current = state) {
+            DashboardSurfaceState.Loading -> DashboardLoading()
+            is DashboardSurfaceState.Failed -> DashboardFailure(
+                message = current.message,
+                onRetry = { refreshAttempt += 1 },
+            )
+            is DashboardSurfaceState.Available -> {
+                val bindings = remember(current.snapshot.widgets) {
+                    homeDashboardWidgetBindings(current.snapshot.widgets)
+                }
+                val availableSectionIds = remember(bindings) {
+                    buildList {
+                        add(HomeSectionIds.QuickActions)
+                        bindings.forEach { binding ->
+                            if (size < MAX_HOME_WORKSPACE_SECTIONS) add(binding.sectionId)
+                        }
+                    }
+                }
+                val effectiveLayout = remember(workspaceLayout, availableSectionIds) {
+                    workspaceLayout.reconcileAvailableSections(availableSectionIds)
+                }
+                LaunchedEffect(effectiveLayout) {
+                    if (effectiveLayout != workspaceLayout) {
+                        workspaceLayout = effectiveLayout
+                        workspaceRepository.save(effectiveLayout)
+                    }
+                }
+                val bindingsBySection = remember(bindings) {
+                    bindings.associateBy(HomeDashboardWidgetBinding::sectionId)
+                }
+                current.status?.let { status ->
+                    CurrentStatusStrip(status = status, onClick = onOpenStatus)
+                }
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(330.dp),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(NextcloudSpacing.XLarge),
+                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Large),
+                    verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Large),
+                ) {
+                    items(
+                        effectiveLayout.visibleSections,
+                        key = { section -> section.id.value },
+                    ) { section ->
+                        when (section.id) {
+                            HomeSectionIds.QuickActions -> DashboardQuickActionsCard(
+                                installedApps = installedApps,
+                                onOpenApp = onOpenApp,
+                            )
+
+                            else -> bindingsBySection[section.id]?.let { binding ->
+                                DashboardWidgetCard(
+                                    widget = binding.widget,
+                                    items = current.snapshot.itemsByWidget[binding.widget.id].orEmpty(),
+                                    size = section.size,
+                                    onOpenLink = { link ->
+                                        val appId = dashboardAppIdForLink(session, link)
+                                        val nativeApp = installedApps.firstOrNull { it.id == appId }
+                                        if (nativeApp != null) {
+                                            onOpenApp(nativeApp)
+                                        } else {
+                                            services.openExternalUrl(dashboardBrowserUrl(session, link))
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (customizeWorkspace) {
+                    HomeWorkspaceCustomizerDialog(
+                        layout = effectiveLayout,
+                        sectionLabels = buildMap {
+                            put(HomeSectionIds.QuickActions, "Quick actions")
+                            bindings.forEach { put(it.sectionId, it.widget.title) }
+                        },
+                        persistenceError = workspacePersistenceError,
+                        onDismiss = {
+                            customizeWorkspace = false
+                            workspacePersistenceError = null
+                        },
+                        onSave = { updated ->
+                            workspaceLayout = updated
+                            if (workspaceRepository.save(updated)) {
+                                customizeWorkspace = false
+                                workspacePersistenceError = null
+                            } else {
+                                workspacePersistenceError =
+                                    "Your changes are active, but could not be saved on this device."
+                            }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun rememberNativeDashboardState(
+    services: NextcloudPlatformServices,
+    session: NextcloudSession,
+    refreshAttempt: Int,
+): DashboardSurfaceState {
+    var state by remember(session) {
+        mutableStateOf<DashboardSurfaceState>(DashboardSurfaceState.Loading)
+    }
     LaunchedEffect(session, refreshAttempt) {
         val now = currentDashboardEpochSeconds()
         sharedDashboardStatusMemoryCache.get(session, now)?.let { cached ->
@@ -119,50 +255,7 @@ internal fun NativeDashboardScreen(
             }
         }
     }
-
-    Column(modifier = Modifier.fillMaxSize()) {
-        DashboardHeader(
-            title = "Dashboard",
-            subtitle = "Your cloud at a glance",
-            onBack = onBack,
-            onRefresh = { refreshAttempt += 1 },
-        )
-        when (val current = state) {
-            DashboardSurfaceState.Loading -> DashboardLoading()
-            is DashboardSurfaceState.Failed -> DashboardFailure(
-                message = current.message,
-                onRetry = { refreshAttempt += 1 },
-            )
-            is DashboardSurfaceState.Available -> {
-                current.status?.let { status ->
-                    CurrentStatusStrip(status = status, onClick = onOpenStatus)
-                }
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(330.dp),
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(NextcloudSpacing.XLarge),
-                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Large),
-                    verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Large),
-                ) {
-                    items(current.snapshot.widgets, key = NativeDashboardWidget::id) { widget ->
-                        DashboardWidgetCard(
-                            widget = widget,
-                            items = current.snapshot.itemsByWidget[widget.id].orEmpty(),
-                            onOpenLink = { link ->
-                                val appId = dashboardAppIdForLink(session, link)
-                                val nativeApp = installedApps.firstOrNull { it.id == appId }
-                                if (nativeApp != null) {
-                                    onOpenApp(nativeApp)
-                                } else {
-                                    services.openExternalUrl(dashboardBrowserUrl(session, link))
-                                }
-                            },
-                        )
-                    }
-                }
-            }
-        }
-    }
+    return state
 }
 
 @Composable
@@ -171,6 +264,7 @@ private fun DashboardHeader(
     subtitle: String,
     onBack: () -> Unit,
     onRefresh: () -> Unit,
+    onCustomize: (() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(
@@ -189,6 +283,11 @@ private fun DashboardHeader(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+        if (onCustomize != null) {
+            IconButton(onClick = onCustomize) {
+                Icon(NextcloudIcons.Edit, contentDescription = "Customize home")
+            }
         }
         IconButton(onClick = onRefresh) {
             Icon(NextcloudIcons.Refresh, contentDescription = "Refresh dashboard")
@@ -242,16 +341,201 @@ private fun CurrentStatusStrip(
     }
 }
 
+internal data class HomeDashboardWidgetBinding(
+    val sectionId: HomeSectionId,
+    val widget: NativeDashboardWidget,
+)
+
+internal fun homeDashboardWidgetBindings(
+    widgets: List<NativeDashboardWidget>,
+): List<HomeDashboardWidgetBinding> {
+    val occupied = mutableSetOf<HomeSectionId>()
+    return widgets.map { widget ->
+        val preferred = widget.preferredHomeSectionId()
+        val sectionId = if (preferred !in occupied) {
+            preferred
+        } else {
+            widget.dynamicHomeSectionId()
+        }
+        occupied += sectionId
+        HomeDashboardWidgetBinding(sectionId = sectionId, widget = widget)
+    }
+}
+
+@Composable
+private fun DashboardQuickActionsCard(
+    installedApps: List<NextcloudAppEntry>,
+    onOpenApp: (NextcloudAppEntry) -> Unit,
+) {
+    val quickApps = remember(installedApps) {
+        installedApps
+            .filter { it.id in DASHBOARD_QUICK_ACTION_APP_IDS }
+            .sortedBy { DASHBOARD_QUICK_ACTION_APP_IDS.indexOf(it.id) }
+            .take(MAX_DASHBOARD_QUICK_ACTIONS)
+    }
+    Card(
+        modifier = Modifier.fillMaxWidth().heightIn(min = 112.dp),
+        colors = CardDefaults.cardColors(containerColor = NextcloudTheme.colors.appTile),
+        shape = RoundedCornerShape(NextcloudRadii.Card),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(NextcloudSpacing.Large)) {
+            Text(
+                "Quick actions",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            if (quickApps.isEmpty()) {
+                Text(
+                    "Your shortcuts will appear as native apps become available.",
+                    modifier = Modifier.padding(top = NextcloudSpacing.Medium),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth().padding(top = NextcloudSpacing.Medium),
+                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                ) {
+                    items(quickApps, key = NextcloudAppEntry::id) { app ->
+                        FilterChip(
+                            selected = false,
+                            onClick = { onOpenApp(app) },
+                            label = { Text(app.name, maxLines = 1) },
+                            leadingIcon = {
+                                Icon(
+                                    NextcloudIcons.app(app.id),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeWorkspaceCustomizerDialog(
+    layout: HomeWorkspaceLayout,
+    sectionLabels: Map<HomeSectionId, String>,
+    persistenceError: String?,
+    onDismiss: () -> Unit,
+    onSave: (HomeWorkspaceLayout) -> Unit,
+) {
+    var draft by remember(layout) { mutableStateOf(layout) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Customize home") },
+        text = {
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth().heightIn(max = 540.dp),
+                verticalArrangement = Arrangement.spacedBy(NextcloudSpacing.Medium),
+            ) {
+                persistenceError?.let { message ->
+                    item {
+                        Text(message, color = MaterialTheme.colorScheme.error)
+                    }
+                }
+                items(draft.sections, key = { section -> section.id.value }) { section ->
+                    val index = draft.sections.indexOfFirst { it.id == section.id }
+                    Surface(
+                        color = NextcloudTheme.colors.appTile,
+                        shape = RoundedCornerShape(NextcloudRadii.Card),
+                    ) {
+                        Column(
+                            modifier = Modifier.fillMaxWidth().padding(NextcloudSpacing.Medium),
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    sectionLabels[section.id] ?: "Dashboard section",
+                                    modifier = Modifier.weight(1f),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                TextButton(
+                                    enabled = index > 0,
+                                    onClick = { draft = draft.move(section.id, index - 1) },
+                                ) {
+                                    Text("Up")
+                                }
+                                TextButton(
+                                    enabled = index < draft.sections.lastIndex,
+                                    onClick = { draft = draft.move(section.id, index + 1) },
+                                ) {
+                                    Text("Down")
+                                }
+                            }
+                            FilterChip(
+                                selected = section.visible,
+                                onClick = {
+                                    draft = if (section.visible) {
+                                        draft.hide(section.id)
+                                    } else {
+                                        draft.show(section.id)
+                                    }
+                                },
+                                label = { Text(if (section.visible) "Shown" else "Hidden") },
+                            )
+                            LazyRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                            ) {
+                                items(HomeSectionSize.entries) { size ->
+                                    FilterChip(
+                                        selected = section.size == size,
+                                        onClick = { draft = draft.resize(section.id, size) },
+                                        label = { Text(size.name) },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        dismissButton = {
+            Row {
+                TextButton(
+                    onClick = {
+                        draft = draft.restoreDefaults()
+                            .reconcileAvailableSections(layout.sections.map(HomeWorkspaceSection::id))
+                    },
+                ) {
+                    Text("Restore defaults")
+                }
+                TextButton(onClick = onDismiss) { Text("Cancel") }
+            }
+        },
+        confirmButton = {
+            Button(onClick = { onSave(draft) }) { Text("Save") }
+        },
+    )
+}
+
 @Composable
 private fun DashboardWidgetCard(
     widget: NativeDashboardWidget,
     items: List<NativeDashboardItem>,
+    size: HomeSectionSize,
     onOpenLink: (String) -> Unit,
 ) {
     var expanded by remember(widget.id) { mutableStateOf(false) }
-    val visibleItems = if (expanded) items else items.take(DASHBOARD_COLLAPSED_ITEM_COUNT)
+    val collapsedItemCount = dashboardCollapsedItemCount(size)
+    val visibleItems = if (expanded) items else items.take(collapsedItemCount)
     Card(
-        modifier = Modifier.fillMaxWidth().heightIn(min = 150.dp),
+        modifier = Modifier.fillMaxWidth().heightIn(
+            min = when (size) {
+                HomeSectionSize.Compact -> 112.dp
+                HomeSectionSize.Comfortable -> 150.dp
+                HomeSectionSize.Dense -> 180.dp
+            },
+        ),
         colors = CardDefaults.cardColors(containerColor = NextcloudTheme.colors.appTile),
         shape = RoundedCornerShape(NextcloudRadii.Card),
     ) {
@@ -297,13 +581,13 @@ private fun DashboardWidgetCard(
                     }
                     DashboardItemRow(item = item, onOpenLink = onOpenLink)
                 }
-                if (items.size > DASHBOARD_COLLAPSED_ITEM_COUNT) {
+                if (items.size > collapsedItemCount) {
                     TextButton(onClick = { expanded = !expanded }) {
                         Text(
                             if (expanded) {
                                 "Show less"
                             } else {
-                                "Show ${items.size - DASHBOARD_COLLAPSED_ITEM_COUNT} more"
+                                "Show ${items.size - collapsedItemCount} more"
                             },
                         )
                     }
@@ -323,6 +607,47 @@ private fun DashboardWidgetCard(
             }
         }
     }
+}
+
+internal fun dashboardCollapsedItemCount(size: HomeSectionSize): Int = when (size) {
+    HomeSectionSize.Compact -> 2
+    HomeSectionSize.Comfortable -> 4
+    HomeSectionSize.Dense -> 8
+}
+
+private fun NativeDashboardWidget.preferredHomeSectionId(): HomeSectionId = when (id.lowercase()) {
+    "activity" -> HomeSectionIds.Activity
+    "calendar", "upcoming" -> HomeSectionIds.Upcoming
+    "recommendations", "recent-files", "recent_files", "recentfiles" -> HomeSectionIds.RecentFiles
+    "photos", "memories", "photo-backup", "photo_backup" -> HomeSectionIds.PhotoBackup
+    "favorites", "favourites" -> HomeSectionIds.Favorites
+    "quota", "storage", "storage-quota", "storage_quota" -> HomeSectionIds.Storage
+    else -> dynamicHomeSectionId()
+}
+
+private fun NativeDashboardWidget.dynamicHomeSectionId(): HomeSectionId {
+    val readable = id.lowercase()
+        .map { character ->
+            if (
+                character in 'a'..'z' ||
+                character in '0'..'9' ||
+                character == '-' ||
+                character == '_' ||
+                character == '.'
+            ) {
+                character
+            } else {
+                '-'
+            }
+        }
+        .joinToString("")
+        .trim('-')
+        .take(MAX_DASHBOARD_SECTION_READABLE_ID_LENGTH)
+        .ifEmpty { "widget" }
+    val hash = id.encodeToByteArray().fold(FNV_OFFSET_BASIS) { current, byte ->
+        (current xor byte.toUByte().toUInt()) * FNV_PRIME
+    }
+    return HomeSectionId("dashboard:$readable:${hash.toString(16).padStart(8, '0')}")
 }
 
 @Composable
@@ -785,4 +1110,16 @@ private fun StatusExpiryChoice.expiryEpochSeconds(): Long? =
 
 private fun currentDashboardEpochSeconds(): Long = Clock.System.now().epochSeconds
 
-private const val DASHBOARD_COLLAPSED_ITEM_COUNT = 8
+private val DASHBOARD_QUICK_ACTION_APP_IDS = listOf(
+    "files",
+    "photos",
+    "memories",
+    "notes",
+    "calendar",
+    "spreed",
+    "talk",
+)
+private const val MAX_DASHBOARD_QUICK_ACTIONS = 6
+private const val MAX_DASHBOARD_SECTION_READABLE_ID_LENGTH = 48
+private const val FNV_OFFSET_BASIS: UInt = 2_166_136_261u
+private const val FNV_PRIME: UInt = 16_777_619u

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
@@ -72,7 +72,9 @@ internal fun NativeDashboardScreen(
     installedApps: List<NextcloudAppEntry>,
     onOpenApp: (NextcloudAppEntry) -> Unit,
     onOpenStatus: (() -> Unit)?,
-    onBack: () -> Unit,
+    onBack: (() -> Unit)?,
+    onSearch: (() -> Unit)? = null,
+    onSettings: (() -> Unit)? = null,
 ) {
     var refreshAttempt by remember(session) { mutableStateOf(0) }
     var customizeWorkspace by remember(session) { mutableStateOf(false) }
@@ -104,6 +106,8 @@ internal fun NativeDashboardScreen(
             onBack = onBack,
             onRefresh = { refreshAttempt += 1 },
             onCustomize = { customizeWorkspace = true },
+            onSearch = onSearch,
+            onSettings = onSettings,
         )
         when (val current = state) {
             DashboardSurfaceState.Loading -> DashboardLoading()
@@ -262,9 +266,11 @@ internal fun rememberNativeDashboardState(
 private fun DashboardHeader(
     title: String,
     subtitle: String,
-    onBack: () -> Unit,
+    onBack: (() -> Unit)?,
     onRefresh: () -> Unit,
     onCustomize: (() -> Unit)? = null,
+    onSearch: (() -> Unit)? = null,
+    onSettings: (() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().padding(
@@ -273,8 +279,10 @@ private fun DashboardHeader(
         ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        IconButton(onClick = onBack) {
-            Icon(NextcloudIcons.Back, contentDescription = "Back")
+        if (onBack != null) {
+            IconButton(onClick = onBack) {
+                Icon(NextcloudIcons.Back, contentDescription = "Back")
+            }
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(title, style = MaterialTheme.typography.headlineSmall)
@@ -289,8 +297,18 @@ private fun DashboardHeader(
                 Icon(NextcloudIcons.Edit, contentDescription = "Customize home")
             }
         }
+        if (onSearch != null) {
+            IconButton(onClick = onSearch) {
+                Icon(NextcloudIcons.Search, contentDescription = "Search Nextcloud")
+            }
+        }
         IconButton(onClick = onRefresh) {
             Icon(NextcloudIcons.Refresh, contentDescription = "Refresh dashboard")
+        }
+        if (onSettings != null) {
+            IconButton(onClick = onSettings) {
+                Icon(NextcloudIcons.Settings, contentDescription = "Settings")
+            }
         }
     }
     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -351,12 +369,7 @@ internal fun homeDashboardWidgetBindings(
 ): List<HomeDashboardWidgetBinding> {
     val occupied = mutableSetOf<HomeSectionId>()
     return widgets.map { widget ->
-        val preferred = widget.preferredHomeSectionId()
-        val sectionId = if (preferred !in occupied) {
-            preferred
-        } else {
-            widget.dynamicHomeSectionId()
-        }
+        val sectionId = widget.availableHomeSectionId(occupied)
         occupied += sectionId
         HomeDashboardWidgetBinding(sectionId = sectionId, widget = widget)
     }
@@ -625,7 +638,21 @@ private fun NativeDashboardWidget.preferredHomeSectionId(): HomeSectionId = when
     else -> dynamicHomeSectionId()
 }
 
-private fun NativeDashboardWidget.dynamicHomeSectionId(): HomeSectionId {
+private fun NativeDashboardWidget.availableHomeSectionId(
+    occupied: Set<HomeSectionId>,
+): HomeSectionId {
+    val preferred = preferredHomeSectionId()
+    if (preferred !in occupied) return preferred
+    repeat(MAX_HOME_WORKSPACE_SECTIONS) { disambiguation ->
+        val candidate = dynamicHomeSectionId(disambiguation)
+        if (candidate !in occupied) return candidate
+    }
+    error("The dashboard has no available bounded section ID.")
+}
+
+private fun NativeDashboardWidget.dynamicHomeSectionId(
+    disambiguation: Int = 0,
+): HomeSectionId {
     val readable = id.lowercase()
         .map { character ->
             if (
@@ -644,7 +671,8 @@ private fun NativeDashboardWidget.dynamicHomeSectionId(): HomeSectionId {
         .trim('-')
         .take(MAX_DASHBOARD_SECTION_READABLE_ID_LENGTH)
         .ifEmpty { "widget" }
-    val hash = id.encodeToByteArray().fold(FNV_OFFSET_BASIS) { current, byte ->
+    val hashSource = if (disambiguation == 0) id else "$id#$disambiguation"
+    val hash = hashSource.encodeToByteArray().fold(FNV_OFFSET_BASIS) { current, byte ->
         (current xor byte.toUByte().toUInt()) * FNV_PRIME
     }
     return HomeSectionId("dashboard:$readable:${hash.toString(16).padStart(8, '0')}")

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
@@ -303,7 +303,7 @@ private fun DashboardHeader(
             }
         }
         IconButton(onClick = onRefresh) {
-            Icon(NextcloudIcons.Refresh, contentDescription = "Refresh dashboard")
+            Icon(NextcloudIcons.Refresh, contentDescription = dashboardRefreshDescription(title))
         }
         if (onSettings != null) {
             IconButton(onClick = onSettings) {
@@ -313,6 +313,8 @@ private fun DashboardHeader(
     }
     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 }
+
+internal fun dashboardRefreshDescription(title: String): String = "Refresh $title"
 
 @Composable
 private fun CurrentStatusStrip(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspaceLayout.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspaceLayout.kt
@@ -1,0 +1,341 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The broad device class used to scope a home layout.
+ *
+ * This is intentionally independent from a transient window width. A phone layout should not be
+ * overwritten when the same account is opened on desktop or when a device is rotated.
+ */
+@Serializable
+enum class HomeFormFactor {
+    Phone,
+    Tablet,
+    Desktop,
+}
+
+@Serializable
+enum class HomeSectionSize {
+    Compact,
+    Comfortable,
+    Dense,
+}
+
+/**
+ * A stable, non-secret section identifier.
+ *
+ * Identifiers are deliberately restricted to a small URL-safe alphabet so they can be used in
+ * future local persistence without escaping or accepting unbounded server-provided values.
+ */
+@Serializable
+@JvmInline
+value class HomeSectionId(val value: String) {
+    init {
+        require(value.length in 1..MAX_HOME_SECTION_ID_LENGTH) {
+            "The home section ID length is invalid."
+        }
+        require(value.first().isLowerAsciiLetter()) {
+            "The home section ID must start with a lowercase ASCII letter."
+        }
+        require(value.all(Char::isHomeSectionIdCharacter)) {
+            "The home section ID contains unsupported characters."
+        }
+    }
+}
+
+/**
+ * Persistence scope for one account and one form factor.
+ *
+ * Callers must derive [accountScopeDigest] from the canonical account identity before constructing
+ * this value. A server URL, login name, display name, or other raw account detail is rejected.
+ */
+@Serializable
+data class HomeWorkspaceScope(
+    val accountScopeDigest: String,
+    val formFactor: HomeFormFactor,
+) {
+    init {
+        require(accountScopeDigest.isCanonicalSha256Digest()) {
+            "The home workspace account scope must be a canonical SHA-256 digest."
+        }
+    }
+
+    /**
+     * Safe key material for platform persistence. It contains only a schema marker, form factor,
+     * and the one-way account scope digest. The compact prefix stays below the Java Preferences
+     * key limit used by the desktop implementation.
+     */
+    val persistenceKey: String
+        get() = "home:$HOME_WORKSPACE_SCHEMA_VERSION:${formFactor.persistenceCode}:$accountScopeDigest"
+}
+
+@Serializable
+data class HomeWorkspaceSection(
+    val id: HomeSectionId,
+    val visible: Boolean,
+    val size: HomeSectionSize,
+)
+
+/**
+ * Validated, ordered home workspace state.
+ *
+ * Hidden sections remain in the ordered list so showing one again does not unexpectedly move it.
+ */
+data class HomeWorkspaceLayout(
+    val scope: HomeWorkspaceScope,
+    val sections: List<HomeWorkspaceSection>,
+) {
+    init {
+        require(sections.isNotEmpty()) { "The home workspace must contain at least one section." }
+        require(sections.size <= MAX_HOME_WORKSPACE_SECTIONS) {
+            "The home workspace contains too many sections."
+        }
+        require(sections.map(HomeWorkspaceSection::id).distinct().size == sections.size) {
+            "The home workspace contains duplicate section IDs."
+        }
+        require(sections.any(HomeWorkspaceSection::visible)) {
+            "The home workspace must keep at least one section visible."
+        }
+    }
+
+    val visibleSections: List<HomeWorkspaceSection>
+        get() = sections.filter(HomeWorkspaceSection::visible)
+
+    val hiddenSections: List<HomeWorkspaceSection>
+        get() = sections.filterNot(HomeWorkspaceSection::visible)
+
+    /**
+     * Reorders a section using its position in the complete list, including hidden sections.
+     *
+     * Stale section IDs are ignored and drag positions outside the current list are clamped. This
+     * makes the operation safe to call from asynchronous drag-and-drop UI.
+     */
+    fun move(sectionId: HomeSectionId, destinationIndex: Int): HomeWorkspaceLayout {
+        val sourceIndex = sections.indexOfFirst { it.id == sectionId }
+        if (sourceIndex < 0) return this
+        val boundedDestination = destinationIndex.coerceIn(0, sections.lastIndex)
+        if (sourceIndex == boundedDestination) return this
+
+        val reordered = sections.toMutableList()
+        val section = reordered.removeAt(sourceIndex)
+        reordered.add(boundedDestination, section)
+        return copy(sections = reordered)
+    }
+
+    fun show(sectionId: HomeSectionId): HomeWorkspaceLayout =
+        update(sectionId) { section -> section.copy(visible = true) }
+
+    /**
+     * Hides a section while preventing an accidentally empty home workspace.
+     */
+    fun hide(sectionId: HomeSectionId): HomeWorkspaceLayout {
+        val section = sections.firstOrNull { it.id == sectionId } ?: return this
+        if (!section.visible || visibleSections.size == 1) return this
+        return update(sectionId) { it.copy(visible = false) }
+    }
+
+    fun resize(sectionId: HomeSectionId, size: HomeSectionSize): HomeWorkspaceLayout =
+        update(sectionId) { section -> section.copy(size = size) }
+
+    fun restoreDefaults(): HomeWorkspaceLayout = defaultHomeWorkspaceLayout(scope)
+
+    fun snapshot(): HomeWorkspaceLayoutSnapshot = HomeWorkspaceLayoutSnapshot(
+        schemaVersion = HOME_WORKSPACE_SCHEMA_VERSION,
+        scope = scope,
+        sections = sections,
+    )
+
+    private inline fun update(
+        sectionId: HomeSectionId,
+        transform: (HomeWorkspaceSection) -> HomeWorkspaceSection,
+    ): HomeWorkspaceLayout {
+        val index = sections.indexOfFirst { it.id == sectionId }
+        if (index < 0) return this
+        val updatedSection = transform(sections[index])
+        if (updatedSection == sections[index]) return this
+        return copy(sections = sections.toMutableList().also { it[index] = updatedSection })
+    }
+}
+
+/**
+ * Storage-neutral snapshot. Platform repositories may encode this without ever receiving raw
+ * account details.
+ */
+@Serializable
+data class HomeWorkspaceLayoutSnapshot(
+    val schemaVersion: Int,
+    val scope: HomeWorkspaceScope,
+    val sections: List<HomeWorkspaceSection>,
+) {
+    init {
+        require(schemaVersion in 1..MAX_HOME_WORKSPACE_SCHEMA_VERSION) {
+            "The home workspace schema version is invalid."
+        }
+        require(sections.size <= MAX_HOME_WORKSPACE_SECTIONS) {
+            "The home workspace snapshot contains too many sections."
+        }
+    }
+}
+
+/**
+ * Restores a snapshot only when both its schema and complete non-secret scope match.
+ *
+ * Missing, stale, or cross-account snapshots fall back to useful defaults instead of leaking one
+ * account's customization into another account or device class.
+ */
+fun restoreHomeWorkspaceLayout(
+    scope: HomeWorkspaceScope,
+    snapshot: HomeWorkspaceLayoutSnapshot?,
+): HomeWorkspaceLayout {
+    if (
+        snapshot == null ||
+        snapshot.schemaVersion != HOME_WORKSPACE_SCHEMA_VERSION ||
+        snapshot.scope != scope
+    ) {
+        return defaultHomeWorkspaceLayout(scope)
+    }
+    return try {
+        HomeWorkspaceLayout(scope = scope, sections = snapshot.sections)
+    } catch (_: IllegalArgumentException) {
+        defaultHomeWorkspaceLayout(scope)
+    }
+}
+
+fun defaultHomeWorkspaceLayout(scope: HomeWorkspaceScope): HomeWorkspaceLayout =
+    HomeWorkspaceLayout(
+        scope = scope,
+        sections = when (scope.formFactor) {
+            HomeFormFactor.Phone -> listOf(
+                section(HomeSectionIds.QuickActions, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.RecentFiles, visible = true, HomeSectionSize.Comfortable),
+                section(HomeSectionIds.PhotoBackup, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Upcoming, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Activity, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Favorites, visible = false, HomeSectionSize.Compact),
+                section(HomeSectionIds.Storage, visible = false, HomeSectionSize.Compact),
+            )
+
+            HomeFormFactor.Tablet -> listOf(
+                section(HomeSectionIds.QuickActions, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Upcoming, visible = true, HomeSectionSize.Comfortable),
+                section(HomeSectionIds.RecentFiles, visible = true, HomeSectionSize.Comfortable),
+                section(HomeSectionIds.Activity, visible = true, HomeSectionSize.Dense),
+                section(HomeSectionIds.PhotoBackup, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Favorites, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Storage, visible = false, HomeSectionSize.Compact),
+            )
+
+            HomeFormFactor.Desktop -> listOf(
+                section(HomeSectionIds.QuickActions, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Activity, visible = true, HomeSectionSize.Dense),
+                section(HomeSectionIds.Upcoming, visible = true, HomeSectionSize.Dense),
+                section(HomeSectionIds.RecentFiles, visible = true, HomeSectionSize.Comfortable),
+                section(HomeSectionIds.Favorites, visible = true, HomeSectionSize.Dense),
+                section(HomeSectionIds.PhotoBackup, visible = true, HomeSectionSize.Compact),
+                section(HomeSectionIds.Storage, visible = true, HomeSectionSize.Compact),
+            )
+        },
+    )
+
+/**
+ * Restricts a layout to currently available sections while retaining compatible customization.
+ *
+ * New sections are appended and visible by default. Missing sections are removed so stale server
+ * widgets do not leave empty spaces. At least one section is made visible after reconciliation.
+ */
+fun HomeWorkspaceLayout.reconcileAvailableSections(
+    availableSectionIds: List<HomeSectionId>,
+): HomeWorkspaceLayout {
+    require(availableSectionIds.isNotEmpty()) {
+        "The home workspace must have at least one available section."
+    }
+    require(availableSectionIds.size <= MAX_HOME_WORKSPACE_SECTIONS) {
+        "The home workspace has too many available sections."
+    }
+    require(availableSectionIds.distinct().size == availableSectionIds.size) {
+        "The home workspace has duplicate available section IDs."
+    }
+
+    val available = availableSectionIds.toSet()
+    val retained = sections.filter { it.id in available }.toMutableList()
+    val retainedIds = retained.mapTo(mutableSetOf(), HomeWorkspaceSection::id)
+    availableSectionIds.forEach { id ->
+        if (id !in retainedIds) {
+            retained += HomeWorkspaceSection(
+                id = id,
+                visible = true,
+                size = defaultHomeSectionSize(id, scope.formFactor),
+            )
+        }
+    }
+    if (retained.none(HomeWorkspaceSection::visible)) {
+        retained[0] = retained[0].copy(visible = true)
+    }
+    return copy(sections = retained)
+}
+
+object HomeSectionIds {
+    val QuickActions = HomeSectionId("native:quick-actions")
+    val RecentFiles = HomeSectionId("native:recent-files")
+    val PhotoBackup = HomeSectionId("native:photo-backup")
+    val Upcoming = HomeSectionId("native:upcoming")
+    val Activity = HomeSectionId("native:activity")
+    val Favorites = HomeSectionId("native:favorites")
+    val Storage = HomeSectionId("native:storage")
+}
+
+private fun section(
+    id: HomeSectionId,
+    visible: Boolean,
+    size: HomeSectionSize,
+): HomeWorkspaceSection = HomeWorkspaceSection(id = id, visible = visible, size = size)
+
+private fun defaultHomeSectionSize(
+    id: HomeSectionId,
+    formFactor: HomeFormFactor,
+): HomeSectionSize = when (id) {
+    HomeSectionIds.Activity -> if (formFactor == HomeFormFactor.Phone) {
+        HomeSectionSize.Compact
+    } else {
+        HomeSectionSize.Dense
+    }
+    HomeSectionIds.Upcoming -> when (formFactor) {
+        HomeFormFactor.Phone -> HomeSectionSize.Compact
+        HomeFormFactor.Tablet -> HomeSectionSize.Comfortable
+        HomeFormFactor.Desktop -> HomeSectionSize.Dense
+    }
+    HomeSectionIds.Favorites -> if (formFactor == HomeFormFactor.Desktop) {
+        HomeSectionSize.Dense
+    } else {
+        HomeSectionSize.Compact
+    }
+    HomeSectionIds.RecentFiles -> HomeSectionSize.Comfortable
+    HomeSectionIds.QuickActions,
+    HomeSectionIds.PhotoBackup,
+    HomeSectionIds.Storage,
+    -> HomeSectionSize.Compact
+    else -> HomeSectionSize.Comfortable
+}
+
+private fun String.isCanonicalSha256Digest(): Boolean =
+    length == SHA256_HEX_CHARACTER_COUNT && all { it in '0'..'9' || it in 'a'..'f' }
+
+private fun Char.isLowerAsciiLetter(): Boolean = this in 'a'..'z'
+
+private fun Char.isHomeSectionIdCharacter(): Boolean =
+    isLowerAsciiLetter() || this in '0'..'9' || this == '-' || this == '_' || this == ':' || this == '.'
+
+private val HomeFormFactor.persistenceCode: Char
+    get() = when (this) {
+        HomeFormFactor.Phone -> 'p'
+        HomeFormFactor.Tablet -> 't'
+        HomeFormFactor.Desktop -> 'd'
+    }
+
+const val HOME_WORKSPACE_SCHEMA_VERSION = 1
+const val MAX_HOME_WORKSPACE_SECTIONS = 32
+
+private const val MAX_HOME_SECTION_ID_LENGTH = 80
+private const val MAX_HOME_WORKSPACE_SCHEMA_VERSION = 1_000
+private const val SHA256_HEX_CHARACTER_COUNT = 64

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.kt
@@ -1,0 +1,65 @@
+package dev.obiente.nextcloudnative.app
+
+import androidx.compose.runtime.Composable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal interface HomeWorkspaceLayoutStorage {
+    fun read(persistenceKey: String): String?
+
+    fun write(persistenceKey: String, encodedSnapshot: String)
+}
+
+internal class HomeWorkspaceLayoutRepository(
+    private val storage: HomeWorkspaceLayoutStorage,
+) {
+    fun load(scope: HomeWorkspaceScope): HomeWorkspaceLayout {
+        val encoded = runCatching { storage.read(scope.persistenceKey) }.getOrNull()
+            ?: return defaultHomeWorkspaceLayout(scope)
+        return decodeHomeWorkspaceLayoutSnapshot(scope, encoded)
+    }
+
+    /**
+     * Returns false when platform persistence fails. The caller may keep the in-memory layout
+     * without crashing or pretending it was durably saved.
+     */
+    fun save(layout: HomeWorkspaceLayout): Boolean {
+        val encoded = encodeHomeWorkspaceLayoutSnapshot(layout)
+        return runCatching {
+            storage.write(layout.scope.persistenceKey, encoded)
+        }.isSuccess
+    }
+}
+
+internal fun encodeHomeWorkspaceLayoutSnapshot(layout: HomeWorkspaceLayout): String =
+    homeWorkspaceJson.encodeToString(layout.snapshot()).also { encoded ->
+        require(encoded.length <= MAX_HOME_WORKSPACE_SNAPSHOT_CHARACTERS) {
+            "The home workspace snapshot is too large."
+        }
+    }
+
+internal fun decodeHomeWorkspaceLayoutSnapshot(
+    scope: HomeWorkspaceScope,
+    encoded: String,
+): HomeWorkspaceLayout {
+    if (encoded.length !in 1..MAX_HOME_WORKSPACE_SNAPSHOT_CHARACTERS) {
+        return defaultHomeWorkspaceLayout(scope)
+    }
+    val snapshot = runCatching {
+        homeWorkspaceJson.decodeFromString<HomeWorkspaceLayoutSnapshot>(encoded)
+    }.getOrNull()
+    return restoreHomeWorkspaceLayout(scope, snapshot)
+}
+
+@Composable
+internal expect fun rememberHomeWorkspaceLayoutStorage(): HomeWorkspaceLayoutStorage
+
+@Composable
+internal expect fun rememberHomeFormFactor(): HomeFormFactor
+
+private val homeWorkspaceJson = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+}
+
+internal const val MAX_HOME_WORKSPACE_SNAPSHOT_CHARACTERS = 8 * 1024

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.kt
@@ -1,6 +1,7 @@
 package dev.obiente.nextcloudnative.app
 
 import androidx.compose.runtime.Composable
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
@@ -12,6 +13,8 @@ internal interface HomeWorkspaceLayoutStorage {
 
 internal class HomeWorkspaceLayoutRepository(
     private val storage: HomeWorkspaceLayoutStorage,
+    private val encodeSnapshot: (HomeWorkspaceLayout) -> String =
+        ::encodeHomeWorkspaceLayoutSnapshot,
 ) {
     fun load(scope: HomeWorkspaceScope): HomeWorkspaceLayout {
         val encoded = runCatching { storage.read(scope.persistenceKey) }.getOrNull()
@@ -24,8 +27,8 @@ internal class HomeWorkspaceLayoutRepository(
      * without crashing or pretending it was durably saved.
      */
     fun save(layout: HomeWorkspaceLayout): Boolean {
-        val encoded = encodeHomeWorkspaceLayoutSnapshot(layout)
         return runCatching {
+            val encoded = encodeSnapshot(layout)
             storage.write(layout.scope.persistenceKey, encoded)
         }.isSuccess
     }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -189,6 +189,22 @@ private sealed interface Screen {
     data class TextEditor(val file: NextcloudFile, val parentPath: String) : Screen
 }
 
+internal enum class RootDestinationContent {
+    HomeWorkspace,
+    Apps,
+    Activity,
+    Settings,
+}
+
+internal fun rootDestinationContent(
+    destination: NextcloudDestination,
+): RootDestinationContent = when (destination) {
+    NextcloudDestination.Home -> RootDestinationContent.HomeWorkspace
+    NextcloudDestination.Apps -> RootDestinationContent.Apps
+    NextcloudDestination.Activity -> RootDestinationContent.Activity
+    NextcloudDestination.Settings -> RootDestinationContent.Settings
+}
+
 private val navigationStateJson = Json {
     ignoreUnknownKeys = true
     encodeDefaults = true
@@ -382,7 +398,6 @@ private fun AuthenticatedApp(
         session.loginName,
         stateSaver = enumSaver<NextcloudDestination>(),
     ) { mutableStateOf(NextcloudDestination.Home) }
-    var lastOpenedAppId by remember { mutableStateOf(services.loadLastOpenedAppId()) }
     var serverInfo by remember(session) { mutableStateOf<NextcloudServerInfo?>(null) }
     val cachedAppDiscoveries = remember(session) { mutableStateMapOf<String, DynamicDescriptorDiscovery>() }
     var discoveryError by remember(session) { mutableStateOf<String?>(null) }
@@ -402,14 +417,16 @@ private fun AuthenticatedApp(
 
     fun openApp(app: NextcloudAppEntry, from: NextcloudDestination) {
         returnDestination = from
-        lastOpenedAppId = app.id
         services.saveLastOpenedAppId(app.id)
         screen = when (app.id) {
             "files" -> Screen.Files("")
             "photos", "memories" -> Screen.Media
             "spreed", "talk" -> Screen.Talk
             "notes" -> Screen.Notes
-            "dashboard" -> Screen.Dashboard
+            "dashboard" -> {
+                destination = NextcloudDestination.Home
+                Screen.Root
+            }
             "user_status" -> Screen.UserStatus
             "calendar" -> Screen.Calendar
             "contacts" -> Screen.Contacts
@@ -482,18 +499,22 @@ private fun AuthenticatedApp(
     }
     val screenContent: @Composable () -> Unit = {
         when (val current = screen) {
-            Screen.Root -> when (destination) {
-                NextcloudDestination.Home -> HomeScreen(
-                    serverInfo = serverInfo,
-                    error = discoveryError,
-                    lastOpenedAppId = lastOpenedAppId,
-                    onRetry = { discoveryAttempt += 1 },
-                    onSettings = { destination = NextcloudDestination.Settings },
-                    onSearch = ::openSearch,
-                    onApps = { destination = NextcloudDestination.Apps },
+            Screen.Root -> when (rootDestinationContent(destination)) {
+                RootDestinationContent.HomeWorkspace -> NativeDashboardScreen(
+                    services = services,
+                    session = session,
+                    installedApps = serverInfo?.apps.orEmpty(),
                     onOpenApp = { openApp(it, NextcloudDestination.Home) },
+                    onOpenStatus = serverInfo?.apps
+                        ?.firstOrNull { it.id == "user_status" }
+                        ?.let { statusApp ->
+                            { openApp(statusApp, NextcloudDestination.Home) }
+                        },
+                    onBack = null,
+                    onSearch = ::openSearch,
+                    onSettings = { destination = NextcloudDestination.Settings },
                 )
-                NextcloudDestination.Apps -> AppsScreen(
+                RootDestinationContent.Apps -> AppsScreen(
                     serverInfo = serverInfo,
                     error = discoveryError,
                     onRetry = { discoveryAttempt += 1 },
@@ -501,7 +522,7 @@ private fun AuthenticatedApp(
                     onSearch = ::openSearch,
                     onOpenApp = { openApp(it, NextcloudDestination.Apps) },
                 )
-                NextcloudDestination.Activity -> ActivityScreen(
+                RootDestinationContent.Activity -> ActivityScreen(
                     services = services,
                     session = session,
                     activityInstalled = serverInfo?.apps?.any { it.id == "activity" } == true,
@@ -509,7 +530,7 @@ private fun AuthenticatedApp(
                     onApps = { destination = NextcloudDestination.Apps },
                     onOpenApp = { app -> openApp(app, NextcloudDestination.Activity) },
                 )
-                NextcloudDestination.Settings -> SettingsScreen(
+                RootDestinationContent.Settings -> SettingsScreen(
                     services = services,
                     session = session,
                     serverInfo = serverInfo,
@@ -835,204 +856,6 @@ private fun RootShell(
 }
 
 @Composable
-private fun HomeScreen(
-    serverInfo: NextcloudServerInfo?,
-    error: String?,
-    lastOpenedAppId: String,
-    onRetry: () -> Unit,
-    onSettings: () -> Unit,
-    onSearch: () -> Unit,
-    onApps: () -> Unit,
-    onOpenApp: (NextcloudAppEntry) -> Unit,
-) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        ProductHeader(title = "Nextcloud Native", onSettings = onSettings, onSearch = onSearch)
-        when {
-            error != null -> ErrorMessage(error, onRetry)
-            serverInfo == null -> LoadingMessage("Discovering your cloud…")
-            else -> {
-                val apps = serverInfo.apps
-                val files = apps.firstOrNull { it.id == "files" }
-                val media = apps.firstOrNull { it.id == "photos" || it.id == "memories" }
-                val talk = apps.firstOrNull { it.id == "spreed" || it.id == "talk" }
-                val lastOpened = apps.firstOrNull { it.id == lastOpenedAppId && it.id in nativeAppIds } ?: files
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        start = NextcloudSpacing.XLarge,
-                        top = NextcloudSpacing.XLarge,
-                        end = NextcloudSpacing.XLarge,
-                        bottom = NextcloudSpacing.XXLarge,
-                    ),
-                ) {
-                    item {
-                        Text(
-                            "Welcome back, ${serverInfo.displayName.substringBefore(' ')}",
-                            style = MaterialTheme.typography.displaySmall,
-                        )
-                        Row(
-                            modifier = Modifier.padding(top = 10.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
-                        ) {
-                            Icon(
-                                NextcloudIcons.CheckCircle,
-                                contentDescription = null,
-                                tint = NextcloudTheme.colors.success,
-                                modifier = Modifier.size(18.dp),
-                            )
-                            Text(
-                                "Connected to ${serverInfo.themeName ?: "Nextcloud"}",
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                    lastOpened?.let { app ->
-                        item {
-                            SectionTitle("Continue", Modifier.padding(top = 34.dp, bottom = 12.dp))
-                            ContinueCard(app = app, onClick = { onOpenApp(app) })
-                        }
-                    }
-                    item { SectionTitle("Your cloud", Modifier.padding(top = 32.dp, bottom = 8.dp)) }
-                    files?.let { app ->
-                        item {
-                            CloudRow(
-                                title = "My stuff",
-                                subtitle = "Files, photos and notes",
-                                icon = NextcloudIcons.Folder,
-                                onClick = { onOpenApp(app) },
-                            )
-                        }
-                    }
-                    media?.let { app ->
-                        item {
-                            CloudRow(
-                                title = "Photos & Memories",
-                                subtitle = "Albums and RAW previews",
-                                icon = NextcloudIcons.Photo,
-                                onClick = { onOpenApp(app) },
-                            )
-                        }
-                    }
-                    talk?.let { app ->
-                        item {
-                            CloudRow(
-                                title = "Conversations",
-                                subtitle = "Talk and messages",
-                                icon = NextcloudIcons.app(app.id),
-                                onClick = { onOpenApp(app) },
-                            )
-                        }
-                    }
-                    item {
-                        SectionTitle("Discover", Modifier.padding(top = 32.dp, bottom = 8.dp))
-                        TimelineRow(
-                            title = "Your native apps are ready",
-                            subtitle = "${apps.count { it.id in nativeAppIds }} connected experiences",
-                            icon = NextcloudIcons.CheckCircle,
-                            accent = true,
-                            onClick = onApps,
-                        )
-                        TimelineRow(
-                            title = "Explore every installed app",
-                            subtitle = "Discovery stays separate from your home",
-                            icon = NextcloudIcons.Apps,
-                            accent = false,
-                            onClick = onApps,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ContinueCard(app: NextcloudAppEntry, onClick: () -> Unit) {
-    Card(
-        onClick = onClick,
-        modifier = Modifier.fillMaxWidth().heightIn(min = 72.dp),
-        colors = CardDefaults.cardColors(containerColor = NextcloudTheme.colors.appTile),
-        shape = RoundedCornerShape(NextcloudRadii.Card),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Large),
-        ) {
-            Surface(color = NextcloudTheme.colors.appIconContainer, shape = RoundedCornerShape(12.dp)) {
-                Icon(
-                    NextcloudIcons.app(app.id),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(10.dp).size(28.dp),
-                )
-            }
-            Column(modifier = Modifier.weight(1f)) {
-                Text(app.name, style = MaterialTheme.typography.titleMedium)
-                Text(
-                    nativeSubtitle(app.id),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Icon(NextcloudIcons.ChevronRight, contentDescription = "Open ${app.name}")
-        }
-    }
-}
-
-@Composable
-private fun CloudRow(
-    title: String,
-    subtitle: String,
-    icon: ImageVector,
-    onClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Large),
-    ) {
-        Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(36.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(title, style = MaterialTheme.typography.titleMedium)
-            Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-        Icon(NextcloudIcons.ChevronRight, contentDescription = "Open $title", modifier = Modifier.size(20.dp))
-    }
-    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-}
-
-@Composable
-private fun TimelineRow(
-    title: String,
-    subtitle: String,
-    icon: ImageVector,
-    accent: Boolean,
-    onClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Large),
-    ) {
-        Surface(color = NextcloudTheme.colors.appIconContainer, shape = CircleShape) {
-            Icon(
-                icon,
-                contentDescription = null,
-                tint = if (accent) NextcloudTheme.colors.success else MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(11.dp).size(24.dp),
-            )
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(title, style = MaterialTheme.typography.titleMedium)
-            Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-        Icon(NextcloudIcons.ChevronRight, contentDescription = "Open $title", modifier = Modifier.size(20.dp))
-    }
-}
-
-@Composable
 private fun AppsScreen(
     serverInfo: NextcloudServerInfo?,
     error: String?,
@@ -1048,7 +871,10 @@ private fun AppsScreen(
             error != null -> ErrorMessage(error, onRetry)
             serverInfo == null -> LoadingMessage("Loading installed apps…")
             else -> {
-                val apps = serverInfo.apps.filter { search.isBlank() || it.name.contains(search, ignoreCase = true) }
+                val apps = serverInfo.apps.filter { app ->
+                    app.id != "dashboard" &&
+                        (search.isBlank() || app.name.contains(search, ignoreCase = true))
+                }
                 OutlinedTextField(
                     value = search,
                     onValueChange = { search = it },

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeDashboardPresentationTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeDashboardPresentationTest.kt
@@ -1,0 +1,67 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class HomeDashboardPresentationTest {
+    @Test
+    fun `known dashboard widgets use reusable semantic home sections`() {
+        val bindings = homeDashboardWidgetBindings(
+            listOf(
+                widget(id = "calendar", title = "Upcoming events"),
+                widget(id = "activity", title = "Recent activity"),
+                widget(id = "recommendations", title = "Recommended files"),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                HomeSectionIds.Upcoming,
+                HomeSectionIds.Activity,
+                HomeSectionIds.RecentFiles,
+            ),
+            bindings.map(HomeDashboardWidgetBinding::sectionId),
+        )
+    }
+
+    @Test
+    fun `unknown and colliding widgets receive stable distinct bounded sections`() {
+        val widgets = listOf(
+            widget(id = "weather", title = "Weather"),
+            widget(id = "photos", title = "Photos"),
+            widget(id = "memories", title = "Memories"),
+        )
+
+        val first = homeDashboardWidgetBindings(widgets)
+        val second = homeDashboardWidgetBindings(widgets)
+
+        assertEquals(first.map(HomeDashboardWidgetBinding::sectionId), second.map(HomeDashboardWidgetBinding::sectionId))
+        assertEquals(HomeSectionIds.PhotoBackup, first[1].sectionId)
+        assertNotEquals(first[1].sectionId, first[2].sectionId)
+        first.forEach { binding ->
+            assertTrue(binding.sectionId.value.length <= 80)
+        }
+    }
+
+    @Test
+    fun `section size controls bounded initial information density`() {
+        assertEquals(2, dashboardCollapsedItemCount(HomeSectionSize.Compact))
+        assertEquals(4, dashboardCollapsedItemCount(HomeSectionSize.Comfortable))
+        assertEquals(8, dashboardCollapsedItemCount(HomeSectionSize.Dense))
+    }
+
+    private fun widget(id: String, title: String): NativeDashboardWidget = NativeDashboardWidget(
+        id = id,
+        title = title,
+        order = 0,
+        iconUrl = null,
+        iconClass = null,
+        widgetUrl = null,
+        itemApiVersions = setOf(1),
+        itemIconsRound = false,
+        reloadIntervalSeconds = null,
+        actions = emptyList(),
+    )
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeDashboardPresentationTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeDashboardPresentationTest.kt
@@ -8,6 +8,12 @@ import kotlin.test.assertTrue
 
 class HomeDashboardPresentationTest {
     @Test
+    fun `home refresh accessibility label follows the visible title`() {
+        assertEquals("Refresh Home", dashboardRefreshDescription("Home"))
+        assertEquals("Refresh User Status", dashboardRefreshDescription("User Status"))
+    }
+
+    @Test
     fun `root home renders the customizable workspace instead of the legacy launcher`() {
         assertEquals(
             RootDestinationContent.HomeWorkspace,

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeDashboardPresentationTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeDashboardPresentationTest.kt
@@ -1,11 +1,32 @@
 package dev.obiente.nextcloudnative.app
 
+import dev.obiente.nextcloudnative.app.design.NextcloudDestination
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class HomeDashboardPresentationTest {
+    @Test
+    fun `root home renders the customizable workspace instead of the legacy launcher`() {
+        assertEquals(
+            RootDestinationContent.HomeWorkspace,
+            rootDestinationContent(NextcloudDestination.Home),
+        )
+        assertEquals(
+            RootDestinationContent.Apps,
+            rootDestinationContent(NextcloudDestination.Apps),
+        )
+        assertEquals(
+            RootDestinationContent.Activity,
+            rootDestinationContent(NextcloudDestination.Activity),
+        )
+        assertEquals(
+            RootDestinationContent.Settings,
+            rootDestinationContent(NextcloudDestination.Settings),
+        )
+    }
+
     @Test
     fun `known dashboard widgets use reusable semantic home sections`() {
         val bindings = homeDashboardWidgetBindings(
@@ -40,6 +61,28 @@ class HomeDashboardPresentationTest {
         assertEquals(first.map(HomeDashboardWidgetBinding::sectionId), second.map(HomeDashboardWidgetBinding::sectionId))
         assertEquals(HomeSectionIds.PhotoBackup, first[1].sectionId)
         assertNotEquals(first[1].sectionId, first[2].sectionId)
+        first.forEach { binding ->
+            assertTrue(binding.sectionId.value.length <= 80)
+        }
+    }
+
+    @Test
+    fun `dynamically hashed section collisions are disambiguated deterministically`() {
+        val collidingWidgets = List(4) { index ->
+            widget(id = "weather", title = "Weather source $index")
+        }
+
+        val first = homeDashboardWidgetBindings(collidingWidgets)
+        val second = homeDashboardWidgetBindings(collidingWidgets)
+
+        assertEquals(
+            first.map(HomeDashboardWidgetBinding::sectionId),
+            second.map(HomeDashboardWidgetBinding::sectionId),
+        )
+        assertEquals(
+            collidingWidgets.size,
+            first.map(HomeDashboardWidgetBinding::sectionId).distinct().size,
+        )
         first.forEach { binding ->
             assertTrue(binding.sectionId.value.length <= 80)
         }

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspaceLayoutTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspaceLayoutTest.kt
@@ -1,0 +1,304 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class HomeWorkspaceLayoutTest {
+    @Test
+    fun `defaults are useful and distinct for each form factor`() {
+        val phone = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Phone))
+        val tablet = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Tablet))
+        val desktop = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Desktop))
+
+        assertEquals(HomeSectionIds.RecentFiles, phone.sections[1].id)
+        assertEquals(HomeSectionIds.Upcoming, tablet.sections[1].id)
+        assertEquals(HomeSectionIds.Activity, desktop.sections[1].id)
+        assertFalse(phone.sections.single { it.id == HomeSectionIds.Storage }.visible)
+        assertTrue(desktop.sections.single { it.id == HomeSectionIds.Storage }.visible)
+        assertEquals(
+            HomeSectionSize.Dense,
+            desktop.sections.single { it.id == HomeSectionIds.Activity }.size,
+        )
+    }
+
+    @Test
+    fun `move keeps visibility and size while clamping drag positions`() {
+        val original = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Phone))
+        val recent = original.sections.single { it.id == HomeSectionIds.RecentFiles }
+
+        val movedToEnd = original.move(HomeSectionIds.RecentFiles, Int.MAX_VALUE)
+        val movedToStart = movedToEnd.move(HomeSectionIds.RecentFiles, -100)
+
+        assertEquals(recent, movedToEnd.sections.last())
+        assertEquals(recent, movedToStart.sections.first())
+    }
+
+    @Test
+    fun `stale section operations are harmless`() {
+        val original = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Tablet))
+        val unavailable = HomeSectionId("app:unavailable-widget")
+
+        assertSame(original, original.move(unavailable, 0))
+        assertSame(original, original.show(unavailable))
+        assertSame(original, original.hide(unavailable))
+        assertSame(original, original.resize(unavailable, HomeSectionSize.Dense))
+    }
+
+    @Test
+    fun `show hide and resize preserve ordered sections`() {
+        val original = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Phone))
+        val storageIndex = original.sections.indexOfFirst { it.id == HomeSectionIds.Storage }
+
+        val changed = original
+            .show(HomeSectionIds.Storage)
+            .resize(HomeSectionIds.Storage, HomeSectionSize.Dense)
+            .hide(HomeSectionIds.PhotoBackup)
+
+        assertEquals(storageIndex, changed.sections.indexOfFirst { it.id == HomeSectionIds.Storage })
+        assertTrue(changed.sections[storageIndex].visible)
+        assertEquals(HomeSectionSize.Dense, changed.sections[storageIndex].size)
+        assertFalse(changed.sections.single { it.id == HomeSectionIds.PhotoBackup }.visible)
+    }
+
+    @Test
+    fun `the final visible section cannot be hidden`() {
+        val only = HomeWorkspaceLayout(
+            scope = scope(HomeFormFactor.Phone),
+            sections = listOf(
+                HomeWorkspaceSection(
+                    id = HomeSectionIds.RecentFiles,
+                    visible = true,
+                    size = HomeSectionSize.Comfortable,
+                ),
+            ),
+        )
+
+        assertSame(only, only.hide(HomeSectionIds.RecentFiles))
+    }
+
+    @Test
+    fun `restore accepts only matching current scoped snapshots`() {
+        val phoneScope = scope(HomeFormFactor.Phone)
+        val customized = defaultHomeWorkspaceLayout(phoneScope)
+            .move(HomeSectionIds.Activity, 0)
+            .hide(HomeSectionIds.PhotoBackup)
+            .resize(HomeSectionIds.RecentFiles, HomeSectionSize.Dense)
+        val restored = restoreHomeWorkspaceLayout(phoneScope, customized.snapshot())
+
+        assertEquals(customized, restored)
+        assertEquals(
+            defaultHomeWorkspaceLayout(phoneScope),
+            restoreHomeWorkspaceLayout(phoneScope, null),
+        )
+        assertEquals(
+            defaultHomeWorkspaceLayout(scope(HomeFormFactor.Desktop)),
+            restoreHomeWorkspaceLayout(scope(HomeFormFactor.Desktop), customized.snapshot()),
+        )
+        assertEquals(
+            defaultHomeWorkspaceLayout(phoneScope),
+            restoreHomeWorkspaceLayout(
+                phoneScope,
+                customized.snapshot().copy(schemaVersion = HOME_WORKSPACE_SCHEMA_VERSION + 1),
+            ),
+        )
+        assertEquals(defaultHomeWorkspaceLayout(phoneScope), customized.restoreDefaults())
+    }
+
+    @Test
+    fun `restore replaces structurally invalid snapshot content with defaults`() {
+        val validScope = scope(HomeFormFactor.Desktop)
+        val invalidSnapshot = HomeWorkspaceLayoutSnapshot(
+            schemaVersion = HOME_WORKSPACE_SCHEMA_VERSION,
+            scope = validScope,
+            sections = listOf(
+                HomeWorkspaceSection(
+                    id = HomeSectionId("app:summary"),
+                    visible = false,
+                    size = HomeSectionSize.Dense,
+                ),
+            ),
+        )
+
+        assertEquals(
+            defaultHomeWorkspaceLayout(validScope),
+            restoreHomeWorkspaceLayout(validScope, invalidSnapshot),
+        )
+    }
+
+    @Test
+    fun `account and form factor scopes use digests without raw account details`() {
+        val first = scope(HomeFormFactor.Phone, digit = 'a')
+        val second = scope(HomeFormFactor.Phone, digit = 'b')
+        val desktop = scope(HomeFormFactor.Desktop, digit = 'a')
+
+        assertTrue(first.persistenceKey.endsWith(first.accountScopeDigest))
+        assertFalse("https://" in first.persistenceKey)
+        assertFalse("@" in first.persistenceKey)
+        assertTrue(first.persistenceKey != second.persistenceKey)
+        assertTrue(first.persistenceKey != desktop.persistenceKey)
+        assertFailsWith<IllegalArgumentException> {
+            HomeWorkspaceScope("https://cloud.example.test/person", HomeFormFactor.Phone)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HomeWorkspaceScope("A".repeat(64), HomeFormFactor.Phone)
+        }
+    }
+
+    @Test
+    fun `layout validation is bounded and rejects duplicate or empty state`() {
+        val validScope = scope(HomeFormFactor.Phone)
+        val repeated = HomeWorkspaceSection(
+            id = HomeSectionId("native:one"),
+            visible = true,
+            size = HomeSectionSize.Compact,
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            HomeWorkspaceLayout(validScope, emptyList())
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HomeWorkspaceLayout(validScope, listOf(repeated, repeated))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HomeWorkspaceLayout(
+                validScope,
+                (0..MAX_HOME_WORKSPACE_SECTIONS).map { index ->
+                    HomeWorkspaceSection(
+                        id = HomeSectionId("app:item-$index"),
+                        visible = true,
+                        size = HomeSectionSize.Compact,
+                    )
+                },
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HomeWorkspaceLayout(
+                validScope,
+                listOf(repeated.copy(visible = false)),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HomeSectionId("../unsafe")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HomeSectionId("app:" + "x".repeat(100))
+        }
+    }
+
+    @Test
+    fun `available sections retain customization and append newly discovered widgets`() {
+        val original = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Phone))
+            .hide(HomeSectionIds.PhotoBackup)
+            .resize(HomeSectionIds.Activity, HomeSectionSize.Dense)
+            .move(HomeSectionIds.Activity, 0)
+        val discovered = HomeSectionId("dashboard:weather:12345678")
+
+        val reconciled = original.reconcileAvailableSections(
+            listOf(HomeSectionIds.QuickActions, HomeSectionIds.Activity, discovered),
+        )
+
+        assertEquals(
+            listOf(HomeSectionIds.Activity, HomeSectionIds.QuickActions, discovered),
+            reconciled.sections.map(HomeWorkspaceSection::id),
+        )
+        assertEquals(HomeSectionSize.Dense, reconciled.sections.first().size)
+        assertTrue(reconciled.sections.last().visible)
+        assertEquals(HomeSectionSize.Comfortable, reconciled.sections.last().size)
+    }
+
+    @Test
+    fun `reconciliation cannot leave an empty or entirely hidden workspace`() {
+        val original = defaultHomeWorkspaceLayout(scope(HomeFormFactor.Phone))
+            .reconcileAvailableSections(
+                listOf(HomeSectionIds.QuickActions, HomeSectionIds.PhotoBackup),
+            )
+            .hide(HomeSectionIds.PhotoBackup)
+
+        assertTrue(
+            original.reconcileAvailableSections(listOf(HomeSectionIds.PhotoBackup))
+                .sections
+                .single()
+                .visible,
+        )
+        assertFailsWith<IllegalArgumentException> {
+            original.reconcileAvailableSections(emptyList())
+        }
+    }
+
+    @Test
+    fun `repository round trip is scoped and contains no raw account identity`() {
+        val storage = RecordingHomeWorkspaceStorage()
+        val repository = HomeWorkspaceLayoutRepository(storage)
+        val phoneScope = scope(HomeFormFactor.Phone)
+        val customized = defaultHomeWorkspaceLayout(phoneScope)
+            .hide(HomeSectionIds.PhotoBackup)
+            .resize(HomeSectionIds.Activity, HomeSectionSize.Dense)
+
+        assertTrue(repository.save(customized))
+        assertEquals(customized, repository.load(phoneScope))
+        assertTrue(storage.lastKey?.startsWith("home:") == true)
+        assertTrue(storage.lastKey.orEmpty().length <= 80)
+        assertFalse(storage.lastKey.orEmpty().contains("https://"))
+        assertFalse(storage.lastValue.orEmpty().contains("example.test"))
+        assertEquals(
+            defaultHomeWorkspaceLayout(scope(HomeFormFactor.Desktop)),
+            repository.load(scope(HomeFormFactor.Desktop)),
+        )
+    }
+
+    @Test
+    fun `corrupt oversized and cross account snapshots restore safe defaults`() {
+        val validScope = scope(HomeFormFactor.Phone)
+        val otherScope = scope(HomeFormFactor.Phone, digit = 'b')
+        val valid = defaultHomeWorkspaceLayout(validScope)
+        val encoded = encodeHomeWorkspaceLayoutSnapshot(valid)
+
+        assertEquals(valid, decodeHomeWorkspaceLayoutSnapshot(validScope, encoded))
+        assertEquals(
+            defaultHomeWorkspaceLayout(validScope),
+            decodeHomeWorkspaceLayoutSnapshot(validScope, "{not-json"),
+        )
+        assertEquals(
+            defaultHomeWorkspaceLayout(validScope),
+            decodeHomeWorkspaceLayoutSnapshot(
+                validScope,
+                "x".repeat(MAX_HOME_WORKSPACE_SNAPSHOT_CHARACTERS + 1),
+            ),
+        )
+        assertNotEquals(
+            valid,
+            decodeHomeWorkspaceLayoutSnapshot(otherScope, encoded),
+        )
+        assertEquals(
+            defaultHomeWorkspaceLayout(otherScope),
+            decodeHomeWorkspaceLayoutSnapshot(otherScope, encoded),
+        )
+    }
+
+    private fun scope(
+        formFactor: HomeFormFactor,
+        digit: Char = 'a',
+    ): HomeWorkspaceScope = HomeWorkspaceScope(
+        accountScopeDigest = digit.toString().repeat(64),
+        formFactor = formFactor,
+    )
+
+    private class RecordingHomeWorkspaceStorage : HomeWorkspaceLayoutStorage {
+        private val values = mutableMapOf<String, String>()
+        var lastKey: String? = null
+        var lastValue: String? = null
+
+        override fun read(persistenceKey: String): String? = values[persistenceKey]
+
+        override fun write(persistenceKey: String, encodedSnapshot: String) {
+            lastKey = persistenceKey
+            lastValue = encodedSnapshot
+            values[persistenceKey] = encodedSnapshot
+        }
+    }
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspaceLayoutTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspaceLayoutTest.kt
@@ -252,6 +252,19 @@ class HomeWorkspaceLayoutTest {
     }
 
     @Test
+    fun `repository reports snapshot encoding failures without touching storage`() {
+        val storage = RecordingHomeWorkspaceStorage()
+        val repository = HomeWorkspaceLayoutRepository(
+            storage = storage,
+            encodeSnapshot = { error("The encoded snapshot exceeds its safe bound.") },
+        )
+
+        assertFalse(repository.save(defaultHomeWorkspaceLayout(scope(HomeFormFactor.Phone))))
+        assertEquals(null, storage.lastKey)
+        assertEquals(null, storage.lastValue)
+    }
+
+    @Test
     fun `corrupt oversized and cross account snapshots restore safe defaults`() {
         val validScope = scope(HomeFormFactor.Phone)
         val otherScope = scope(HomeFormFactor.Phone, digit = 'b')

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.desktop.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/HomeWorkspacePersistence.desktop.kt
@@ -1,0 +1,22 @@
+package dev.obiente.nextcloudnative.app
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import java.util.prefs.Preferences
+
+@Composable
+internal actual fun rememberHomeWorkspaceLayoutStorage(): HomeWorkspaceLayoutStorage = remember {
+    val preferences = Preferences.userRoot().node("dev/obiente/nextcloudnative/home-workspace")
+    object : HomeWorkspaceLayoutStorage {
+        override fun read(persistenceKey: String): String? =
+            preferences.get(persistenceKey, null)
+
+        override fun write(persistenceKey: String, encodedSnapshot: String) {
+            preferences.put(persistenceKey, encodedSnapshot)
+            preferences.flush()
+        }
+    }
+}
+
+@Composable
+internal actual fun rememberHomeFormFactor(): HomeFormFactor = HomeFormFactor.Desktop


### PR DESCRIPTION
## Summary

Introduces the first functional Home workspace foundation for #183.

- makes the customizable live workspace the root Home destination instead of hiding it behind the Dashboard app
- keeps root-level search, settings, refresh, and customization actions without a misleading back action
- adds per-account, per-form-factor ordering, visibility, and density preferences
- persists Android layouts in private app preferences and desktop layouts in Java Preferences
- reconciles installed server widgets without leaving stale empty sections or colliding dynamic section IDs
- scopes persisted state with a one-way SHA-256 account digest so raw account identities are never stored in keys
- preserves distinct phone, tablet, and desktop defaults

## User impact

Home now presents actionable cloud information instead of the former static launcher. Users can choose which available sections are shown, reorder them, change their information density, restore useful defaults, and keep different layouts for each account and device class.

This is a foundation slice of #183. Follow-up work will add the remaining richer native summaries, pinned destinations, section-level freshness/error treatment, interaction accessibility, and visual fixture coverage described in the issue.

## Validation

- focused `HomeWorkspaceLayoutTest` desktop tests
- focused `HomeDashboardPresentationTest` desktop tests
- Android debug Kotlin compilation
- `bash tools/check-repository.sh`
- `git diff --check origin/main...HEAD`

The branch is based on current `main`, and both commits are SSH-signed under the configured repository author.

Progresses #183.