### PR TITLE
fix(release): parse current Android signer output

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -213,21 +213,48 @@ jobs:
             "dist/nextcloud-native-${version}-android.apk"
           cp androidApp/build/outputs/bundle/release/androidApp-release.aab \
             "dist/nextcloud-native-${version}-android.aab"
-          apksigner_path="$(find "${ANDROID_HOME}/build-tools" -type f -name apksigner -print |
-            sort -V | tail -n 1)"
-          test -n "${apksigner_path}"
-          "${apksigner_path}" verify --verbose --print-certs \
-            "dist/nextcloud-native-${version}-android.apk" >"${RUNNER_TEMP}/apk-signing.txt"
-          jarsigner -verify \
-            "dist/nextcloud-native-${version}-android.aab" >/dev/null
-          certificate_sha256="$(awk -F': ' \
-            '/Signer #1 certificate SHA-256 digest:/ { print $2; exit }' \
-            "${RUNNER_TEMP}/apk-signing.txt" | tr '[:upper:]' '[:lower:]')"
-          test -n "${certificate_sha256}"
-          aab_certificate_sha256="$(keytool -printcert \
-            -jarfile "dist/nextcloud-native-${version}-android.aab" |
-            awk -F': ' '/SHA256:/{ fingerprint=$2; gsub(":", "", fingerprint); print tolower(fingerprint); exit }')"
-          test -n "${aab_certificate_sha256}"
+          apksigner_path="${ANDROID_HOME}/build-tools/35.0.0/apksigner"
+          if [[ ! -x "${apksigner_path}" ]]; then
+            echo "::error::Expected Android Build Tools 35.0.0 apksigner was not found."
+            exit 1
+          fi
+          if ! "${apksigner_path}" verify --verbose --print-certs \
+            "dist/nextcloud-native-${version}-android.apk" \
+            >"${RUNNER_TEMP}/apk-signing.txt" 2>&1; then
+            tail -100 "${RUNNER_TEMP}/apk-signing.txt"
+            echo "::error::APK cryptographic signature verification failed."
+            exit 1
+          fi
+          if ! jarsigner -verify \
+            "dist/nextcloud-native-${version}-android.aab" \
+            >"${RUNNER_TEMP}/aab-signing.txt" 2>&1; then
+            tail -100 "${RUNNER_TEMP}/aab-signing.txt"
+            echo "::error::App Bundle cryptographic signature verification failed."
+            exit 1
+          fi
+          if ! certificate_sha256="$(
+            tools/extract-apksigner-certificate-sha256.sh \
+              <"${RUNNER_TEMP}/apk-signing.txt"
+          )"; then
+            tail -100 "${RUNNER_TEMP}/apk-signing.txt"
+            echo "::error::APK signing certificate fingerprint was not reported."
+            exit 1
+          fi
+          if ! keytool -printcert \
+            -jarfile "dist/nextcloud-native-${version}-android.aab" \
+            >"${RUNNER_TEMP}/aab-certificate.txt" 2>&1; then
+            tail -100 "${RUNNER_TEMP}/aab-certificate.txt"
+            echo "::error::App Bundle signing certificate could not be read."
+            exit 1
+          fi
+          aab_certificate_sha256="$(awk -F': ' \
+            '/SHA256:/{ fingerprint=$2; gsub(":", "", fingerprint); print tolower(fingerprint); exit }' \
+            "${RUNNER_TEMP}/aab-certificate.txt")"
+          if [[ -z "${aab_certificate_sha256}" ]]; then
+            tail -100 "${RUNNER_TEMP}/aab-certificate.txt"
+            echo "::error::App Bundle signing certificate fingerprint was not reported."
+            exit 1
+          fi
           expected_certificate_sha256="$(tr -d ':[:space:]' \
             <release/android-signing-certificate.sha256 | tr '[:upper:]' '[:lower:]')"
           if [[ "${certificate_sha256}" != "${expected_certificate_sha256}" ]]; then

--- a/tools/check-repository.sh
+++ b/tools/check-repository.sh
@@ -33,4 +33,6 @@ for file in "${candidate_files[@]}"; do
     fi
 done
 
+bash tools/test-apksigner-certificate-parser.sh
+
 printf 'Repository hygiene checks passed.\n'

--- a/tools/extract-apksigner-certificate-sha256.sh
+++ b/tools/extract-apksigner-certificate-sha256.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 certificate_sha256="$(
     awk -F': ' \
