### PR TITLE
fix(photos): apply EXIF orientation exactly once

### DIFF
--- a/androidApp/src/androidTest/kotlin/dev/obiente/nextcloudnative/ExifOrientationInstrumentedTest.kt
+++ b/androidApp/src/androidTest/kotlin/dev/obiente/nextcloudnative/ExifOrientationInstrumentedTest.kt
@@ -1,0 +1,158 @@
+package dev.obiente.nextcloudnative
+
+import android.graphics.Bitmap
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.obiente.nextcloudnative.app.EncodedImageOrientationPolicy
+import dev.obiente.nextcloudnative.app.decodePlatformImageSampled
+import java.io.ByteArrayOutputStream
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExifOrientationInstrumentedTest {
+    @Test
+    fun bitmapMatrixNormalizesAllExifOrientationsExactlyOnce() {
+        val jpeg = syntheticCornerJpeg()
+        val raw = requireNotNull(
+            decodePlatformImageSampled(
+                jpeg,
+                256,
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            ),
+        )
+        val sourceCoordinates = listOf(
+            10 to 7,
+            30 to 7,
+            10 to 22,
+            30 to 22,
+        )
+        val sourcePixels = raw.image.readAllPixels()
+
+        for (orientation in 1..8) {
+            val decoded = requireNotNull(
+                decodePlatformImageSampled(
+                    jpeg.withExifOrientation(orientation),
+                    256,
+                    EncodedImageOrientationPolicy.ApplyExif,
+                ),
+            )
+            val expectedWidth = if (orientation in 5..8) raw.sourceHeight else raw.sourceWidth
+            val expectedHeight = if (orientation in 5..8) raw.sourceWidth else raw.sourceHeight
+            assertEquals("source width for EXIF $orientation", expectedWidth, decoded.sourceWidth)
+            assertEquals("source height for EXIF $orientation", expectedHeight, decoded.sourceHeight)
+            assertEquals("bitmap width for EXIF $orientation", expectedWidth, decoded.image.width)
+            assertEquals("bitmap height for EXIF $orientation", expectedHeight, decoded.image.height)
+            val outputPixels = decoded.image.readAllPixels()
+            sourceCoordinates.forEach { (x, y) ->
+                val (destinationX, destinationY) = expectedDestination(
+                    x,
+                    y,
+                    raw.sourceWidth,
+                    raw.sourceHeight,
+                    orientation,
+                )
+                assertColorNear(
+                    expected = sourcePixels[y * raw.sourceWidth + x],
+                    actual = outputPixels[destinationY * decoded.image.width + destinationX],
+                    message = "pixel ($x,$y) for EXIF $orientation",
+                )
+            }
+        }
+
+        val trustedServerPreview = requireNotNull(
+            decodePlatformImageSampled(
+                jpeg.withExifOrientation(6),
+                256,
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            ),
+        )
+        assertEquals(40, trustedServerPreview.image.width)
+        assertEquals(30, trustedServerPreview.image.height)
+        assertColorNear(
+            expected = sourcePixels[7 * raw.sourceWidth + 10],
+            actual = trustedServerPreview.image.readAllPixels()[7 * trustedServerPreview.image.width + 10],
+            message = "already-normalized server preview",
+        )
+    }
+
+    private fun syntheticCornerJpeg(): ByteArray {
+        val source = Bitmap.createBitmap(40, 30, Bitmap.Config.ARGB_8888)
+        val colors = intArrayOf(
+            0xFFE02020.toInt(),
+            0xFF20C040.toInt(),
+            0xFF3050E0.toInt(),
+            0xFFE0C020.toInt(),
+        )
+        repeat(source.height) { y ->
+            repeat(source.width) { x ->
+                val quadrant = (if (y >= source.height / 2) 2 else 0) +
+                    (if (x >= source.width / 2) 1 else 0)
+                source.setPixel(x, y, colors[quadrant])
+            }
+        }
+        return ByteArrayOutputStream().use { output ->
+            assertTrue(source.compress(Bitmap.CompressFormat.JPEG, 100, output))
+            source.recycle()
+            output.toByteArray()
+        }
+    }
+
+    private fun ByteArray.withExifOrientation(orientation: Int): ByteArray {
+        require(orientation in 1..8)
+        val tiff = byteArrayOf(
+            'I'.code.toByte(), 'I'.code.toByte(), 42, 0,
+            8, 0, 0, 0,
+            1, 0,
+            0x12, 0x01,
+            3, 0,
+            1, 0, 0, 0,
+            orientation.toByte(), 0, 0, 0,
+            0, 0, 0, 0,
+        )
+        val payload = "Exif\u0000\u0000".encodeToByteArray() + tiff
+        val length = payload.size + 2
+        val app1 = byteArrayOf(
+            0xFF.toByte(),
+            0xE1.toByte(),
+            (length ushr 8).toByte(),
+            length.toByte(),
+        ) + payload
+        return copyOfRange(0, 2) + app1 + copyOfRange(2, size)
+    }
+
+    private fun ImageBitmap.readAllPixels(): IntArray =
+        IntArray(width * height).also { readPixels(it) }
+
+    private fun expectedDestination(
+        sourceX: Int,
+        sourceY: Int,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        orientation: Int,
+    ): Pair<Int, Int> = when (orientation) {
+        1 -> sourceX to sourceY
+        2 -> sourceWidth - 1 - sourceX to sourceY
+        3 -> sourceWidth - 1 - sourceX to sourceHeight - 1 - sourceY
+        4 -> sourceX to sourceHeight - 1 - sourceY
+        5 -> sourceY to sourceX
+        6 -> sourceHeight - 1 - sourceY to sourceX
+        7 -> sourceHeight - 1 - sourceY to sourceWidth - 1 - sourceX
+        8 -> sourceY to sourceWidth - 1 - sourceX
+        else -> error("Unsupported EXIF orientation.")
+    }
+
+    private fun assertColorNear(expected: Int, actual: Int, message: String) {
+        fun channel(color: Int, shift: Int): Int = (color ushr shift) and 0xFF
+        for (shift in listOf(16, 8, 0)) {
+            assertTrue(
+                "$message expected 0x${expected.toUInt().toString(16)}, " +
+                    "actual 0x${actual.toUInt().toString(16)}",
+                abs(channel(expected, shift) - channel(actual, shift)) <= 24,
+            )
+        }
+    }
+}

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
         val androidMain by getting
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
+            implementation("androidx.exifinterface:exifinterface:1.4.2")
             implementation(libs.androidx.media3.exoplayer)
             implementation(libs.androidx.media3.datasource.okhttp)
             implementation(libs.androidx.media3.ui)

