### PR TITLE
docs(release): prepare alpha 1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,27 @@ until the full product sprint is complete.
 
 ### Added
 
-- Persistent device-media backup states for pending, uploading, backed-up,
-  changed, failed, and cloud-only items.
+- A customizable Home workspace that can show, hide, reorder, and resize
+  available sections, with separate layouts for each account and device size.
+- Persistent device-media backup states for files that are pending, uploading,
+  backed up, changed, failed, or available only in the cloud.
+- A preview of representative photos, videos, counts, and storage size before
+  enabling backup for a detected Android media folder.
+- A native Nextcloud destination picker for media backup and folder sync,
+  including explicit confirmation before creating a missing destination.
+- Native Cookbook recipe creation, editing, URL import, and recipe lists
+  filtered by category or keyword through the adaptive app runtime.
+- An optional face-outline view in recognized-person galleries so people can
+  see which face was matched without changing server data.
+- Project news inside the app and a resumable direct-APK update flow with
+  progress, cancellation, retry, package verification, and Android's install
+  confirmation.
 - A protected prerelease workflow for signed Android artifacts and native
   Linux, Windows, and macOS packages.
 - Deterministic prerelease version and Android version-code validation.
 - SHA-256 checksums and machine-readable Android update metadata.
+- Isolated Android emulator tooling for repeatable portrait, landscape, and
+  process-lifecycle testing with synthetic or technically read-only data.
 - A maintained privacy, data-safety, permissions, accessibility, packaging,
   and upgrade checklist for prerelease approval.
 
@@ -28,6 +43,24 @@ until the full product sprint is complete.
   `gradle.properties`.
 - Media backup status refreshes cancel stale queries when newer transfer state
   arrives.
+- The photo and video viewer uses the available canvas more effectively while
+  keeping controls clear of the status bar in portrait and landscape.
+- RAW and JPEG choices use their own scrollable row instead of crowding photo
+  actions.
+- Folder-sync direction labels now distinguish upload-only and download-only
+  folders.
+- Build validation avoids duplicate branch runs and reuses Gradle and Rust
+  caches where safe.
+
+### Fixed
+
+- Suggested Nextcloud destinations that do not exist can recover to the nearest
+  existing parent and offer to create the missing folders after confirmation.
+- Cookbook actions no longer open empty forms when a verified contract refers
+  to a separately defined schema.
+- Cookbook categories and keywords now open their matching recipes instead of
+  exposing the category or keyword record as the destination.
+- Binary recipe images are no longer opened as JSON detail records.
 
 ### Security
 
@@ -35,3 +68,7 @@ until the full product sprint is complete.
   public certificate fingerprint.
 - Release publication rejects stable versions, `1.0.0` and higher versions,
   mismatched tags, unsigned Android artifacts, and unexpected signing keys.
+- Direct APK updates verify the download checksum, package identity, version,
+  and signing certificate before handing the package to Android.
+- Permission to request package installation is limited to the direct-APK
+  build; store builds do not request it.

--- a/docs/release-notes/0.1.0-alpha.1.md
+++ b/docs/release-notes/0.1.0-alpha.1.md
@@ -1,30 +1,96 @@
-# Nextcloud Native 0.1.0 alpha 1
+# Nextcloud Native 0.1.0-alpha.1
 
-This is an early testing build of Nextcloud Native. It brings Files, Photos,
-Talk, Notes, and several other Nextcloud apps into one native workspace for
-Android and desktop.
+This is the first public testing build of Nextcloud Native, an independent
+native workspace for Nextcloud on Android and desktop. It is an early alpha for
+trying the direction of the project, not yet a dependable replacement for the
+clients you use with important data.
 
-## What you can try
+## Highlights
 
