### PR TITLE
feat(photos): show recognized face outlines

### DIFF
--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollections.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollections.kt
@@ -180,6 +180,8 @@ data class NativeMediaItem(
     val videoDurationSeconds: Int?,
     val isFavorite: Boolean,
     val rawStackFileIds: List<Long> = emptyList(),
+    /** Normalized recognized-face geometry when the active Memories filter supplied one. */
+    val faceRectangle: NativeFaceRectangle? = null,
 ) {
     init {
         require(fileId > 0L) { "The media file ID is invalid." }
@@ -526,6 +528,7 @@ private fun parseMemoriesMediaItem(
         videoDurationSeconds = item.optionalNonNegativeInt("video_duration"),
         isFavorite = item.optionalBoolean("isfavorite") ?: false,
         rawStackFileIds = rawStackIds,
+        faceRectangle = item.faceRectangleOrNull(),
     )
 }
 

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -5442,6 +5442,7 @@ private fun PersonMediaScreen(
     var error by remember(person.id, person.backend) { mutableStateOf<String?>(null) }
     var loadAttempt by remember(person.id, person.backend) { mutableStateOf(0) }
     var actionMenuExpanded by remember(person.id) { mutableStateOf(false) }
+    var showFaceRectangles by rememberSaveable(currentUserId, person.id, person.backend) { mutableStateOf(false) }
     var photoSelectionMode by remember(person.id) { mutableStateOf<PersonPhotoSelectionMode?>(null) }
     var renameDialogVisible by remember(person.id) { mutableStateOf(false) }
     var renameDraft by remember(person.id) { mutableStateOf(person.name) }
@@ -5656,6 +5657,9 @@ private fun PersonMediaScreen(
         hasDirectFaceReferences =
             NextcloudPeopleBackend.fromApiValue(person.backend) == NextcloudPeopleBackend.Recognize,
     )
+    val faceRectanglesAvailable = mediaItems.orEmpty().any { item ->
+        item.faceRectangle != null && item.width != null && item.height != null
+    }
 
     Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
         ScreenHeader(
@@ -5678,6 +5682,27 @@ private fun PersonMediaScreen(
                         onDismissRequest = { actionMenuExpanded = false },
                         modifier = Modifier.widthIn(min = 280.dp, max = 360.dp),
                     ) {
+                        if (faceRectanglesAvailable) {
+                            DropdownMenuItem(
+                                text = {
+                                    Column {
+                                        Text(if (showFaceRectangles) "Hide face outlines" else "Show face outlines")
+                                        Text(
+                                            "See which recognized face matched each photo",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                },
+                                leadingIcon = {
+                                    Icon(NextcloudIcons.People, contentDescription = null)
+                                },
+                                onClick = {
+                                    showFaceRectangles = !showFaceRectangles
+                                    actionMenuExpanded = false
+                                },
+                            )
+                        }
                         menuItems.forEach { item ->
                             DropdownMenuItem(
                                 text = {
@@ -5782,6 +5807,9 @@ private fun PersonMediaScreen(
                             file = file,
                             badge = if (photoSelectionMode != null && selectable) "Choose" else null,
                             backupStatus = mediaBackupStatuses[file.path.trim('/')],
+                            faceRectangle = item.faceRectangle.takeIf { showFaceRectangles },
+                            sourceWidth = item.width,
+                            sourceHeight = item.height,
                             onClick = {
                                 when (photoSelectionMode) {
                                     PersonPhotoSelectionMode.Cover -> if (selectable) {
@@ -6257,6 +6285,9 @@ private fun MediaTile(
     file: NextcloudFile,
     badge: String? = null,
     backupStatus: MediaBackupStatus? = null,
+    faceRectangle: NativeFaceRectangle? = null,
+    sourceWidth: Int? = null,
+    sourceHeight: Int? = null,
     onClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
 ) {
@@ -6282,7 +6313,15 @@ private fun MediaTile(
                     bitmap = it,
                     contentDescription = file.name,
                     modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop,
+                    // A face outline must map to the complete source image. Switching to Fit while
+                    // it is visible avoids drawing a plausible-looking box over a cropped preview.
+                    contentScale = if (faceRectangle == null) ContentScale.Crop else ContentScale.Fit,
+                )
+                FaceRectangleOverlay(
+                    rectangle = faceRectangle,
+                    sourceWidth = sourceWidth,
+                    sourceHeight = sourceHeight,
+                    color = MaterialTheme.colorScheme.primary,
                 )
             } ?: Icon(
                 NextcloudIcons.Image,

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -5657,8 +5657,8 @@ private fun PersonMediaScreen(
         hasDirectFaceReferences =
             NextcloudPeopleBackend.fromApiValue(person.backend) == NextcloudPeopleBackend.Recognize,
     )
-    val faceRectanglesAvailable = mediaItems.orEmpty().any { item ->
-        item.faceRectangle != null && item.width != null && item.height != null
+    val faceRectanglesAvailable = remember(mediaItems) {
+        mediaItems.orEmpty().any { item -> item.faceOutlineGeometryOrNull() != null }
     }
 
     Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
@@ -6292,6 +6292,9 @@ private fun MediaTile(
     onLongClick: (() -> Unit)? = null,
 ) {
     var image by remember(file.fileId) { mutableStateOf<ImageBitmap?>(null) }
+    val faceOutlineGeometry = remember(faceRectangle, sourceWidth, sourceHeight) {
+        nativeFaceOutlineGeometryOrNull(faceRectangle, sourceWidth, sourceHeight)
+    }
     LaunchedEffect(file.fileId) {
         file.fileId ?: return@LaunchedEffect
         if (!file.hasPreview) return@LaunchedEffect
@@ -6315,12 +6318,10 @@ private fun MediaTile(
                     modifier = Modifier.fillMaxSize(),
                     // A face outline must map to the complete source image. Switching to Fit while
                     // it is visible avoids drawing a plausible-looking box over a cropped preview.
-                    contentScale = if (faceRectangle == null) ContentScale.Crop else ContentScale.Fit,
+                    contentScale = if (faceOutlineGeometry == null) ContentScale.Crop else ContentScale.Fit,
                 )
                 FaceRectangleOverlay(
-                    rectangle = faceRectangle,
-                    sourceWidth = sourceWidth,
-                    sourceHeight = sourceHeight,
+                    geometry = faceOutlineGeometry,
                     color = MaterialTheme.colorScheme.primary,
                 )
             } ?: Icon(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceRemovalPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceRemovalPicker.kt
@@ -236,9 +236,11 @@ private fun RecognizedFaceTile(
                     )
                     val outlineColor = MaterialTheme.colorScheme.primary
                     FaceRectangleOverlay(
-                        rectangle = face.rectangle,
-                        sourceWidth = face.sourceWidth,
-                        sourceHeight = face.sourceHeight,
+                        geometry = nativeFaceOutlineGeometryOrNull(
+                            rectangle = face.rectangle,
+                            sourceWidth = face.sourceWidth,
+                            sourceHeight = face.sourceHeight,
+                        ),
                         color = outlineColor,
                     )
                 } ?: Icon(
@@ -278,27 +280,28 @@ private fun RecognizedFaceTile(
 
 @Composable
 internal fun FaceRectangleOverlay(
-    rectangle: NativeFaceRectangle?,
-    sourceWidth: Int?,
-    sourceHeight: Int?,
+    geometry: NativeFaceOutlineGeometry?,
     color: Color,
 ) {
-    if (rectangle == null || sourceWidth == null || sourceHeight == null) return
+    if (geometry == null) return
     Canvas(modifier = Modifier.fillMaxSize()) {
-        val scale = min(size.width / sourceWidth.toFloat(), size.height / sourceHeight.toFloat())
-        val displayedWidth = sourceWidth * scale
-        val displayedHeight = sourceHeight * scale
+        val scale = min(
+            size.width / geometry.sourceWidth.toFloat(),
+            size.height / geometry.sourceHeight.toFloat(),
+        )
+        val displayedWidth = geometry.sourceWidth * scale
+        val displayedHeight = geometry.sourceHeight * scale
         val offsetX = (size.width - displayedWidth) / 2f
         val offsetY = (size.height - displayedHeight) / 2f
         drawRect(
             color = color,
             topLeft = Offset(
-                x = offsetX + rectangle.x * displayedWidth,
-                y = offsetY + rectangle.y * displayedHeight,
+                x = offsetX + geometry.rectangle.x * displayedWidth,
+                y = offsetY + geometry.rectangle.y * displayedHeight,
             ),
             size = Size(
-                width = rectangle.width * displayedWidth,
-                height = rectangle.height * displayedHeight,
+                width = geometry.rectangle.width * displayedWidth,
+                height = geometry.rectangle.height * displayedHeight,
             ),
             style = Stroke(width = 3.dp.toPx()),
         )

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceRemovalPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceRemovalPicker.kt
@@ -277,7 +277,7 @@ private fun RecognizedFaceTile(
 }
 
 @Composable
-private fun FaceRectangleOverlay(
+internal fun FaceRectangleOverlay(
     rectangle: NativeFaceRectangle?,
     sourceWidth: Int?,
     sourceHeight: Int?,

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceSelection.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceSelection.kt
@@ -34,6 +34,35 @@ data class NativeFaceRectangle(
 }
 
 /**
+ * Complete geometry required to place a normalized face outline over a source image.
+ *
+ * Keeping this as one value prevents callers from switching presentation modes when only a
+ * rectangle or only source dimensions are available.
+ */
+data class NativeFaceOutlineGeometry(
+    val rectangle: NativeFaceRectangle,
+    val sourceWidth: Int,
+    val sourceHeight: Int,
+) {
+    init {
+        require(sourceWidth > 0 && sourceHeight > 0)
+    }
+}
+
+internal fun nativeFaceOutlineGeometryOrNull(
+    rectangle: NativeFaceRectangle?,
+    sourceWidth: Int?,
+    sourceHeight: Int?,
+): NativeFaceOutlineGeometry? {
+    if (rectangle == null || sourceWidth == null || sourceHeight == null) return null
+    if (sourceWidth <= 0 || sourceHeight <= 0) return null
+    return NativeFaceOutlineGeometry(rectangle, sourceWidth, sourceHeight)
+}
+
+internal fun NativeMediaItem.faceOutlineGeometryOrNull(): NativeFaceOutlineGeometry? =
+    nativeFaceOutlineGeometryOrNull(faceRectangle, width, height)
+
+/**
  * One actionable Recognize detection. [file] identifies the source photo, while [detectionId]
  * identifies only the face assignment. They must never be treated as interchangeable IDs.
  */

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceSelection.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceSelection.kt
@@ -273,7 +273,13 @@ private fun JsonObject.positiveInt(key: String): Int? =
 private fun JsonObject.nonNegativeInt(key: String): Int? =
     (this[key] as? JsonPrimitive)?.intOrNull?.takeIf { it >= 0 }
 
-private fun JsonObject.faceRectangleOrNull(): NativeFaceRectangle? {
+/**
+ * Parses the common normalized face rectangle returned by Memories day payloads.
+ *
+ * This stays shared between the read-only person gallery and the exact face-removal picker so
+ * both surfaces clip detector overflow identically.
+ */
+internal fun JsonObject.faceRectangleOrNull(): NativeFaceRectangle? {
     val rectangle = this["facerect"] as? JsonObject ?: return null
     val rawX = rectangle.finiteDouble("x") ?: return null
     val rawY = rectangle.finiteDouble("y") ?: return null

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionsTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionsTest.kt
@@ -152,7 +152,7 @@ class NativeMediaCollectionsTest {
                 200,
                 """[
                     {"fileid":41,"dayid":20260723,"basename":"clip.mp4","mimetype":"video/mp4","etag":"a","w":1920,"h":1080,"epoch":1720000000,"isvideo":1,"video_duration":12,"isfavorite":true},
-                    {"fileid":42,"dayid":20260723,"basename":"photo.jpg","mimetype":"image/jpeg","etag":"b","w":6240,"h":4160,"isvideo":false,"stackraw":[{"fileid":43},{"fileid":44}]}
+                    {"fileid":42,"dayid":20260723,"basename":"photo.jpg","mimetype":"image/jpeg","etag":"b","w":6240,"h":4160,"isvideo":false,"facerect":{"x":-0.1,"y":0.8,"w":0.4,"h":0.5},"stackraw":[{"fileid":43},{"fileid":44}]}
                 ]""",
             ),
             collection,
@@ -164,6 +164,11 @@ class NativeMediaCollectionsTest {
         assertEquals(12, media.first().videoDurationSeconds)
         assertTrue(media.first().isFavorite)
         assertEquals(listOf(43L, 44L), media.last().rawStackFileIds)
+        assertEquals(
+            NativeFaceRectangle(x = 0f, y = 0.8f, width = 0.3f, height = 0.2f),
+            media.last().faceRectangle,
+        )
+        assertNull(media.first().faceRectangle)
         val previewOnlyFile = media.last().toNextcloudFile(collection.key)
         assertEquals("memories/collections/album:ada/Summer/20260723/42", previewOnlyFile.path)
         assertFalse(previewOnlyFile.originalAccessAllowed)

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/PersonMediaPagingTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/PersonMediaPagingTest.kt
@@ -62,6 +62,10 @@ class PersonMediaPagingTest {
         assertEquals(NativeMediaDayCursor(dayIds[11]), second.nextCursor)
         assertEquals("photo-${dayIds.first()}.jpg", first.items.first().name)
         assertEquals(
+            NativeFaceRectangle(x = 0.2f, y = 0.1f, width = 0.3f, height = 0.4f),
+            first.items.first().faceRectangle,
+        )
+        assertEquals(
             "memories/people/recognize/42/${dayIds.first()}/${dayIds.first()}",
             first.items.first().toPersonMediaFile(person).path,
         )

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceSelectionTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceSelectionTest.kt
@@ -9,6 +9,19 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RecognizedFaceSelectionTest {
+    @Test
+    fun `face outline requires both normalized rectangle and complete source dimensions`() {
+        val rectangle = NativeFaceRectangle(x = 0.2f, y = 0.1f, width = 0.3f, height = 0.4f)
+
+        assertEquals(
+            NativeFaceOutlineGeometry(rectangle, sourceWidth = 6240, sourceHeight = 4160),
+            nativeFaceOutlineGeometryOrNull(rectangle, sourceWidth = 6240, sourceHeight = 4160),
+        )
+        assertNull(nativeFaceOutlineGeometryOrNull(rectangle, sourceWidth = null, sourceHeight = 4160))
+        assertNull(nativeFaceOutlineGeometryOrNull(rectangle, sourceWidth = 6240, sourceHeight = null))
+        assertNull(nativeFaceOutlineGeometryOrNull(null, sourceWidth = 6240, sourceHeight = 4160))
+    }
+
     private val person = PersonMediaReference(
         backend = NextcloudPeopleBackend.Recognize,
         clusterId = 42,


### PR DESCRIPTION
## Summary

- preserve normalized `facerect` geometry from Memories day responses in the shared native media model
- add a Show/Hide face outlines control to person photo views
- render outlined previews using the complete fitted image so the server-provided geometry remains accurate
- reuse the same bounded and clipped rectangle parser as the exact face-removal picker

## Why

Nextcloud Native already requested `facerect=1`, but the normal person gallery discarded that field. This made it difficult to understand which recognized face caused a photo to appear, especially when several people were present.

This is a read-only presentation change. It does not rename, merge, remove, or otherwise mutate people or photos.

Related to #90.

## Validation

- focused desktop tests: `NativeMediaCollectionsTest`, `PersonMediaPagingTest`, and `RecognizedFaceSelectionTest`
- Android debug Kotlin compilation
- repository hygiene check
- staged diff whitespace check

Progresses #90.