--- a/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.android.kt
+++ b/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.android.kt
@@ -5,13 +5,27 @@ import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.exifinterface.media.ExifInterface
+import java.io.ByteArrayInputStream
 
-actual fun decodePlatformImage(bytes: ByteArray): ImageBitmap? {
+actual fun decodePlatformImage(
+    bytes: ByteArray,
+    orientationPolicy: EncodedImageOrientationPolicy,
+): ImageBitmap? {
     val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size) ?: return null
-    return bitmap.applyEncodedOrientation(encodedImageOrientation(bytes)).asImageBitmap()
+    val orientation = bytes.orientationFor(orientationPolicy)
+    val oriented = bitmap.applyEncodedOrientation(orientation) ?: run {
+        bitmap.recycle()
+        return null
+    }
+    return oriented.asImageBitmap()
 }
 
-actual fun decodePlatformImageSampled(bytes: ByteArray, maximumDimension: Int): PlatformDecodedImage? {
+actual fun decodePlatformImageSampled(
+    bytes: ByteArray,
+    maximumDimension: Int,
+    orientationPolicy: EncodedImageOrientationPolicy,
+): PlatformDecodedImage? {
     require(maximumDimension > 0)
     val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
     BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
@@ -24,10 +38,12 @@ actual fun decodePlatformImageSampled(bytes: ByteArray, maximumDimension: Int): 
         inSampleSize = sampleSize
         inPreferredConfig = android.graphics.Bitmap.Config.ARGB_8888
     }
-    val orientation = encodedImageOrientation(bytes)
-    val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
-        ?.applyEncodedOrientation(orientation)
-        ?: return null
+    val orientation = bytes.orientationFor(orientationPolicy)
+    val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options) ?: return null
+    val bitmap = decoded.applyEncodedOrientation(orientation) ?: run {
+        decoded.recycle()
+        return null
+    }
     return PlatformDecodedImage(
         image = bitmap.asImageBitmap(),
         sourceWidth = if (orientationSwapsDimensions(orientation)) bounds.outHeight else bounds.outWidth,
@@ -35,31 +51,33 @@ actual fun decodePlatformImageSampled(bytes: ByteArray, maximumDimension: Int): 
     )
 }
 
-private fun Bitmap.applyEncodedOrientation(orientation: Int): Bitmap {
+private fun Bitmap.applyEncodedOrientation(orientation: Int): Bitmap? {
     if (orientation == 1) return this
-    val matrix = Matrix().apply {
-        when (orientation) {
-            2 -> setScale(-1f, 1f)
-            3 -> setRotate(180f)
-            4 -> {
-                setRotate(180f)
-                postScale(-1f, 1f)
-            }
-            5 -> {
-                setRotate(90f)
-                postScale(-1f, 1f)
-            }
-            6 -> setRotate(90f)
-            7 -> {
-                setRotate(-90f)
-                postScale(-1f, 1f)
-            }
-            8 -> setRotate(-90f)
-        }
-    }
     return runCatching {
+        val (source, destination) = exifOrientationAffinePoints(width, height, orientation)
+        val matrix = Matrix().apply {
+            check(setPolyToPoly(source, 0, destination, 0, 3)) {
+                "Could not construct the EXIF orientation transform."
+            }
+        }
         Bitmap.createBitmap(this, 0, 0, width, height, matrix, true).also { transformed ->
             if (transformed !== this) recycle()
         }
-    }.getOrElse { this }
+    }.getOrNull()
+}
+
+private fun ByteArray.orientationFor(policy: EncodedImageOrientationPolicy): Int = when (policy) {
+    EncodedImageOrientationPolicy.ApplyExif -> runCatching {
+        ByteArrayInputStream(this).use { input ->
+            ExifInterface(input).getAttributeInt(
+                ExifInterface.TAG_ORIENTATION,
+                ExifInterface.ORIENTATION_NORMAL,
+            )
+        }.takeIf { it in 1..8 } ?: 1
+    }.getOrElse {
+        // The bounded common parser keeps JPEG/TIFF orientation available if a vendor-specific
+        // payload is rejected by ExifInterface.
+        encodedImageOrientation(this)
+    }
+    EncodedImageOrientationPolicy.PixelsAlreadyUpright -> 1
 }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ExifOrientation.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ExifOrientation.kt