-- Browse, preview, share, rename, move, and manage files.
-- Explore photos, albums, tags, and recognized people.
-- Read and send Talk messages.
-- Open Notes, Cookbook, Deck, Tables, Music, Mail, Calendar, Contacts, and
-  other supported apps through adaptive native views.
-- Try early media backup and folder-sync controls on Android.
+### A useful, personal Home
+
+Home now opens as a live workspace instead of a static app launcher. You can
+choose which available sections are visible, put them in the order you prefer,
+and select how much information each section shows. The layout is kept
+separately for each account and adapts to phone, tablet, and desktop screens.
+
+### Clearer photo backup setup
+
+On Android, Nextcloud Native can detect common media folders and show a bounded
+preview with representative photos or videos, item counts, and storage size
+before you enable backup. A native folder picker lets you choose the Nextcloud
+destination without typing an internal path. If the suggested destination does
+not exist yet, the app can create it only after you confirm.
+
+Photo grids can show whether device media is waiting, uploading, safely backed
+up, changed, failed, or available only in the cloud. These states are stored
+locally so a long queue does not need to be rebuilt whenever the app opens.
+
+### Better photo and people views
+
+The full-screen photo and video viewer makes better use of portrait and
+landscape screens while keeping controls out of the status bar. RAW and JPEG
+choices no longer crowd the main action row. Recognized-person galleries can
+optionally draw the face area reported by Memories, which helps explain why a
+photo appears for a person without changing the photo or recognition data.
+
+### Cookbook actions that lead somewhere useful
+
+Cookbook can now present usable native fields for creating and editing a
+recipe, import a recipe from a web address, and open the matching recipes when
+you select a category or keyword. These improvements come from reusable
+semantic rules rather than a Cookbook-only screen.
+
+### News and direct APK updates
+
+Project news is available inside the app. Android builds downloaded directly
+from the project can check for a newer prerelease, resume an interrupted
+download, show progress, cancel or retry, and verify the package before Android
+asks whether to install it. Builds installed through an app store stay on that
+store's update channel.
+
+## Other things to try
+
+- Browse Files in list or grid views, open supported previews, share items, and
+  use common file actions.
+- Explore Photos and Memories timelines, albums, tags, and recognized people.
+- Read and send Talk messages, including native presentation for several
+  message and attachment types.
+- Edit Markdown Notes with separate edit and preview modes.
+- Open installed apps such as Activity, Deck, Tables, Music, Mail, Calendar,
+  Contacts, and others through adaptive native views.
+- Pin server folders for one-way offline availability and configure early
+  folder-sync foundations.
 
 ## Important limitations
 
-This alpha is not yet a replacement for every official Nextcloud client
-feature. Some app actions are still read-only or incomplete, sync behavior is
-still being hardened, and calling is not ready for everyday use. Keep another
-copy of important files and review sync choices carefully.
+- Keep another copy of important files. File sync, media backup, conflict
+  recovery, and interrupted-transfer handling are still being hardened.
+- Android media-folder backup is intentionally upload-only. It does not mirror
+  server deletions or modify the phone's media library.
+- Adaptive app support is uneven. Some actions and settings are read-only,
+  incomplete, or less useful than their dedicated app. Mail, Calendar, Music,
+  Deck, Tables, Contacts, and administration still need substantial work.
+- Talk text messaging is available, but voice and video calling are not ready
+  for everyday use.
+- Face outlines are a read-only aid. This release does not complete the full
+  rename, merge, remove, and recognition-management workflow.
+- The persistent encrypted content cache and offline mutation queue are not
+  implemented yet, so some non-file apps may load slowly or require a
+  connection.
+- Direct APK updates work only in the direct-download Android build and still
+  require Android's normal installation confirmation.
+- Android 8.0 or newer is required. This release does not include an iPhone or
+  iPad build.
 
 Please report reproducible problems through the project issue tracker without
 including passwords, app tokens, private server addresses, or personal files.
 
 ## For technical testers
 
-This build establishes the shared Compose application, adaptive contract
-runtime, Android and desktop packaging, and the first persistent SQLite-backed
-media-transfer state. It requires Android 8.0 or newer.
+This build uses one shared Compose application on Android and desktop, a
+conservative adaptive contract runtime, revision-guarded file operations, and
+a persistent SQLite-backed media-transfer ledger. Release artifacts are
+published only as prereleases after source validation, desktop packaging,
+Android signing verification, and explicit approval of the protected
+`prerelease` environment.


### PR DESCRIPTION
## Summary

- finalize the changelog for 0.1.0-alpha.1
- publish user-facing alpha 1 release notes

## Validation

- prerelease version and tag guards
- Android signing configuration guard
- prerelease update producer/consumer contract
- repository hygiene

Relates to #100.