### PR TITLE
chore(release): prepare concise alpha 4

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -277,6 +277,24 @@ jobs:
               sort -z |
               xargs -0 sha256sum >SHA256SUMS
           )
+          cp "docs/release-notes/${version}.md" "${RUNNER_TEMP}/release-notes.md"
+          if [[ "${{ steps.platforms.outputs.successful }}" -lt 4 ]]; then
+            {
+              printf '\n## Build availability\n\n'
+              printf '| Platform | Status |\n'
+              printf '| --- | --- |\n'
+              for platform in android linux windows macos; do
+                artifact="artifacts/nextcloud-native-${platform}"
+                label="${platform^}"
+                if [[ -d "${artifact}" ]] &&
+                  find "${artifact}" -type f -print -quit | grep -q .; then
+                  printf '| %s | ✅ Available |\n' "${label}"
+                else
+                  printf '| %s | ❌ Unavailable |\n' "${label}"
+                fi
+              done
+            } >>"${RUNNER_TEMP}/release-notes.md"
+          fi
 
       - name: Stage assets on the tagged draft release
         env:
@@ -290,7 +308,7 @@ jobs:
             --verify-tag \
             --draft \
             --prerelease \
-            --notes-file "docs/release-notes/${version}.md" \
+            --notes-file "${RUNNER_TEMP}/release-notes.md" \
             --title "Nextcloud Native ${version}"
 
   release-quorum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ until the full product sprint is complete.
 
 ## Unreleased
 
+## [0.1.0-alpha.4]
+
+### Fixed
+
+- Android release lint now understands Kotlin 2.4 metadata and catches real
+  release issues without relying on build-log text.
+- Release pages show a compact platform status table only when a build is
+  unavailable.
+
 ## [0.1.0-alpha.3]
 
 ### Fixed

--- a/docs/release-notes/0.1.0-alpha.3.md
+++ b/docs/release-notes/0.1.0-alpha.3.md
@@ -29,9 +29,3 @@ workspace for Nextcloud on Android and desktop.
 
 Please report reproducible problems through the project issue tracker without
 including passwords, app tokens, private server addresses, or personal files.
-
-## Packaging note
-
-Each successful platform package is retained on this tagged release. The
-release becomes public when at least three of Android, Linux, Windows, and
-macOS succeed.

--- a/docs/release-notes/0.1.0-alpha.4.md
+++ b/docs/release-notes/0.1.0-alpha.4.md
@@ -1,0 +1,19 @@
+# Nextcloud Native 0.1.0-alpha.4
+
+An early testing build of the native Nextcloud workspace for Android and
+desktop.
+
+## Highlights
+
+- Customizable Home with account-specific layouts.
+- Native Files, Photos, Memories, Talk, Notes, and Cookbook experiences.
+- Adaptive views for other installed Nextcloud apps.
+- Android media backup, destination picking, and persistent transfer states.
+- Project news and verified direct APK updates.
+
+## Still in development
+
+Sync conflict recovery, offline caching, Talk calls, and several adaptive app
+actions are incomplete. Keep another copy of important files.
+
+Android 8.0 or newer is required. iPhone and iPad builds are not available yet.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,6 @@ android.useAndroidX=true
 android.experimental.lint.version=9.3.1
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
-ncVersionName=0.1.0-alpha.3
-ncVersionCode=10000003
+ncVersionName=0.1.0-alpha.4
+ncVersionCode=10000004
 ncDesktopPackageVersion=0.1.0

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -128,7 +128,7 @@ compose.desktop {
             macOS {
                 // Apple's package metadata requires the first numeric component
                 // to be greater than zero, independently of our prerelease name.
-                packageVersion = "1.0.3"
+                packageVersion = "1.0.4"
             }
         }
     }


### PR DESCRIPTION
## Summary

- prepare concise alpha.4 notes and version metadata
- show platform availability only when a build is missing
- remove internal packaging details from public release notes

## Validation

- full Android release lint gate
- prerelease version and update contracts
- Android signing configuration guard
- repository hygiene

Relates to #100.