@@ -18,6 +18,112 @@ internal fun encodedImageOrientation(bytes: ByteArray): Int {
 
 internal fun orientationSwapsDimensions(orientation: Int): Boolean = orientation in 5..8
 
+internal data class ExifOrientedDimensions(
+    val width: Int,
+    val height: Int,
+)
+
+internal data class ExifPixelCoordinate(
+    val x: Int,
+    val y: Int,
+)
+
+internal fun exifOrientedDimensions(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    orientation: Int,
+): ExifOrientedDimensions {
+    require(sourceWidth > 0 && sourceHeight > 0)
+    require(orientation in 1..8)
+    return if (orientationSwapsDimensions(orientation)) {
+        ExifOrientedDimensions(sourceHeight, sourceWidth)
+    } else {
+        ExifOrientedDimensions(sourceWidth, sourceHeight)
+    }
+}
+
+/**
+ * Maps one encoded pixel into the canonical upright coordinate system defined by EXIF 1.
+ *
+ * Orientations 2, 4, 5, and 7 are mirrored; treating them as rotations loses information and
+ * makes crop and editor coordinates disagree with exported copies.
+ */
+internal fun exifOrientedPixel(
+    sourceX: Int,
+    sourceY: Int,
+    sourceWidth: Int,
+    sourceHeight: Int,
+    orientation: Int,
+): ExifPixelCoordinate {
+    require(sourceWidth > 0 && sourceHeight > 0)
+    require(sourceX in 0 until sourceWidth && sourceY in 0 until sourceHeight)
+    require(orientation in 1..8)
+    return when (orientation) {
+        1 -> ExifPixelCoordinate(sourceX, sourceY)
+        2 -> ExifPixelCoordinate(sourceWidth - 1 - sourceX, sourceY)
+        3 -> ExifPixelCoordinate(sourceWidth - 1 - sourceX, sourceHeight - 1 - sourceY)
+        4 -> ExifPixelCoordinate(sourceX, sourceHeight - 1 - sourceY)
+        5 -> ExifPixelCoordinate(sourceY, sourceX)
+        6 -> ExifPixelCoordinate(sourceHeight - 1 - sourceY, sourceX)
+        7 -> ExifPixelCoordinate(sourceHeight - 1 - sourceY, sourceWidth - 1 - sourceX)
+        8 -> ExifPixelCoordinate(sourceY, sourceWidth - 1 - sourceX)
+        else -> error("Unreachable EXIF orientation.")
+    }
+}
+
+/**
+ * Three source/destination edge points for an affine EXIF transform.
+ *
+ * Edge coordinates use width/height rather than the last pixel so platform rasterizers preserve
+ * the complete image bounds without half-pixel translations.
+ */
+internal fun exifOrientationAffinePoints(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    orientation: Int,
+): Pair<FloatArray, FloatArray> {
+    require(sourceWidth > 0 && sourceHeight > 0)
+    require(orientation in 1..8)
+    val width = sourceWidth.toFloat()
+    val height = sourceHeight.toFloat()
+    val source = floatArrayOf(0f, 0f, width, 0f, 0f, height)
+    val destination = when (orientation) {
+        1 -> floatArrayOf(0f, 0f, width, 0f, 0f, height)
+        2 -> floatArrayOf(width, 0f, 0f, 0f, width, height)
+        3 -> floatArrayOf(width, height, 0f, height, width, 0f)
+        4 -> floatArrayOf(0f, height, width, height, 0f, 0f)
+        5 -> floatArrayOf(0f, 0f, 0f, width, height, 0f)
+        6 -> floatArrayOf(height, 0f, height, width, 0f, 0f)
+        7 -> floatArrayOf(height, width, height, 0f, 0f, width)
+        8 -> floatArrayOf(0f, width, 0f, 0f, height, width)
+        else -> error("Unreachable EXIF orientation.")
+    }
+    return source to destination
+}
+
+internal fun exifOrientationMatrixValues(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    orientation: Int,
+): FloatArray {
+    val (source, destination) = exifOrientationAffinePoints(sourceWidth, sourceHeight, orientation)
+    val scaleX = source[2] - source[0]
+    val scaleY = source[5] - source[1]
+    val destinationX0 = destination[0]
+    val destinationY0 = destination[1]
+    return floatArrayOf(
+        (destination[2] - destinationX0) / scaleX,
+        (destination[4] - destinationX0) / scaleY,
+        destinationX0,
+        (destination[3] - destinationY0) / scaleX,
+        (destination[5] - destinationY0) / scaleY,
+        destinationY0,
+        0f,
+        0f,
+        1f,
+    )
+}
+
 private fun ByteArray.jpegExifTiffStart(): Int? {
     var cursor = 2
     while (cursor + 4 <= size) {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionBrowser.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionBrowser.kt
@@ -260,7 +260,10 @@ fun NativeMediaCollectionCover(
     LaunchedEffect(session, coverFile?.fileId, coverFile?.etag) {
         image = coverFile?.let { file ->
             runCatching {
-                decodePlatformImage(services.loadPreviewCached(session, file, width = 480, height = 480))
+                decodePlatformImage(
+                    services.loadPreviewCached(session, file, width = 480, height = 480),
+                    EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+                )
             }.getOrNull()
         }
     }
@@ -361,7 +364,10 @@ private fun NativeMediaItemTile(
     var image by remember(file.fileId, file.etag) { mutableStateOf<ImageBitmap?>(null) }
     LaunchedEffect(session, file.fileId, file.etag) {
         image = runCatching {
-            decodePlatformImage(services.loadPreviewCached(session, file, width = 384, height = 384))
+            decodePlatformImage(
+                services.loadPreviewCached(session, file, width = 384, height = 384),
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            )
         }.getOrNull()
     }
     Box(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudDocumentPreview.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudDocumentPreview.kt
@@ -322,7 +322,12 @@ private fun RenderedMarkdownDocument(preview: DocumentPreview.Text, filename: St
 
 @Composable
 private fun RasterDocument(preview: DocumentPreview.Raster, filename: String) {
-    val image = remember(preview) { decodePlatformImage(preview.encodedImage) }
+    val image = remember(preview) {
+        decodePlatformImage(
+            preview.encodedImage,
+            EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+        )
+    }
     if (image == null) {
         DocumentPreviewMessage(
             title = "Preview unavailable",

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
@@ -217,7 +217,13 @@ fun NextcloudMediaViewer(
             load = { candidate ->
                 services.loadPreviewCached(session, candidate, width = 1_600, height = 1_600)
             },
-            decode = { bytes -> decodePlatformImageSampled(bytes, MAXIMUM_PREVIEW_IMAGE_DIMENSION)?.image },
+            decode = { bytes ->
+                decodePlatformImageSampled(
+                    bytes,
+                    MAXIMUM_PREVIEW_IMAGE_DIMENSION,
+                    EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+                )?.image
+            },
         )
         previewState = loaded?.let {
             MediaPreviewState.Ready(it.value, it.source, it.usedFallback)

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -4633,7 +4633,10 @@ private fun FileGridTile(
         file.fileId ?: return@LaunchedEffect
         if (!file.hasPreview || file.isDirectory) return@LaunchedEffect
         preview = runCatching {
-            decodePlatformImage(services.loadPreviewCached(session, file, width = 320, height = 320))
+            decodePlatformImage(
+                services.loadPreviewCached(session, file, width = 320, height = 320),
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            )
         }.getOrNull()
     }
     Card(
@@ -5500,7 +5503,12 @@ private fun PersonTile(
     var image by remember(person.id, person.coverFileId, person.coverEtag) { mutableStateOf<ImageBitmap?>(null) }
     LaunchedEffect(person.id, person.coverFileId, person.coverEtag) {
         if (person.coverFileId == null) return@LaunchedEffect
-        image = runCatching { decodePlatformImage(services.loadPersonCoverCached(session, person)) }.getOrNull()
+        image = runCatching {
+            decodePlatformImage(
+                services.loadPersonCoverCached(session, person),
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            )
+        }.getOrNull()
     }
 
     Card(
@@ -6414,7 +6422,12 @@ private fun MediaTile(
     LaunchedEffect(file.fileId) {
         file.fileId ?: return@LaunchedEffect
         if (!file.hasPreview) return@LaunchedEffect
-        image = runCatching { decodePlatformImage(services.loadPreviewCached(session, file)) }.getOrNull()
+        image = runCatching {
+            decodePlatformImage(
+                services.loadPreviewCached(session, file),
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            )
+        }.getOrNull()
     }
     Surface(
         modifier = Modifier.fillMaxWidth().aspectRatio(1f).then(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.kt
@@ -2,7 +2,18 @@ package dev.obiente.nextcloudnative.app
 
 import androidx.compose.ui.graphics.ImageBitmap
 
-expect fun decodePlatformImage(bytes: ByteArray): ImageBitmap?
+enum class EncodedImageOrientationPolicy {
+    /** Pixel storage still uses the file's EXIF orientation and must be normalized exactly once. */
+    ApplyExif,
+
+    /** A trusted server renderer has already returned upright pixels. Ignore stale copied EXIF. */
+    PixelsAlreadyUpright,
+}
+
+expect fun decodePlatformImage(
+    bytes: ByteArray,
+    orientationPolicy: EncodedImageOrientationPolicy = EncodedImageOrientationPolicy.ApplyExif,
+): ImageBitmap?
 
 data class PlatformDecodedImage(
     val image: ImageBitmap,
@@ -11,4 +22,8 @@ data class PlatformDecodedImage(
 )
 
 /** Decodes a display-safe bitmap while retaining the source dimensions used for export. */
-expect fun decodePlatformImageSampled(bytes: ByteArray, maximumDimension: Int): PlatformDecodedImage?
+expect fun decodePlatformImageSampled(
+    bytes: ByteArray,
+    maximumDimension: Int,
+    orientationPolicy: EncodedImageOrientationPolicy = EncodedImageOrientationPolicy.ApplyExif,
+): PlatformDecodedImage?

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceRemovalPicker.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizedFaceRemovalPicker.kt
@@ -207,6 +207,7 @@ private fun RecognizedFaceTile(
                     width = 512,
                     height = 512,
                 ),
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
             )
         }.getOrNull()
     }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/TalkMessageCards.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/TalkMessageCards.kt
@@ -285,7 +285,10 @@ private fun TalkNativeAttachmentCard(
         if (!model.canLoadServerRaster) return@LaunchedEffect
         preview = runCatching {
             val bytes = services.loadPreviewCached(session, file, width = 720, height = 480)
-            decodePlatformImage(bytes) ?: error("Invalid Talk attachment preview")
+            decodePlatformImage(
+                bytes,
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            ) ?: error("Invalid Talk attachment preview")
         }.fold(
             onSuccess = TalkAttachmentPreviewState::Ready,
             onFailure = { TalkAttachmentPreviewState.Failed },

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.desktop.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.desktop.kt
@@ -3,19 +3,32 @@ package dev.obiente.nextcloudnative.app
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Codec
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.EncodedOrigin
 import org.jetbrains.skia.Image
+import org.jetbrains.skia.Matrix33
 import org.jetbrains.skia.SamplingMode
 import kotlin.math.roundToInt
 
-actual fun decodePlatformImage(bytes: ByteArray): ImageBitmap? = runCatching {
-    Image.makeFromEncoded(bytes).toComposeImageBitmap()
+actual fun decodePlatformImage(
+    bytes: ByteArray,
+    orientationPolicy: EncodedImageOrientationPolicy,
+): ImageBitmap? = runCatching {
+    decodeDesktopImage(bytes, orientationPolicy).image.toComposeImageBitmap()
 }.getOrNull()
 
-actual fun decodePlatformImageSampled(bytes: ByteArray, maximumDimension: Int): PlatformDecodedImage? = runCatching {
+actual fun decodePlatformImageSampled(
+    bytes: ByteArray,
+    maximumDimension: Int,
+    orientationPolicy: EncodedImageOrientationPolicy,
+): PlatformDecodedImage? = runCatching {
     require(maximumDimension > 0)
-    val source = Image.makeFromEncoded(bytes)
-    val sourceWidth = source.width
-    val sourceHeight = source.height
+    val decoded = decodeDesktopImage(bytes, orientationPolicy)
+    val source = decoded.image
+    val sourceWidth = decoded.width
+    val sourceHeight = decoded.height
     val sampled = if (maxOf(sourceWidth, sourceHeight) <= maximumDimension) {
         source
     } else {
@@ -36,3 +49,56 @@ actual fun decodePlatformImageSampled(bytes: ByteArray, maximumDimension: Int): 
         sourceHeight = sourceHeight,
     )
 }.getOrNull()
+
+private data class DesktopDecodedImage(
+    val image: Image,
+    val width: Int,
+    val height: Int,
+)
+
+/**
+ * Codec.readPixels returns encoded pixel storage without applying EncodedOrigin. This lets a
+ * trusted server preview opt out of stale EXIF while originals use Skia's complete 1-8 transform.
+ */
+private fun decodeDesktopImage(
+    bytes: ByteArray,
+    orientationPolicy: EncodedImageOrientationPolicy,
+): DesktopDecodedImage {
+    val codec = Codec.makeFromData(Data.makeFromBytes(bytes))
+    val rawBitmap = codec.readPixels()
+    val rawImage = Image.makeFromBitmap(rawBitmap)
+    val orientation = when (orientationPolicy) {
+        EncodedImageOrientationPolicy.ApplyExif -> codec.encodedOrigin.exifOrientation()
+        EncodedImageOrientationPolicy.PixelsAlreadyUpright -> 1
+    }
+    if (orientation == 1) {
+        return DesktopDecodedImage(rawImage, rawImage.width, rawImage.height)
+    }
+    val dimensions = exifOrientedDimensions(rawImage.width, rawImage.height, orientation)
+    val target = Bitmap()
+    check(target.allocN32Pixels(dimensions.width, dimensions.height, false)) {
+        "Could not allocate an EXIF-normalized image."
+    }
+    Canvas(target).apply {
+        concat(Matrix33(*exifOrientationMatrixValues(rawImage.width, rawImage.height, orientation)))
+        drawImage(rawImage, 0f, 0f)
+    }
+    return DesktopDecodedImage(
+        image = Image.makeFromBitmap(target),
+        width = dimensions.width,
+        height = dimensions.height,
+    )
+}
+
+private fun EncodedOrigin.exifOrientation(): Int = when (this) {
+    EncodedOrigin.UNUSED,
+    EncodedOrigin.TOP_LEFT,
+    -> 1
+    EncodedOrigin.TOP_RIGHT -> 2
+    EncodedOrigin.BOTTOM_RIGHT -> 3
+    EncodedOrigin.BOTTOM_LEFT -> 4
+    EncodedOrigin.LEFT_TOP -> 5
+    EncodedOrigin.RIGHT_TOP -> 6
+    EncodedOrigin.RIGHT_BOTTOM -> 7
+    EncodedOrigin.LEFT_BOTTOM -> 8
+}

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.desktop.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.desktop.kt
@@ -16,7 +16,13 @@ actual fun decodePlatformImage(
     bytes: ByteArray,
     orientationPolicy: EncodedImageOrientationPolicy,
 ): ImageBitmap? = runCatching {
-    decodeDesktopImage(bytes, orientationPolicy).image.toComposeImageBitmap()
+    val decoded = decodeDesktopImage(bytes, orientationPolicy)
+    try {
+        decoded.image.toComposeImageBitmap()
+    } catch (failure: Throwable) {
+        decoded.image.close()
+        throw failure
+    }
 }.getOrNull()
 
 actual fun decodePlatformImageSampled(
@@ -29,25 +35,44 @@ actual fun decodePlatformImageSampled(
     val source = decoded.image
     val sourceWidth = decoded.width
     val sourceHeight = decoded.height
-    val sampled = if (maxOf(sourceWidth, sourceHeight) <= maximumDimension) {
-        source
-    } else {
-        val scale = maximumDimension.toFloat() / maxOf(sourceWidth, sourceHeight)
-        val width = (sourceWidth * scale).roundToInt().coerceAtLeast(1)
-        val height = (sourceHeight * scale).roundToInt().coerceAtLeast(1)
-        val target = Bitmap()
-        check(target.allocN32Pixels(width, height, false)) { "Could not allocate a display-safe image." }
-        val targetPixels = checkNotNull(target.peekPixels()) { "Could not access display-safe image pixels." }
-        check(source.scalePixels(targetPixels, SamplingMode.MITCHELL, true)) {
-            "Could not create a display-safe image."
+    try {
+        val sampled = if (maxOf(sourceWidth, sourceHeight) <= maximumDimension) {
+            source
+        } else {
+            val scale = maximumDimension.toFloat() / maxOf(sourceWidth, sourceHeight)
+            val width = (sourceWidth * scale).roundToInt().coerceAtLeast(1)
+            val height = (sourceHeight * scale).roundToInt().coerceAtLeast(1)
+            Bitmap().use { target ->
+                check(target.allocN32Pixels(width, height, false)) {
+                    "Could not allocate a display-safe image."
+                }
+                val targetPixels = checkNotNull(target.peekPixels()) {
+                    "Could not access display-safe image pixels."
+                }
+                check(source.scalePixels(targetPixels, SamplingMode.MITCHELL, true)) {
+                    "Could not create a display-safe image."
+                }
+                Image.makeFromBitmap(target)
+            }.also {
+                source.close()
+            }
         }
-        Image.makeFromBitmap(target)
+        try {
+            PlatformDecodedImage(
+                image = sampled.toComposeImageBitmap(),
+                sourceWidth = sourceWidth,
+                sourceHeight = sourceHeight,
+            )
+        } catch (failure: Throwable) {
+            sampled.close()
+            throw failure
+        }
+    } catch (failure: Throwable) {
+        if (!source.isClosed) {
+            source.close()
+        }
+        throw failure
     }
-    PlatformDecodedImage(
-        image = sampled.toComposeImageBitmap(),
-        sourceWidth = sourceWidth,
-        sourceHeight = sourceHeight,
-    )
 }.getOrNull()
 
 private data class DesktopDecodedImage(
@@ -64,30 +89,45 @@ private fun decodeDesktopImage(
     bytes: ByteArray,
     orientationPolicy: EncodedImageOrientationPolicy,
 ): DesktopDecodedImage {
-    val codec = Codec.makeFromData(Data.makeFromBytes(bytes))
-    val rawBitmap = codec.readPixels()
-    val rawImage = Image.makeFromBitmap(rawBitmap)
-    val orientation = when (orientationPolicy) {
-        EncodedImageOrientationPolicy.ApplyExif -> codec.encodedOrigin.exifOrientation()
-        EncodedImageOrientationPolicy.PixelsAlreadyUpright -> 1
+    return Data.makeFromBytes(bytes).use { data ->
+        Codec.makeFromData(data).use { codec ->
+            codec.readPixels().use { rawBitmap ->
+                val rawImage = Image.makeFromBitmap(rawBitmap)
+                val orientation = when (orientationPolicy) {
+                    EncodedImageOrientationPolicy.ApplyExif -> codec.encodedOrigin.exifOrientation()
+                    EncodedImageOrientationPolicy.PixelsAlreadyUpright -> 1
+                }
+                if (orientation == 1) {
+                    return@use DesktopDecodedImage(rawImage, rawImage.width, rawImage.height)
+                }
+                rawImage.use { source ->
+                    val dimensions = exifOrientedDimensions(source.width, source.height, orientation)
+                    Bitmap().use { target ->
+                        check(target.allocN32Pixels(dimensions.width, dimensions.height, false)) {
+                            "Could not allocate an EXIF-normalized image."
+                        }
+                        Canvas(target).use { canvas ->
+                            canvas.concat(
+                                Matrix33(
+                                    *exifOrientationMatrixValues(
+                                        source.width,
+                                        source.height,
+                                        orientation,
+                                    ),
+                                ),
+                            )
+                            canvas.drawImage(source, 0f, 0f)
+                        }
+                        DesktopDecodedImage(
+                            image = Image.makeFromBitmap(target),
+                            width = dimensions.width,
+                            height = dimensions.height,
+                        )
+                    }
+                }
+            }
+        }
     }
-    if (orientation == 1) {
-        return DesktopDecodedImage(rawImage, rawImage.width, rawImage.height)
-    }
-    val dimensions = exifOrientedDimensions(rawImage.width, rawImage.height, orientation)
-    val target = Bitmap()
-    check(target.allocN32Pixels(dimensions.width, dimensions.height, false)) {
-        "Could not allocate an EXIF-normalized image."
-    }
-    Canvas(target).apply {
-        concat(Matrix33(*exifOrientationMatrixValues(rawImage.width, rawImage.height, orientation)))
-        drawImage(rawImage, 0f, 0f)
-    }
-    return DesktopDecodedImage(
-        image = Image.makeFromBitmap(target),
-        width = dimensions.width,
-        height = dimensions.height,
-    )
 }
 
 private fun EncodedOrigin.exifOrientation(): Int = when (this) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.desktop.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.desktop.kt
@@ -102,31 +102,51 @@ private fun decodeDesktopImage(
                 }
                 rawImage.use { source ->
                     val dimensions = exifOrientedDimensions(source.width, source.height, orientation)
-                    Bitmap().use { target ->
-                        check(target.allocN32Pixels(dimensions.width, dimensions.height, false)) {
-                            "Could not allocate an EXIF-normalized image."
-                        }
-                        Canvas(target).use { canvas ->
-                            canvas.concat(
-                                Matrix33(
-                                    *exifOrientationMatrixValues(
-                                        source.width,
-                                        source.height,
-                                        orientation,
-                                    ),
-                                ),
-                            )
-                            canvas.drawImage(source, 0f, 0f)
-                        }
-                        DesktopDecodedImage(
-                            image = Image.makeFromBitmap(target),
-                            width = dimensions.width,
-                            height = dimensions.height,
-                        )
-                    }
+                    DesktopDecodedImage(
+                        image = renderDesktopExifOrientation(source, orientation),
+                        width = dimensions.width,
+                        height = dimensions.height,
+                    )
                 }
             }
         }
+    }
+}
+
+internal fun renderDesktopExifOrientation(source: Image, orientation: Int): Image {
+    val dimensions = exifOrientedDimensions(source.width, source.height, orientation)
+    return Bitmap().use { target ->
+        check(
+            target.allocPixels(
+                source.imageInfo.withWidthHeight(dimensions.width, dimensions.height),
+            ),
+        ) {
+            "Could not allocate an EXIF-normalized image."
+        }
+        drawDesktopExifOrientation(source, target, orientation)
+        Image.makeFromBitmap(target)
+    }
+}
+
+internal fun drawDesktopExifOrientation(
+    source: Image,
+    target: Bitmap,
+    orientation: Int,
+) {
+    val dimensions = exifOrientedDimensions(source.width, source.height, orientation)
+    require(target.width == dimensions.width && target.height == dimensions.height)
+    target.erase(0x00000000)
+    Canvas(target).use { canvas ->
+        canvas.concat(
+            Matrix33(
+                *exifOrientationMatrixValues(
+                    source.width,
+                    source.height,
+                    orientation,
+                ),
+            ),
+        )
+        canvas.drawImage(source, 0f, 0f)
     }
 }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/ExifOrientationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/ExifOrientationTest.kt
@@ -1,13 +1,21 @@
 package dev.obiente.nextcloudnative.app
 
+import androidx.compose.ui.graphics.toComposeImageBitmap
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.math.abs
+import org.jetbrains.skia.Bitmap
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
 
 class ExifOrientationTest {
     @Test
@@ -179,6 +187,67 @@ class ExifOrientationTest {
         )
     }
 
+    @Test
+    fun desktopOrientationPreservesPartialTransparency() {
+        val source = BufferedImage(3, 2, BufferedImage.TYPE_INT_ARGB).apply {
+            setRGB(0, 0, 0x40FF0000)
+            setRGB(1, 0, 0x8000FF00.toInt())
+            setRGB(2, 0, 0xC00000FF.toInt())
+            setRGB(0, 1, 0x60FFFF00)
+            setRGB(1, 1, 0xA000FFFF.toInt())
+            setRGB(2, 1, 0xE0FF00FF.toInt())
+        }
+        val png = ByteArrayOutputStream().also { output ->
+            assertTrue(ImageIO.write(source, "png", output))
+        }.toByteArray()
+        Image.makeFromEncoded(png).use { encoded ->
+            Bitmap().use { target ->
+                assertTrue(target.allocN32Pixels(2, 3, false))
+                target.erase(0xFFFF00FF.toInt())
+                drawDesktopExifOrientation(encoded, target, 6)
+                Image.makeFromBitmap(target).use { oriented ->
+                    val decoded = oriented.toComposeImageBitmap()
+                    assertEquals(2, decoded.width)
+                    assertEquals(3, decoded.height)
+                    val output = decoded.readAllPixels()
+                    repeat(source.height) { y ->
+                        repeat(source.width) { x ->
+                            val mapped = exifOrientedPixel(x, y, source.width, source.height, 6)
+                            assertArgbNear(
+                                expected = source.getRGB(x, y),
+                                actual = output[mapped.y * decoded.width + mapped.x],
+                                tolerance = 1,
+                                message = "transparent pixel ($x,$y)",
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun desktopOrientationPreservesEmbeddedColorSpace() {
+        Bitmap().use { bitmap ->
+            val imageInfo = ImageInfo(
+                3,
+                2,
+                ColorType.RGBA_8888,
+                ColorAlphaType.PREMUL,
+                ColorSpace.displayP3,
+            )
+            assertTrue(bitmap.allocPixels(imageInfo))
+            bitmap.erase(0xFFCC6633.toInt())
+            Image.makeFromBitmap(bitmap).use { source ->
+                renderDesktopExifOrientation(source, 6).use { oriented ->
+                    val colorSpace = assertNotNull(oriented.colorSpace)
+                    assertFalse(colorSpace.isSRGB)
+                    assertEquals(ColorSpace.displayP3, colorSpace)
+                }
+            }
+        }
+    }
+
     private fun syntheticCornerJpeg(): ByteArray {
         val source = BufferedImage(40, 30, BufferedImage.TYPE_INT_RGB)
         val colors = intArrayOf(0xE02020, 0x20C040, 0x3050E0, 0xE0C020)
@@ -209,6 +278,18 @@ class ExifOrientationTest {
         for (shift in listOf(16, 8, 0)) {
             assertTrue(
                 abs(channel(expected, shift) - channel(actual, shift)) <= 20,
+                "$message expected 0x${expected.toUInt().toString(16)}, " +
+                    "actual 0x${actual.toUInt().toString(16)}",
+            )
+        }
+    }
+
+    private fun assertArgbNear(expected: Int, actual: Int, tolerance: Int, message: String) {
+        for (shift in listOf(24, 16, 8, 0)) {
+            val expectedChannel = (expected ushr shift) and 0xFF
+            val actualChannel = (actual ushr shift) and 0xFF
+            assertTrue(
+                abs(expectedChannel - actualChannel) <= tolerance,
                 "$message expected 0x${expected.toUInt().toString(16)}, " +
                     "actual 0x${actual.toUInt().toString(16)}",
             )

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/ExifOrientationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/ExifOrientationTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.math.abs
 
 class ExifOrientationTest {
     @Test
@@ -17,6 +18,20 @@ class ExifOrientationTest {
     @Test
     fun readsBigEndianJpegExifOrientation() {
         assertEquals(8, encodedImageOrientation(jpegWithExifOrientation(8, littleEndian = false)))
+    }
+
+    @Test
+    fun readsEveryExifOrientationInBothByteOrders() {
+        for (orientation in 1..8) {
+            assertEquals(
+                orientation,
+                encodedImageOrientation(jpegWithExifOrientation(orientation, littleEndian = true)),
+            )
+            assertEquals(
+                orientation,
+                encodedImageOrientation(jpegWithExifOrientation(orientation, littleEndian = false)),
+            )
+        }
     }
 
     @Test
@@ -31,6 +46,48 @@ class ExifOrientationTest {
         assertFalse(orientationSwapsDimensions(4))
         assertTrue(orientationSwapsDimensions(5))
         assertTrue(orientationSwapsDimensions(8))
+    }
+
+    @Test
+    fun allEightOrientationsMapPixelsIncludingMirroredCases() {
+        val sourceRows = listOf("ABC", "DEF")
+        val expected = mapOf(
+            1 to listOf("ABC", "DEF"),
+            2 to listOf("CBA", "FED"),
+            3 to listOf("FED", "CBA"),
+            4 to listOf("DEF", "ABC"),
+            5 to listOf("AD", "BE", "CF"),
+            6 to listOf("DA", "EB", "FC"),
+            7 to listOf("FC", "EB", "DA"),
+            8 to listOf("CF", "BE", "AD"),
+        )
+        for (orientation in 1..8) {
+            val dimensions = exifOrientedDimensions(3, 2, orientation)
+            val destination = Array(dimensions.height) { CharArray(dimensions.width) { '?' } }
+            sourceRows.forEachIndexed { y, row ->
+                row.forEachIndexed { x, label ->
+                    val mapped = exifOrientedPixel(x, y, 3, 2, orientation)
+                    destination[mapped.y][mapped.x] = label
+                }
+            }
+            assertEquals(
+                expected.getValue(orientation),
+                destination.map(CharArray::concatToString),
+                "EXIF orientation $orientation",
+            )
+            val matrix = exifOrientationMatrixValues(3, 2, orientation)
+            sourceRows.forEachIndexed { y, row ->
+                row.indices.forEach { x ->
+                    val centerX = x + 0.5f
+                    val centerY = y + 0.5f
+                    val mappedX = matrix[0] * centerX + matrix[1] * centerY + matrix[2]
+                    val mappedY = matrix[3] * centerX + matrix[4] * centerY + matrix[5]
+                    val expectedPixel = exifOrientedPixel(x, y, 3, 2, orientation)
+                    assertEquals(expectedPixel.x, mappedX.toInt(), "matrix x for EXIF $orientation")
+                    assertEquals(expectedPixel.y, mappedY.toInt(), "matrix y for EXIF $orientation")
+                }
+            }
+        }
     }
 
     @Test
@@ -54,6 +111,108 @@ class ExifOrientationTest {
         assertEquals(30, decoded.sourceHeight)
         assertEquals(20, decoded.image.width)
         assertEquals(30, decoded.image.height)
+    }
+
+    @Test
+    fun desktopDecodeAppliesEveryOrientationOnceAndCanTrustNormalizedServerPixels() {
+        val jpeg = syntheticCornerJpeg()
+        val source = requireNotNull(
+            decodePlatformImageSampled(
+                jpeg,
+                256,
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            ),
+        )
+        val sourceCoordinates = listOf(
+            10 to 7,
+            30 to 7,
+            10 to 22,
+            30 to 22,
+        )
+        val sourcePixels = source.image.readAllPixels()
+
+        for (orientation in 1..8) {
+            val encoded = jpeg.withExifOrientation(orientation)
+            val decoded = requireNotNull(
+                decodePlatformImageSampled(
+                    encoded,
+                    256,
+                    EncodedImageOrientationPolicy.ApplyExif,
+                ),
+            )
+            val expectedDimensions = exifOrientedDimensions(source.sourceWidth, source.sourceHeight, orientation)
+            assertEquals(expectedDimensions.width, decoded.sourceWidth, "width for EXIF $orientation")
+            assertEquals(expectedDimensions.height, decoded.sourceHeight, "height for EXIF $orientation")
+            assertEquals(expectedDimensions.width, decoded.image.width, "bitmap width for EXIF $orientation")
+            assertEquals(expectedDimensions.height, decoded.image.height, "bitmap height for EXIF $orientation")
+            val outputPixels = decoded.image.readAllPixels()
+            sourceCoordinates.forEach { (x, y) ->
+                val mapped = exifOrientedPixel(
+                    x,
+                    y,
+                    source.sourceWidth,
+                    source.sourceHeight,
+                    orientation,
+                )
+                assertColorNear(
+                    expected = sourcePixels[y * source.sourceWidth + x],
+                    actual = outputPixels[mapped.y * decoded.image.width + mapped.x],
+                    message = "pixel ($x,$y) for EXIF $orientation",
+                )
+            }
+        }
+
+        val staleExifServerPreview = jpeg.withExifOrientation(6)
+        val trusted = requireNotNull(
+            decodePlatformImageSampled(
+                staleExifServerPreview,
+                256,
+                EncodedImageOrientationPolicy.PixelsAlreadyUpright,
+            ),
+        )
+        assertEquals(40, trusted.sourceWidth)
+        assertEquals(30, trusted.sourceHeight)
+        assertColorNear(
+            expected = sourcePixels[7 * source.sourceWidth + 10],
+            actual = trusted.image.readAllPixels()[7 * trusted.image.width + 10],
+            message = "already-normalized server preview",
+        )
+    }
+
+    private fun syntheticCornerJpeg(): ByteArray {
+        val source = BufferedImage(40, 30, BufferedImage.TYPE_INT_RGB)
+        val colors = intArrayOf(0xE02020, 0x20C040, 0x3050E0, 0xE0C020)
+        repeat(source.height) { y ->
+            repeat(source.width) { x ->
+                val quadrant = (if (y >= source.height / 2) 2 else 0) +
+                    (if (x >= source.width / 2) 1 else 0)
+                source.setRGB(x, y, colors[quadrant])
+            }
+        }
+        return ByteArrayOutputStream().also { output ->
+            assertTrue(ImageIO.write(source, "jpg", output))
+        }.toByteArray()
+    }
+
+    private fun ByteArray.withExifOrientation(orientation: Int): ByteArray {
+        val metadataOnly = jpegWithExifOrientation(orientation, littleEndian = true)
+        return copyOfRange(0, 2) +
+            metadataOnly.copyOfRange(2, metadataOnly.size - 2) +
+            copyOfRange(2, size)
+    }
+
+    private fun androidx.compose.ui.graphics.ImageBitmap.readAllPixels(): IntArray =
+        IntArray(width * height).also { readPixels(it) }
+
+    private fun assertColorNear(expected: Int, actual: Int, message: String) {
+        fun channel(color: Int, shift: Int): Int = (color ushr shift) and 0xFF
+        for (shift in listOf(16, 8, 0)) {
+            assertTrue(
+                abs(channel(expected, shift) - channel(actual, shift)) <= 20,
+                "$message expected 0x${expected.toUInt().toString(16)}, " +
+                    "actual 0x${actual.toUInt().toString(16)}",
+            )
+        }
     }
 
     private fun jpegWithExifOrientation(orientation: Int, littleEndian: Boolean): ByteArray {


### PR DESCRIPTION
## Summary

- distinguish server previews whose pixels are already upright from original bytes that still require EXIF orientation
- support all eight EXIF orientations, including mirrored transforms and dimension swaps
- use Android ExifInterface and desktop Skia codec origin consistently across viewers, editors, previews, Talk attachments, and face selection

## Impact

Full-quality photos no longer rotate or mirror incorrectly when switching from a server preview to original bytes, zoom, or editing.

## Validation

- desktop EXIF suite covered orientations 1 through 8
- Android instrumented test covered actual Bitmap, Matrix, and ExifInterface behavior for orientations 1 through 8
- verified corner placement, mirrored transforms, dimension swaps, and the already-upright preview policy
- `bash tools/check-repository.sh`
- `git diff --check`

Closes #82