-        '/certificate SHA-256 digest:/ { print tolower($NF); exit }'
+        '/^(Signer #[0-9]+|V[0-9][0-9.]* Signer( #[0-9]+)?):? certificate SHA-256 digest:/ {
+            print tolower($NF)
+            exit
+        }'
 )"
 
 if [[ ! "$certificate_sha256" =~ ^[0-9a-f]{64}$ ]]; then

--- a/tools/extract-apksigner-certificate-sha256.sh
+++ b/tools/extract-apksigner-certificate-sha256.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+certificate_sha256="$(
+    awk -F': ' \
+        '/certificate SHA-256 digest:/ { print tolower($NF); exit }'
+)"
+
+if [[ ! "$certificate_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'No valid APK signing certificate SHA-256 digest was reported.\n' >&2
+    exit 1
+fi
+
+printf '%s\n' "$certificate_sha256"

--- a/tools/test-apksigner-certificate-parser.sh
+++ b/tools/test-apksigner-certificate-parser.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+parser="$repo_root/tools/extract-apksigner-certificate-sha256.sh"
+expected='0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+
+old_format="$(
+    printf 'Signer #1 certificate SHA-256 digest: %s\n' "$expected" |
+        "$parser"
+)"
+new_format="$(
+    printf 'V2 Signer: certificate SHA-256 digest: %s\n' "$expected" |
+        "$parser"
+)"
+
+if [[ "$old_format" != "$expected" || "$new_format" != "$expected" ]]; then
+    printf 'APK certificate parser changed a valid digest.\n' >&2
+    exit 1
+fi
+
+if printf 'Verifies\n' | "$parser" >/dev/null 2>&1; then
+    printf 'APK certificate parser accepted output without a digest.\n' >&2
+    exit 1
+fi
+
+if printf 'Signer #1 certificate SHA-256 digest: invalid\n' |
+    "$parser" >/dev/null 2>&1; then
+    printf 'APK certificate parser accepted a malformed digest.\n' >&2
+    exit 1
+fi
+
+printf 'APK certificate parser tests passed.\n'

--- a/tools/test-apksigner-certificate-parser.sh
+++ b/tools/test-apksigner-certificate-parser.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 parser="$repo_root/tools/extract-apksigner-certificate-sha256.sh"
 expected='0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+source_stamp='ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 
 old_format="$(
     printf 'Signer #1 certificate SHA-256 digest: %s\n' "$expected" |
@@ -13,8 +14,14 @@ new_format="$(
     printf 'V2 Signer: certificate SHA-256 digest: %s\n' "$expected" |
         "$parser"
 )"
+stamped_format="$(
+    printf 'Source Stamp certificate SHA-256 digest: %s\nV2 Signer: certificate SHA-256 digest: %s\n' \
+        "$source_stamp" "$expected" |
+        "$parser"
+)"
 
-if [[ "$old_format" != "$expected" || "$new_format" != "$expected" ]]; then
+if [[ "$old_format" != "$expected" || "$new_format" != "$expected" ||
+    "$stamped_format" != "$expected" ]]; then
     printf 'APK certificate parser changed a valid digest.\n' >&2
     exit 1
 fi
@@ -27,6 +34,12 @@ fi
 if printf 'Signer #1 certificate SHA-256 digest: invalid\n' |
     "$parser" >/dev/null 2>&1; then
     printf 'APK certificate parser accepted a malformed digest.\n' >&2
+    exit 1
+fi
+
+if printf 'Source Stamp certificate SHA-256 digest: %s\n' "$source_stamp" |
+    "$parser" >/dev/null 2>&1; then
+    printf 'APK certificate parser accepted a source stamp as the app signer.\n' >&2
     exit 1
 fi
 


### PR DESCRIPTION
## What changed

- pin Android artifact verification to the installed Build Tools version
- parse both legacy and current `apksigner` certificate output
- surface explicit APK and AAB verification failures
- add regression coverage for valid, missing, and malformed certificate digests

## Root cause

The release build produced a valid signed APK, but the runner selected Build Tools 37. Its output labels the certificate as `V2 Signer`, while the workflow only recognized the older `Signer #1` label. The empty parse result then stopped the job without a useful error.

## Validation

- repository hygiene checks
- prerelease update contract checks
- Android release signing configuration guard on JDK 21
- parser tests against Build Tools 35, 36, and 37 output
- full APK and AAB cryptographic verification against retained signed artifacts
- pinned certificate fingerprint comparison for both artifacts

Progresses #101.