### PR TITLE
fix(release): retain staged platform packages

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -253,7 +253,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          find artifacts -mindepth 2 -maxdepth 2 -type f \
+          find artifacts -mindepth 2 -type f \
             -exec cp -t dist -- {} +
           version="${GITHUB_REF_NAME#v}"
           version_code="$(awk -F= '$1 == "ncVersionCode" { print $2 }' gradle.properties)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ until the full product sprint is complete.
 
 ## Unreleased
 
+## [0.1.0-alpha.3]
+
+### Fixed
+
+- macOS packages use a valid Apple package version while the application keeps
+  its prerelease product version.
+- Staged release assets retain packages nested inside platform artifact
+  directories.
+
 ## [0.1.0-alpha.2]
 
 ### Fixed

--- a/docs/release-notes/0.1.0-alpha.3.md
+++ b/docs/release-notes/0.1.0-alpha.3.md
@@ -1,0 +1,37 @@
+# Nextcloud Native 0.1.0-alpha.3
+
+This is an early testing build of Nextcloud Native, an independent native
+workspace for Nextcloud on Android and desktop.
+
+## Highlights
+
+- A customizable Home workspace with account-specific layouts.
+- Native Files, Photos, Memories, Talk, Notes, Cookbook, Deck, Tables, Music,
+  Mail, Calendar, Contacts, and adaptive views for other installed apps.
+- Clear Android media-backup states, folder previews, and a native Nextcloud
+  destination picker.
+- Native Cookbook recipe creation, editing, URL import, categories, and tags.
+- Full-screen photo and video viewing, RAW/JPEG choices, and optional face
+  outlines in recognized-person galleries.
+- Project news and a verified direct-APK update flow.
+
+## Important limitations
+
+- Keep another copy of important files. File sync, media backup, conflict
+  recovery, and interrupted-transfer handling are still being hardened.
+- Adaptive app support remains uneven. Several actions and settings are still
+  read-only or incomplete.
+- Talk voice and video calling are not ready for everyday use.
+- The persistent encrypted content cache and offline mutation queue are not
+  implemented yet, so some non-file apps may load slowly.
+- Android 8.0 or newer is required. This release does not include an iPhone or
+  iPad build.
+
+Please report reproducible problems through the project issue tracker without
+including passwords, app tokens, private server addresses, or personal files.
+
+## Packaging note
+
+Each successful platform package is retained on this tagged release. The
+release becomes public when at least three of Android, Linux, Windows, and
+macOS succeed.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 android.useAndroidX=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
-ncVersionName=0.1.0-alpha.2
-ncVersionCode=10000002
+ncVersionName=0.1.0-alpha.3
+ncVersionCode=10000003
 ncDesktopPackageVersion=0.1.0

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -125,6 +125,11 @@ compose.desktop {
             windows {
                 iconFile.set(project.file("src/desktopMain/resources/nextcloud-native.ico"))
             }
+            macOS {
+                // Apple's package metadata requires the first numeric component
+                // to be greater than zero, independently of our prerelease name.
+                packageVersion = "1.0.3"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- retain nested Linux packages when staging tagged release assets
- use an Apple-compatible macOS package metadata version
- prepare immutable alpha.3 release metadata

## Validation

- prerelease version and tag guards
- Gradle desktop configuration
- prerelease update producer/consumer contract
- repository hygiene

Relates to #100.

Progresses #102.