### PR TITLE
feat(release): add changelog fragment pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,24 @@ jobs:
           bash tools/check-repository.sh
           bash tools/test-prerelease-update-contract.sh
 
+      - name: Require a changelog fragment
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASE_SHA}" || "${BASE_SHA}" =~ ^0+$ ]]; then
+            printf 'No comparison base is available; fragment diff check skipped.\n'
+            exit 0
+          fi
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+          fi
+          node tools/changelog-fragments.mjs check-diff \
+            --base "${BASE_SHA}" \
+            --head "${HEAD_SHA}"
+
       - name: Set up JDK 21
         if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.app == 'true'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to Nextcloud Native are recorded here. News articles explain
 features in depth, while release notes summarize what people should know before
-installing a particular build.
+installing a particular build. Pull requests add independent files under
+`changes/unreleased/`; the website renders them here until release preparation
+archives them and curates the immutable version section below.
 
 The project remains in prerelease development. Versions stay below `1.0.0`
 until the full product sprint is complete.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,9 @@ direction, or speak on your behalf.
 
 ## Development setup
 
-Install JDK 21, Rust stable, Node.js 20 or newer, and Android SDK Platform 36
-with Build Tools 35.0.0. Set `ANDROID_HOME` or `ANDROID_SDK_ROOT` to your local
-SDK directory. Do not add local SDK paths to project files.
+Install JDK 21, Rust stable, Node.js `^20.19.0 || >=22.12.0`, and Android SDK
+Platform 36 with Build Tools 35.0.0. Set `ANDROID_HOME` or `ANDROID_SDK_ROOT`
+to your local SDK directory. Do not add local SDK paths to project files.
 
 Run the complete local verification suite:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,9 @@ direction, or speak on your behalf.
 
 ## Development setup
 
-Install JDK 21, Rust stable, and Android SDK Platform 36 with Build Tools
-35.0.0. Set `ANDROID_HOME` or `ANDROID_SDK_ROOT` to your local SDK directory.
-Do not add local SDK paths to project files.
+Install JDK 21, Rust stable, Node.js 20 or newer, and Android SDK Platform 36
+with Build Tools 35.0.0. Set `ANDROID_HOME` or `ANDROID_SDK_ROOT` to your local
+SDK directory. Do not add local SDK paths to project files.
 
 Run the complete local verification suite:
 
@@ -150,6 +150,10 @@ real account or copy those generated artifacts into the repository.
 ## Pull requests
 
 - Keep changes focused and explain the user-facing outcome.
+- Add one small file under `changes/unreleased/` for every pull request. Use a
+  user-facing category for product changes or an explicit `internal` fragment
+  with `user-facing: no` for maintenance that should not appear in release
+  notes. See [changes/README.md](changes/README.md) for the format.
 - Add regression tests for bug fixes and contract tests for API behavior.
 - Describe any server versions and apps tested without exposing account data.
 - Include screenshots for visible UI changes on the affected form factors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,10 +83,11 @@ bash tools/check-repository.sh
 Focused tests are useful while iterating, but the full suite must pass before a
 pull request is ready for review.
 
-Repository-authored text uses ordinary ASCII punctuation. Run
+Repository-authored text uses ordinary ASCII punctuation while allowing normal
+UTF-8 letters and translations. Run
 `bash tools/check-repository.sh` to catch smart quotes, typographic dashes,
 Unicode ellipses, Unicode minus signs, no-break spaces, and invisible
-formatting characters. Normal UTF-8 letters and translations remain supported.
+formatting characters.
 
 ### Isolated Android emulator tests
 

--- a/changes/README.md
+++ b/changes/README.md
@@ -10,7 +10,8 @@ Use a lowercase hyphenated filename that is unique to the change:
 changes/unreleased/218-raw-preview.md
 ```
 
-The format is strict and intentionally small:
+The format is strict and intentionally small. Use ordinary ASCII punctuation;
+normal UTF-8 letters remain valid for names and translated text:
 
 ```text
 category: feature

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,62 @@
+# Changelog fragments
+
+Every pull request that changes the repository adds one small fragment under
+`changes/unreleased/`. Separate files let concurrent changes record release
+history without editing the same `Unreleased` section in `CHANGELOG.md`.
+
+Use a lowercase hyphenated filename that is unique to the change:
+
+```text
+changes/unreleased/218-raw-preview.md
+```
+
+The format is strict and intentionally small:
+
+```text
+category: feature
+issue: 85
+pull: 218
+platforms: android, desktop
+user-facing: yes
+
+Standalone RAW photos can now open when the server has no generated preview.
+```
+
+Allowed categories are `feature`, `fix`, `platform`, `docs`, and `internal`.
+Allowed platforms are `all`, `android`, `desktop`, `ios`, `linux`, `macos`,
+`website`, and `windows`. Use `none` when either the issue or pull request does
+not exist, but always provide at least one positive reference.
+
+Internal maintenance still needs a fragment so automation does not have to
+guess whether a missing entry was intentional:
+
+```text
+category: internal
+issue: 103
+pull: none
+platforms: all
+user-facing: no
+
+Repository checks now validate independent changelog fragments.
+```
+
+Validate and preview the current entries without modifying the repository:
+
+```bash
+node tools/changelog-fragments.mjs validate
+node tools/changelog-fragments.mjs render
+```
+
+At release time, prepare a concise draft from the same entries used by the
+website:
+
+```bash
+node tools/changelog-fragments.mjs prepare-release \
+  --version 0.2.0-alpha.1 \
+  --output docs/release-notes/0.2.0-alpha.1.md
+```
+
+Review and curate the generated draft, especially its known limitations. Then
+move the included fragments to `changes/archive/<version>/` and copy the
+rendered categories into the new version section of `CHANGELOG.md`. The
+published changelog remains immutable; only unreleased fragments are live.

--- a/changes/unreleased/103-changelog-fragments.md
+++ b/changes/unreleased/103-changelog-fragments.md
@@ -1,0 +1,7 @@
+category: internal
+issue: 103
+pull: none
+platforms: all
+user-facing: no
+
+Repository checks now validate independent changelog fragments and prepare release history from one source.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -27,14 +27,30 @@ candidates. Each prerelease number is between 1 and 999.
 ## Creating a prerelease
 
 1. Update the three `ncVersion*` values in `gradle.properties`.
-2. Move the completed entries from `Unreleased` in `CHANGELOG.md` into a
-   versioned section and start a new empty `Unreleased` section.
-3. Add plain-language notes at `docs/release-notes/<version>.md`. Lead with
-   user-visible changes and known limitations; put implementation details last.
-4. Run `bash tools/test-prerelease-version.sh`.
-5. Merge the version change through the normal reviewed pull-request workflow.
-6. Create the matching tag, such as `v0.1.0-alpha.2`, from the intended commit.
-7. Push the tag.
+2. Prepare the release-note draft from the validated unreleased fragments:
+
+   ```bash
+   node tools/changelog-fragments.mjs prepare-release \
+     --version 0.2.0-alpha.1 \
+     --output docs/release-notes/0.2.0-alpha.1.md
+   ```
+
+3. Review and curate the draft. Lead with user-visible changes and add accurate
+   known limitations; do not expose implementation or workflow mechanics.
+4. Move the included files from `changes/unreleased/` to
+   `changes/archive/<version>/`.
+5. Copy the same rendered categories into a new versioned section in
+   `CHANGELOG.md`, leaving a new empty `Unreleased` section.
+6. Run `bash tools/test-prerelease-version.sh` and
+   `node tools/changelog-fragments.mjs validate`.
+7. Merge the version change through the normal reviewed pull-request workflow.
+8. Create the matching tag, such as `v0.2.0-alpha.1`, from the intended commit.
+9. Push the tag.
+
+The fragment files are the canonical source for changes since the previous
+release. Pull request titles are not scraped, and concurrent work does not edit
+the shared root changelog. Published `CHANGELOG.md` sections and archived
+fragments remain immutable.
 
 The protected `prerelease` GitHub environment should require approval. The
 workflow tests the source again, builds platform artifacts, verifies Android

--- a/tools/changelog-fragments.mjs
+++ b/tools/changelog-fragments.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+export const defaultRepositoryRoot = path.resolve(moduleDirectory, "..");
+
+export const categoryOrder = ["feature", "fix", "platform", "docs", "internal"];
+export const categoryHeadings = {
+  feature: "Features",
+  fix: "Fixes",
+  platform: "Platform",
+  docs: "Documentation",
+  internal: "Internal",
+};
+export const supportedPlatforms = [
+  "all",
+  "android",
+  "desktop",
+  "ios",
+  "linux",
+  "macos",
+  "website",
+  "windows",
+];
+
+const metadataKeys = ["category", "issue", "pull", "platforms", "user-facing"];
+const fragmentNamePattern = /^[a-z0-9][a-z0-9-]{1,79}\.md$/;
+const positiveIntegerPattern = /^[1-9][0-9]*$/;
+const archivedFragmentPattern =
+  /^changes\/archive\/0\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[1-9][0-9]*\/[a-z0-9][a-z0-9-]*\.md$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseReference(value, field, relativePath) {
+  if (value === "none") return null;
+  if (!positiveIntegerPattern.test(value)) {
+    fail(`${relativePath}: ${field} must be a positive integer or "none".`);
+  }
+  const reference = Number(value);
+  if (!Number.isSafeInteger(reference)) {
+    fail(`${relativePath}: ${field} is larger than a safe integer.`);
+  }
+  return reference;
+}
+
+function assertAscii(value, relativePath) {
+  for (const character of value) {
+    if (character.codePointAt(0) > 0x7f) {
+      fail(`${relativePath}: fragments must use ASCII text only.`);
+    }
+  }
+}
+
+export function parseFragment(source, relativePath = "fragment.md") {
+  assertAscii(source, relativePath);
+  if (source.includes("\r")) {
+    fail(`${relativePath}: use LF line endings.`);
+  }
+  if (!source.endsWith("\n")) {
+    fail(`${relativePath}: the file must end with a newline.`);
+  }
+
+  const separator = source.indexOf("\n\n");
+  if (separator < 0) {
+    fail(`${relativePath}: add one blank line between metadata and summary.`);
+  }
+  const metadataLines = source.slice(0, separator).split("\n");
+  const summary = source.slice(separator + 2).trim();
+  const metadata = new Map();
+
+  for (const line of metadataLines) {
+    const match = /^([a-z-]+): (.+)$/.exec(line);
+    if (!match) {
+      fail(`${relativePath}: invalid metadata line "${line}".`);
+    }
+    const [, key, value] = match;
+    if (!metadataKeys.includes(key)) {
+      fail(`${relativePath}: unknown metadata key "${key}".`);
+    }
+    if (metadata.has(key)) {
+      fail(`${relativePath}: duplicate metadata key "${key}".`);
+    }
+    metadata.set(key, value);
+  }
+
+  const actualKeys = [...metadata.keys()];
+  if (
+    actualKeys.length !== metadataKeys.length ||
+    actualKeys.some((key, index) => key !== metadataKeys[index])
+  ) {
+    fail(
+      `${relativePath}: metadata keys must appear once in this order: ${metadataKeys.join(", ")}.`,
+    );
+  }
+
+  const category = metadata.get("category");
+  if (!categoryOrder.includes(category)) {
+    fail(
+      `${relativePath}: category must be one of ${categoryOrder.join(", ")}.`,
+    );
+  }
+
+  const issue = parseReference(metadata.get("issue"), "issue", relativePath);
+  const pull = parseReference(metadata.get("pull"), "pull", relativePath);
+  if (issue === null && pull === null) {
+    fail(`${relativePath}: provide an issue or pull request reference.`);
+  }
+
+  const platforms = metadata.get("platforms").split(", ");
+  if (
+    platforms.length === 0 ||
+    platforms.some((platform) => !supportedPlatforms.includes(platform))
+  ) {
+    fail(
+      `${relativePath}: platforms must use ${supportedPlatforms.join(", ")}.`,
+    );
+  }
+  if (new Set(platforms).size !== platforms.length) {
+    fail(`${relativePath}: platforms must not contain duplicates.`);
+  }
+  if (platforms.includes("all") && platforms.length !== 1) {
+    fail(`${relativePath}: "all" cannot be combined with another platform.`);
+  }
+  const sortedPlatforms = [...platforms].sort(
+    (left, right) =>
+      supportedPlatforms.indexOf(left) - supportedPlatforms.indexOf(right),
+  );
+  if (platforms.some((platform, index) => platform !== sortedPlatforms[index])) {
+    fail(
+      `${relativePath}: platforms must follow this order: ${supportedPlatforms.join(", ")}.`,
+    );
+  }
+
+  const userFacingValue = metadata.get("user-facing");
+  if (!["yes", "no"].includes(userFacingValue)) {
+    fail(`${relativePath}: user-facing must be "yes" or "no".`);
+  }
+  const userFacing = userFacingValue === "yes";
+  if (category === "internal" && userFacing) {
+    fail(`${relativePath}: internal fragments must use user-facing: no.`);
+  }
+  if (category !== "internal" && !userFacing) {
+    fail(
+      `${relativePath}: non-internal fragments must use user-facing: yes.`,
+    );
+  }
+
+  if (summary.includes("\n")) {
+    fail(`${relativePath}: summary must be one paragraph on one line.`);
+  }
+  if (summary.length < 20 || summary.length > 240) {
+    fail(`${relativePath}: summary must contain between 20 and 240 characters.`);
+  }
+  if (!/^[A-Z0-9]/.test(summary)) {
+    fail(`${relativePath}: summary must start with an uppercase letter or number.`);
+  }
+  if (!/[.!?]$/.test(summary)) {
+    fail(`${relativePath}: summary must end with punctuation.`);
+  }
+
+  return {
+    category,
+    issue,
+    pull,
+    platforms,
+    relativePath,
+    summary,
+    userFacing,
+  };
+}
+
+async function walkMarkdownFiles(directory, repositoryRoot) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  }
+
+  const files = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkMarkdownFiles(absolutePath, repositoryRoot)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      if (!fragmentNamePattern.test(entry.name)) {
+        fail(
+          `${path.relative(repositoryRoot, absolutePath)}: use a lowercase hyphenated fragment filename.`,
+        );
+      }
+      files.push(absolutePath);
+    }
+  }
+  return files;
+}
+
+export async function loadFragments(
+  repositoryRoot = defaultRepositoryRoot,
+  { includeArchive = false } = {},
+) {
+  const changesRoot = path.join(repositoryRoot, "changes");
+  const directories = [path.join(changesRoot, "unreleased")];
+  if (includeArchive) directories.push(path.join(changesRoot, "archive"));
+
+  const files = [];
+  for (const directory of directories) {
+    files.push(...(await walkMarkdownFiles(directory, repositoryRoot)));
+  }
+
+  const fragments = [];
+  for (const file of files.sort()) {
+    const relativePath = path.relative(repositoryRoot, file);
+    if (
+      relativePath.startsWith(`changes${path.sep}archive${path.sep}`) &&
+      !archivedFragmentPattern.test(relativePath.split(path.sep).join("/"))
+    ) {
+      fail(
+        `${relativePath}: archived fragments must be under changes/archive/<prerelease-version>/.`,
+      );
+    }
+    fragments.push(parseFragment(await readFile(file, "utf8"), relativePath));
+  }
+  return fragments;
+}
+
+function compareAscii(left, right) {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+export function sortFragments(fragments) {
+  return [...fragments].sort((left, right) => {
+    const categoryDifference =
+      categoryOrder.indexOf(left.category) - categoryOrder.indexOf(right.category);
+    if (categoryDifference !== 0) return categoryDifference;
+    const summaryDifference = compareAscii(left.summary, right.summary);
+    if (summaryDifference !== 0) return summaryDifference;
+    return compareAscii(left.relativePath, right.relativePath);
+  });
+}
+
+function contextSuffix(fragment) {
+  const links = [];
+  if (fragment.issue !== null) links.push(`issue #${fragment.issue}`);
+  if (fragment.pull !== null) links.push(`PR #${fragment.pull}`);
+  return links.length === 0 ? "" : ` (${links.join(", ")})`;
+}
+
+export function renderFragments(
+  fragments,
+  { headingLevel = 3, includeInternal = false, includeContext = true } = {},
+) {
+  const visible = sortFragments(fragments).filter(
+    (fragment) => includeInternal || fragment.userFacing,
+  );
+  const sections = [];
+
+  for (const category of categoryOrder) {
+    if (category === "internal" && !includeInternal) continue;
+    const entries = visible.filter((fragment) => fragment.category === category);
+    if (entries.length === 0) continue;
+    sections.push(`${"#".repeat(headingLevel)} ${categoryHeadings[category]}`);
+    sections.push("");
+    for (const fragment of entries) {
+      const suffix = includeContext ? contextSuffix(fragment) : "";
+      if (suffix) {
+        const punctuation = fragment.summary.at(-1);
+        const summary = fragment.summary.slice(0, -1);
+        sections.push(`- ${summary}${suffix}${punctuation}`);
+      } else {
+        sections.push(`- ${fragment.summary}`);
+      }
+    }
+    sections.push("");
+  }
+  return sections.join("\n").trimEnd();
+}
+
+export function composeChangelogSource(legacySource, fragments) {
+  const rendered = renderFragments(fragments, {
+    headingLevel: 3,
+    includeContext: true,
+  });
+  const unreleased = rendered
+    ? `## Unreleased\n\n${rendered}`
+    : "## Unreleased";
+
+  const unreleasedMatch = /^## Unreleased\s*$/m.exec(legacySource);
+  if (!unreleasedMatch) {
+    fail("CHANGELOG.md must contain an Unreleased section.");
+  }
+  const sectionStart = unreleasedMatch.index;
+  const contentStart = sectionStart + unreleasedMatch[0].length;
+  const nextSectionMatch = /^## (?!Unreleased\b).+$/m.exec(
+    legacySource.slice(contentStart),
+  );
+  const sectionEnd = nextSectionMatch
+    ? contentStart + nextSectionMatch.index
+    : legacySource.length;
+  const prefix = legacySource.slice(0, sectionStart).trimEnd();
+  const suffix = legacySource.slice(sectionEnd).trimStart();
+  return `${prefix}\n\n${unreleased}\n\n${suffix}`.trimEnd() + "\n";
+}
+
+export function composeReleaseNotes(version, fragments) {
+  if (!/^0\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[1-9][0-9]*$/.test(version)) {
+    fail(
+      "Release version must use 0.x.y-alpha.n, 0.x.y-beta.n, or 0.x.y-rc.n.",
+    );
+  }
+  const body = renderFragments(fragments, {
+    headingLevel: 2,
+    includeContext: false,
+  });
+  if (!body) fail("No user-facing unreleased fragments are available.");
+  return [
+    `# Nextcloud Native ${version}`,
+    "",
+    body,
+    "",
+    "## Known limitations",
+    "",
+    "<!-- Curate limitations before publishing. -->",
+    "",
+  ].join("\n");
+}
+
+async function gitChangedFiles(repositoryRoot, base, head) {
+  const { stdout } = await execFileAsync(
+    "git",
+    ["diff", "--name-status", "--find-renames", `${base}..${head}`],
+    { cwd: repositoryRoot, maxBuffer: 1024 * 1024 },
+  );
+  return stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const fields = line.split("\t");
+      const status = fields[0][0];
+      const file = fields.at(-1);
+      return { file, status };
+    });
+}
+
+export async function checkDiffHasFragment(
+  repositoryRoot,
+  base,
+  head = "HEAD",
+) {
+  const changed = await gitChangedFiles(repositoryRoot, base, head);
+  const substantive = changed.filter(
+    ({ file }) => !file.startsWith("changes/"),
+  );
+  if (substantive.length === 0) return;
+
+  const fragments = changed.filter(
+    ({ file, status }) =>
+      status !== "D" &&
+      /^changes\/(unreleased|archive\/[^/]+)\/[a-z0-9][a-z0-9-]*\.md$/.test(
+        file,
+      ),
+  );
+  if (fragments.length === 0) {
+    fail(
+      "This change needs a changelog fragment. Add a user-facing fragment or an explicit internal fragment under changes/unreleased/.",
+    );
+  }
+}
+
+function argumentValue(args, name, fallback = undefined) {
+  const index = args.indexOf(name);
+  if (index < 0) return fallback;
+  if (index + 1 >= args.length) fail(`${name} requires a value.`);
+  return args[index + 1];
+}
+
+async function runCli() {
+  const [, , command, ...args] = process.argv;
+  const repositoryRoot = path.resolve(
+    argumentValue(args, "--root", defaultRepositoryRoot),
+  );
+
+  if (command === "validate") {
+    const fragments = await loadFragments(repositoryRoot, { includeArchive: true });
+    process.stdout.write(`Validated ${fragments.length} changelog fragments.\n`);
+    return;
+  }
+
+  if (command === "render") {
+    const fragments = await loadFragments(repositoryRoot);
+    const rendered = renderFragments(fragments, {
+      headingLevel: 3,
+      includeInternal: args.includes("--include-internal"),
+      includeContext: !args.includes("--without-context"),
+    });
+    process.stdout.write(`${rendered}\n`);
+    return;
+  }
+
+  if (command === "prepare-release") {
+    const version = argumentValue(args, "--version");
+    if (!version) fail("prepare-release requires --version.");
+    const fragments = await loadFragments(repositoryRoot);
+    const notes = composeReleaseNotes(version, fragments);
+    const output = argumentValue(args, "--output");
+    if (output) {
+      await writeFile(path.resolve(repositoryRoot, output), notes, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      process.stdout.write(`Wrote ${output}.\n`);
+    } else {
+      process.stdout.write(notes);
+    }
+    return;
+  }
+
+  if (command === "check-diff") {
+    const base = argumentValue(args, "--base");
+    if (!base) fail("check-diff requires --base.");
+    const head = argumentValue(args, "--head", "HEAD");
+    await checkDiffHasFragment(repositoryRoot, base, head);
+    process.stdout.write("Changelog fragment diff check passed.\n");
+    return;
+  }
+
+  fail(
+    "Usage: changelog-fragments.mjs <validate|render|prepare-release|check-diff> [options]",
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runCli().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/changelog-fragments.mjs
+++ b/tools/changelog-fragments.mjs
@@ -51,16 +51,21 @@ function parseReference(value, field, relativePath) {
   return reference;
 }
 
-function assertAscii(value, relativePath) {
+function assertPlainText(value, relativePath) {
   for (const character of value) {
-    if (character.codePointAt(0) > 0x7f) {
-      fail(`${relativePath}: fragments must use ASCII text only.`);
+    const codepoint = character.codePointAt(0);
+    if (
+      codepoint === 0x00 ||
+      (codepoint < 0x20 && character !== "\n") ||
+      codepoint === 0x7f
+    ) {
+      fail(`${relativePath}: fragments must not contain control characters.`);
     }
   }
 }
 
 export function parseFragment(source, relativePath = "fragment.md") {
-  assertAscii(source, relativePath);
+  assertPlainText(source, relativePath);
   if (source.includes("\r")) {
     fail(`${relativePath}: use LF line endings.`);
   }
@@ -255,6 +260,22 @@ function contextSuffix(fragment) {
   return links.length === 0 ? "" : ` (${links.join(", ")})`;
 }
 
+const platformLabels = {
+  android: "Android",
+  desktop: "Desktop",
+  ios: "iOS",
+  linux: "Linux",
+  macos: "macOS",
+  website: "Website",
+  windows: "Windows",
+};
+
+function platformPrefix(fragment) {
+  if (fragment.platforms.includes("all")) return "";
+  const labels = fragment.platforms.map((platform) => platformLabels[platform]);
+  return `[${labels.join(", ")}] `;
+}
+
 export function renderFragments(
   fragments,
   { headingLevel = 3, includeInternal = false, includeContext = true } = {},
@@ -272,12 +293,13 @@ export function renderFragments(
     sections.push("");
     for (const fragment of entries) {
       const suffix = includeContext ? contextSuffix(fragment) : "";
+      const prefix = platformPrefix(fragment);
       if (suffix) {
         const punctuation = fragment.summary.at(-1);
         const summary = fragment.summary.slice(0, -1);
-        sections.push(`- ${summary}${suffix}${punctuation}`);
+        sections.push(`- ${prefix}${summary}${suffix}${punctuation}`);
       } else {
-        sections.push(`- ${fragment.summary}`);
+        sections.push(`- ${prefix}${fragment.summary}`);
       }
     }
     sections.push("");
@@ -348,7 +370,11 @@ async function gitChangedFiles(repositoryRoot, base, head) {
       const fields = line.split("\t");
       const status = fields[0][0];
       const file = fields.at(-1);
-      return { file, status };
+      const sourceFile =
+        (status === "R" || status === "C") && fields.length >= 3
+          ? fields[1]
+          : null;
+      return { file, sourceFile, status };
     });
 }
 
@@ -358,6 +384,25 @@ export async function checkDiffHasFragment(
   head = "HEAD",
 ) {
   const changed = await gitChangedFiles(repositoryRoot, base, head);
+  const archiveChanges = changed.filter(
+    ({ file, sourceFile }) =>
+      file.startsWith("changes/archive/") ||
+      sourceFile?.startsWith("changes/archive/"),
+  );
+  for (const change of archiveChanges) {
+    const permittedReleaseMove =
+      change.status === "R" &&
+      change.sourceFile !== null &&
+      /^changes\/unreleased\/[a-z0-9][a-z0-9-]*\.md$/.test(
+        change.sourceFile,
+      ) &&
+      archivedFragmentPattern.test(change.file);
+    if (!permittedReleaseMove) {
+      fail(
+        `${change.file}: archived changelog fragments are immutable; only rename unreleased fragments into a version archive.`,
+      );
+    }
+  }
   const substantive = changed.filter(
     ({ file }) => !file.startsWith("changes/"),
   );

--- a/tools/changelog-fragments.mjs
+++ b/tools/changelog-fragments.mjs
@@ -34,6 +34,8 @@ const fragmentNamePattern = /^[a-z0-9][a-z0-9-]{1,79}\.md$/;
 const positiveIntegerPattern = /^[1-9][0-9]*$/;
 const archivedFragmentPattern =
   /^changes\/archive\/0\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[1-9][0-9]*\/[a-z0-9][a-z0-9-]*\.md$/;
+const prereleaseVersionPattern =
+  /^0\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[1-9][0-9]*$/;
 
 function fail(message) {
   throw new Error(message);
@@ -164,7 +166,7 @@ export function parseFragment(source, relativePath = "fragment.md") {
   if (summary.length < 20 || summary.length > 240) {
     fail(`${relativePath}: summary must contain between 20 and 240 characters.`);
   }
-  if (!/^[A-Z0-9]/.test(summary)) {
+  if (!/^(?:\p{Lu}|\p{Lt}|\p{N})/u.test(summary)) {
     fail(`${relativePath}: summary must start with an uppercase letter or number.`);
   }
   if (!/[.!?]$/.test(summary)) {
@@ -194,12 +196,16 @@ async function walkMarkdownFiles(directory, repositoryRoot) {
   const files = [];
   for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
     const absolutePath = path.join(directory, entry.name);
+    const relativePath = path.relative(repositoryRoot, absolutePath);
+    if (entry.isSymbolicLink() || (!entry.isDirectory() && !entry.isFile())) {
+      fail(`${relativePath}: changelog fragment entries must be regular files or directories.`);
+    }
     if (entry.isDirectory()) {
       files.push(...(await walkMarkdownFiles(absolutePath, repositoryRoot)));
     } else if (entry.isFile() && entry.name.endsWith(".md")) {
       if (!fragmentNamePattern.test(entry.name)) {
         fail(
-          `${path.relative(repositoryRoot, absolutePath)}: use a lowercase hyphenated fragment filename.`,
+          `${relativePath}: use a lowercase hyphenated fragment filename.`,
         );
       }
       files.push(absolutePath);
@@ -276,6 +282,15 @@ function platformPrefix(fragment) {
   return `[${labels.join(", ")}] `;
 }
 
+function renderFragmentEntry(fragment, includeContext) {
+  const suffix = includeContext ? contextSuffix(fragment) : "";
+  const prefix = platformPrefix(fragment);
+  if (!suffix) return `${prefix}${fragment.summary}`;
+  const punctuation = fragment.summary.at(-1);
+  const summary = fragment.summary.slice(0, -1);
+  return `${prefix}${summary}${suffix}${punctuation}`;
+}
+
 export function renderFragments(
   fragments,
   { headingLevel = 3, includeInternal = false, includeContext = true } = {},
@@ -292,15 +307,7 @@ export function renderFragments(
     sections.push(`${"#".repeat(headingLevel)} ${categoryHeadings[category]}`);
     sections.push("");
     for (const fragment of entries) {
-      const suffix = includeContext ? contextSuffix(fragment) : "";
-      const prefix = platformPrefix(fragment);
-      if (suffix) {
-        const punctuation = fragment.summary.at(-1);
-        const summary = fragment.summary.slice(0, -1);
-        sections.push(`- ${prefix}${summary}${suffix}${punctuation}`);
-      } else {
-        sections.push(`- ${prefix}${fragment.summary}`);
-      }
+      sections.push(`- ${renderFragmentEntry(fragment, includeContext)}`);
     }
     sections.push("");
   }
@@ -334,7 +341,7 @@ export function composeChangelogSource(legacySource, fragments) {
 }
 
 export function composeReleaseNotes(version, fragments) {
-  if (!/^0\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[1-9][0-9]*$/.test(version)) {
+  if (!prereleaseVersionPattern.test(version)) {
     fail(
       "Release version must use 0.x.y-alpha.n, 0.x.y-beta.n, or 0.x.y-rc.n.",
     );
@@ -354,6 +361,112 @@ export function composeReleaseNotes(version, fragments) {
     "<!-- Curate limitations before publishing. -->",
     "",
   ].join("\n");
+}
+
+function normalizeRenderedEntry(entry) {
+  return entry
+    .replace(/\s+/gu, " ")
+    .trim()
+    .replace(
+      /\s+\((?:issue #[0-9]+|PR #[0-9]+)(?:, (?:issue #[0-9]+|PR #[0-9]+))*\)([.!?])$/u,
+      "$1",
+    );
+}
+
+function extractRenderedEntries(source) {
+  const headings = new Set(Object.values(categoryHeadings));
+  const entries = [];
+  let inCategory = false;
+  let current = null;
+  const flush = () => {
+    if (current !== null) entries.push(normalizeRenderedEntry(current));
+    current = null;
+  };
+  for (const line of source.split("\n")) {
+    const heading = /^#{2,4}\s+(.+?)\s*$/u.exec(line);
+    if (heading) {
+      flush();
+      inCategory = headings.has(heading[1]);
+      continue;
+    }
+    if (!inCategory) continue;
+    if (line.startsWith("- ")) {
+      flush();
+      current = line.slice(2);
+    } else if (current !== null && line.trim()) {
+      current += ` ${line.trim()}`;
+    }
+  }
+  flush();
+  return entries;
+}
+
+async function readReleaseRecord(repositoryRoot, relativePath) {
+  try {
+    return await readFile(path.join(repositoryRoot, relativePath), "utf8");
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      fail(`${relativePath}: archived fragments require this immutable release record.`);
+    }
+    throw error;
+  }
+}
+
+function assertReleaseEntries(version, recordName, expected, actual) {
+  if (
+    expected.length !== actual.length ||
+    expected.some((entry, index) => entry !== actual[index])
+  ) {
+    fail(
+      `${recordName}: user-facing entries for ${version} do not match its archived fragments. ` +
+        `Expected ${JSON.stringify(expected)} but found ${JSON.stringify(actual)}.`,
+    );
+  }
+}
+
+export async function validateArchivedReleaseHistory(
+  repositoryRoot = defaultRepositoryRoot,
+  fragments = undefined,
+) {
+  const allFragments =
+    fragments ?? (await loadFragments(repositoryRoot, { includeArchive: true }));
+  const archivedByVersion = new Map();
+  for (const fragment of allFragments) {
+    const match = /^changes[\\/]archive[\\/]([^\\/]+)[\\/]/u.exec(
+      fragment.relativePath,
+    );
+    if (!match) continue;
+    const entries = archivedByVersion.get(match[1]) ?? [];
+    entries.push(fragment);
+    archivedByVersion.set(match[1], entries);
+  }
+  if (archivedByVersion.size === 0) return;
+
+  const changelogSource = await readReleaseRecord(repositoryRoot, "CHANGELOG.md");
+  const changelogSections = releasedChangelogSections(changelogSource);
+  for (const [version, archived] of [...archivedByVersion.entries()].sort()) {
+    const expected = sortFragments(archived)
+      .filter((fragment) => fragment.userFacing)
+      .map((fragment) => normalizeRenderedEntry(renderFragmentEntry(fragment, false)));
+    const changelogSection = changelogSections.get(version);
+    if (changelogSection === undefined) {
+      fail(`CHANGELOG.md: archived version ${version} needs a corresponding released section.`);
+    }
+    const releaseNotePath = `docs/release-notes/${version}.md`;
+    const releaseNote = await readReleaseRecord(repositoryRoot, releaseNotePath);
+    assertReleaseEntries(
+      version,
+      "CHANGELOG.md",
+      expected,
+      extractRenderedEntries(changelogSection),
+    );
+    assertReleaseEntries(
+      version,
+      releaseNotePath,
+      expected,
+      extractRenderedEntries(releaseNote),
+    );
+  }
 }
 
 async function gitChangedFiles(repositoryRoot, base, head) {
@@ -378,26 +491,141 @@ async function gitChangedFiles(repositoryRoot, base, head) {
     });
 }
 
+function releasedChangelogSections(source) {
+  const sections = new Map();
+  const matches = [
+    ...source.matchAll(
+      /^## \[(0\.[0-9]+\.[0-9]+-(?:alpha|beta|rc)\.[1-9][0-9]*)\]\s*$/gm,
+    ),
+  ];
+  for (const [index, match] of matches.entries()) {
+    const start = match.index;
+    const end = matches[index + 1]?.index ?? source.length;
+    sections.set(match[1], source.slice(start, end).trimEnd());
+  }
+  return sections;
+}
+
+async function gitFileAtRevision(repositoryRoot, revision, relativePath) {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["show", `${revision}:${relativePath}`],
+      { cwd: repositoryRoot, maxBuffer: 4 * 1024 * 1024 },
+    );
+    return stdout;
+  } catch (error) {
+    if (error.code === 128 || error.stderr?.includes("does not exist")) return null;
+    throw error;
+  }
+}
+
+async function protectImmutableReleaseHistory(
+  repositoryRoot,
+  base,
+  head,
+  changed,
+) {
+  const releaseMoves = changed.filter(isPermittedReleaseMove);
+  const releaseVersions = new Set(
+    releaseMoves.map(({ file }) => file.split("/")[2]),
+  );
+  if (releaseVersions.size > 1) {
+    fail("Release preparation may archive fragments for only one new version.");
+  }
+  const noteChanges = changed.filter(
+    ({ file, sourceFile }) =>
+      file.startsWith("docs/release-notes/") ||
+      sourceFile?.startsWith("docs/release-notes/"),
+  );
+  for (const change of noteChanges) {
+    if (change.status !== "A") {
+      fail(
+        `${change.file}: existing release-note files are immutable; release preparation may add one new version file.`,
+      );
+    }
+  }
+  if (noteChanges.filter(({ status }) => status === "A").length > 1) {
+    fail("Release preparation may add only one new release-note file.");
+  }
+  const addedNotes = noteChanges.filter(({ status }) => status === "A");
+  if (addedNotes.length > 0 && releaseMoves.length === 0) {
+    fail("A new release-note file requires archived unreleased fragments in the same change.");
+  }
+
+  const changelogChange = changed.find(
+    ({ file, sourceFile }) => file === "CHANGELOG.md" || sourceFile === "CHANGELOG.md",
+  );
+  if (!changelogChange) {
+    if (releaseMoves.length > 0) {
+      fail("Release preparation must add the matching CHANGELOG.md version section.");
+    }
+    return;
+  }
+  if (changelogChange.status === "D" || changelogChange.file !== "CHANGELOG.md") {
+    fail("CHANGELOG.md and its released sections are immutable and cannot be deleted or renamed.");
+  }
+  const baseSource = await gitFileAtRevision(repositoryRoot, base, "CHANGELOG.md");
+  const headSource = await gitFileAtRevision(repositoryRoot, head, "CHANGELOG.md");
+  if (baseSource === null || headSource === null) {
+    fail("CHANGELOG.md must exist at both revisions.");
+  }
+  const baseSections = releasedChangelogSections(baseSource);
+  const headSections = releasedChangelogSections(headSource);
+  for (const [version, section] of baseSections) {
+    if (headSections.get(version) !== section) {
+      fail(`CHANGELOG.md: released section ${version} is immutable.`);
+    }
+  }
+  const addedVersions = [...headSections.keys()].filter(
+    (version) => !baseSections.has(version),
+  );
+  if (addedVersions.length > 1) {
+    fail("Release preparation may add only one new CHANGELOG.md version section.");
+  }
+  if (addedVersions.length > 0 && releaseMoves.length === 0) {
+    fail("A new CHANGELOG.md version section requires archived unreleased fragments.");
+  }
+  if (releaseMoves.length > 0) {
+    const [releaseVersion] = releaseVersions;
+    if (
+      addedVersions.length !== 1 ||
+      addedVersions[0] !== releaseVersion ||
+      addedNotes.length !== 1 ||
+      addedNotes[0].file !== `docs/release-notes/${releaseVersion}.md`
+    ) {
+      fail(
+        `Release preparation for ${releaseVersion} must add its matching CHANGELOG.md section and release-note file.`,
+      );
+    }
+  }
+}
+
+function isPermittedReleaseMove(change) {
+  return (
+    change.status === "R" &&
+    change.sourceFile !== null &&
+    /^changes\/unreleased\/[a-z0-9][a-z0-9-]*\.md$/.test(
+      change.sourceFile,
+    ) &&
+    archivedFragmentPattern.test(change.file)
+  );
+}
+
 export async function checkDiffHasFragment(
   repositoryRoot,
   base,
   head = "HEAD",
 ) {
   const changed = await gitChangedFiles(repositoryRoot, base, head);
+  await protectImmutableReleaseHistory(repositoryRoot, base, head, changed);
   const archiveChanges = changed.filter(
     ({ file, sourceFile }) =>
       file.startsWith("changes/archive/") ||
       sourceFile?.startsWith("changes/archive/"),
   );
   for (const change of archiveChanges) {
-    const permittedReleaseMove =
-      change.status === "R" &&
-      change.sourceFile !== null &&
-      /^changes\/unreleased\/[a-z0-9][a-z0-9-]*\.md$/.test(
-        change.sourceFile,
-      ) &&
-      archivedFragmentPattern.test(change.file);
-    if (!permittedReleaseMove) {
+    if (!isPermittedReleaseMove(change)) {
       fail(
         `${change.file}: archived changelog fragments are immutable; only rename unreleased fragments into a version archive.`,
       );
@@ -408,16 +636,15 @@ export async function checkDiffHasFragment(
   );
   if (substantive.length === 0) return;
 
-  const fragments = changed.filter(
+  const addedFragments = changed.filter(
     ({ file, status }) =>
-      status !== "D" &&
-      /^changes\/(unreleased|archive\/[^/]+)\/[a-z0-9][a-z0-9-]*\.md$/.test(
-        file,
-      ),
+      status === "A" &&
+      /^changes\/unreleased\/[a-z0-9][a-z0-9-]*\.md$/.test(file),
   );
-  if (fragments.length === 0) {
+  const releaseMoves = archiveChanges.filter(isPermittedReleaseMove);
+  if (addedFragments.length === 0 && releaseMoves.length === 0) {
     fail(
-      "This change needs a changelog fragment. Add a user-facing fragment or an explicit internal fragment under changes/unreleased/.",
+      "This change needs a newly added changelog fragment. Add a user-facing fragment or an explicit internal fragment under changes/unreleased/.",
     );
   }
 }
@@ -437,6 +664,7 @@ async function runCli() {
 
   if (command === "validate") {
     const fragments = await loadFragments(repositoryRoot, { includeArchive: true });
+    await validateArchivedReleaseHistory(repositoryRoot, fragments);
     process.stdout.write(`Validated ${fragments.length} changelog fragments.\n`);
     return;
   }

--- a/tools/changelog-fragments.test.mjs
+++ b/tools/changelog-fragments.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import {
+  checkDiffHasFragment,
+  composeChangelogSource,
+  composeReleaseNotes,
+  loadFragments,
+  parseFragment,
+  renderFragments,
+} from "./changelog-fragments.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function fragment(overrides = {}) {
+  const values = {
+    category: "feature",
+    issue: "42",
+    pull: "none",
+    platforms: "android, desktop",
+    userFacing: "yes",
+    summary: "Native collections now provide a focused list and detail workspace.",
+    ...overrides,
+  };
+  return [
+    `category: ${values.category}`,
+    `issue: ${values.issue}`,
+    `pull: ${values.pull}`,
+    `platforms: ${values.platforms}`,
+    `user-facing: ${values.userFacing}`,
+    "",
+    values.summary,
+    "",
+  ].join("\n");
+}
+
+test("strict fragment metadata parses into a stable record", () => {
+  assert.deepEqual(parseFragment(fragment(), "changes/unreleased/42.md"), {
+    category: "feature",
+    issue: 42,
+    pull: null,
+    platforms: ["android", "desktop"],
+    relativePath: "changes/unreleased/42.md",
+    summary: "Native collections now provide a focused list and detail workspace.",
+    userFacing: true,
+  });
+});
+
+test("internal work requires an explicit no-user-facing marker", () => {
+  assert.throws(
+    () =>
+      parseFragment(
+        fragment({ category: "internal", userFacing: "yes" }),
+        "changes/unreleased/internal.md",
+      ),
+    /internal fragments must use user-facing: no/,
+  );
+  const parsed = parseFragment(
+    fragment({
+      category: "internal",
+      userFacing: "no",
+      summary: "Repository checks now validate independent changelog fragments.",
+    }),
+  );
+  assert.equal(parsed.userFacing, false);
+});
+
+test("rendering is deterministic and omits internal implementation records", () => {
+  const feature = parseFragment(fragment(), "changes/unreleased/z-feature.md");
+  const fix = parseFragment(
+    fragment({
+      category: "fix",
+      issue: "none",
+      pull: "8",
+      platforms: "all",
+      summary: "Account switching now preserves the selected workspace.",
+    }),
+    "changes/unreleased/a-fix.md",
+  );
+  const internal = parseFragment(
+    fragment({
+      category: "internal",
+      issue: "9",
+      platforms: "all",
+      userFacing: "no",
+      summary: "Repository checks now validate independent changelog fragments.",
+    }),
+    "changes/unreleased/internal.md",
+  );
+  assert.equal(
+    renderFragments([internal, fix, feature]),
+    [
+      "### Features",
+      "",
+      "- Native collections now provide a focused list and detail workspace (issue #42).",
+      "",
+      "### Fixes",
+      "",
+      "- Account switching now preserves the selected workspace (PR #8).",
+    ].join("\n"),
+  );
+});
+
+test("website changelog composition replaces only the live Unreleased section", () => {
+  const legacy = [
+    "# Changelog",
+    "",
+    "History.",
+    "",
+    "## Unreleased",
+    "",
+    "Old generated text.",
+    "",
+    "## [0.1.0-alpha.1]",
+    "",
+    "### Added",
+    "",
+    "- First preview.",
+    "",
+  ].join("\n");
+  const parsed = parseFragment(fragment(), "changes/unreleased/42.md");
+  const composed = composeChangelogSource(legacy, [parsed]);
+  assert.match(composed, /## Unreleased\n\n### Features/);
+  assert.doesNotMatch(composed, /Old generated text/);
+  assert.match(composed, /## \[0\.1\.0-alpha\.1\]/);
+});
+
+test("release note preparation shares the user-facing aggregation", () => {
+  const parsed = parseFragment(fragment(), "changes/unreleased/42.md");
+  const notes = composeReleaseNotes("0.2.0-alpha.1", [parsed]);
+  assert.match(notes, /^# Nextcloud Native 0\.2\.0-alpha\.1/m);
+  assert.match(notes, /^## Features$/m);
+  assert.doesNotMatch(notes, /issue #42/);
+  assert.match(notes, /^## Known limitations$/m);
+});
+
+test("loading validates archived and unreleased fragments", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nc-native-changes-"));
+  try {
+    await mkdir(path.join(root, "changes", "unreleased"), { recursive: true });
+    await mkdir(path.join(root, "changes", "archive", "0.1.0-alpha.1"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(root, "changes", "unreleased", "42-feature.md"),
+      fragment(),
+    );
+    await writeFile(
+      path.join(
+        root,
+        "changes",
+        "archive",
+        "0.1.0-alpha.1",
+        "8-fix.md",
+      ),
+      fragment({
+        category: "fix",
+        issue: "none",
+        pull: "8",
+        platforms: "all",
+        summary: "The first preview now opens without duplicate navigation.",
+      }),
+    );
+    assert.equal((await loadFragments(root)).length, 1);
+    assert.equal(
+      (await loadFragments(root, { includeArchive: true })).length,
+      2,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("diff enforcement accepts a fragment and rejects unrecorded work", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nc-native-diff-"));
+  try {
+    await execFileAsync("git", ["init", "-q"], { cwd: root });
+    await execFileAsync("git", ["config", "user.name", "Test"], { cwd: root });
+    await execFileAsync("git", ["config", "user.email", "test@example.invalid"], {
+      cwd: root,
+    });
+    await writeFile(path.join(root, "app.txt"), "one\n");
+    await execFileAsync("git", ["add", "app.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "base"], { cwd: root });
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+    });
+    const base = stdout.trim();
+
+    await writeFile(path.join(root, "app.txt"), "two\n");
+    await execFileAsync("git", ["add", "app.txt"], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "change"], { cwd: root });
+    await assert.rejects(
+      checkDiffHasFragment(root, base),
+      /needs a changelog fragment/,
+    );
+
+    await mkdir(path.join(root, "changes", "unreleased"), { recursive: true });
+    await writeFile(
+      path.join(root, "changes", "unreleased", "42-feature.md"),
+      fragment(),
+    );
+    await execFileAsync("git", ["add", "changes"], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "fragment"], { cwd: root });
+    await checkDiffHasFragment(root, base);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/changelog-fragments.test.mjs
+++ b/tools/changelog-fragments.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -9,9 +9,11 @@ import {
   checkDiffHasFragment,
   composeChangelogSource,
   composeReleaseNotes,
+  defaultRepositoryRoot,
   loadFragments,
   parseFragment,
   renderFragments,
+  validateArchivedReleaseHistory,
 } from "./changelog-fragments.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -58,6 +60,25 @@ test("normal UTF-8 letters are accepted while control characters are rejected", 
     "changes/unreleased/localized.md",
   );
   assert.equal(localized.summary.includes("ge\u00ebxporteerde"), true);
+  assert.equal(
+    parseFragment(
+      fragment({
+        summary: "\u00c9\u00e9n overzicht toont nu alle gesynchroniseerde mappen.",
+      }),
+      "changes/unreleased/localized-start.md",
+    ).summary.startsWith("\u00c9"),
+    true,
+  );
+  assert.throws(
+    () =>
+      parseFragment(
+        fragment({
+          summary: "\u00e9\u00e9n overzicht begint niet met een hoofdletter.",
+        }),
+        "changes/unreleased/lowercase-start.md",
+      ),
+    /must start with an uppercase letter or number/,
+  );
   assert.throws(
     () =>
       parseFragment(
@@ -159,6 +180,23 @@ test("release note preparation shares the user-facing aggregation", () => {
   assert.match(notes, /^## Known limitations$/m);
 });
 
+test("contributor Node.js guidance matches the website engine exactly", async () => {
+  const packageMetadata = JSON.parse(
+    await readFile(
+      path.join(defaultRepositoryRoot, "website", "package.json"),
+      "utf8",
+    ),
+  );
+  const contributing = await readFile(
+    path.join(defaultRepositoryRoot, "CONTRIBUTING.md"),
+    "utf8",
+  );
+  assert.equal(
+    contributing.includes(`Node.js \`${packageMetadata.engines.node}\``),
+    true,
+  );
+});
+
 test("loading validates archived and unreleased fragments", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "nc-native-changes-"));
   try {
@@ -196,6 +234,22 @@ test("loading validates archived and unreleased fragments", async () => {
   }
 });
 
+test("loading rejects symlinks and other non-regular fragment entries", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nc-native-symlink-"));
+  try {
+    const unreleased = path.join(root, "changes", "unreleased");
+    await mkdir(unreleased, { recursive: true });
+    await writeFile(path.join(root, "outside.md"), fragment());
+    await symlink(path.join(root, "outside.md"), path.join(unreleased, "42-feature.md"));
+    await assert.rejects(
+      loadFragments(root),
+      /fragment entries must be regular files or directories/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("diff enforcement accepts a fragment and rejects unrecorded work", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "nc-native-diff-"));
   try {
@@ -217,7 +271,7 @@ test("diff enforcement accepts a fragment and rejects unrecorded work", async ()
     await execFileAsync("git", ["commit", "-qm", "change"], { cwd: root });
     await assert.rejects(
       checkDiffHasFragment(root, base),
-      /needs a changelog fragment/,
+      /needs a newly added changelog fragment/,
     );
 
     await mkdir(path.join(root, "changes", "unreleased"), { recursive: true });
@@ -225,9 +279,50 @@ test("diff enforcement accepts a fragment and rejects unrecorded work", async ()
       path.join(root, "changes", "unreleased", "42-feature.md"),
       fragment(),
     );
-    await execFileAsync("git", ["add", "changes"], { cwd: root });
+    await execFileAsync("git", ["add", "."], { cwd: root });
     await execFileAsync("git", ["commit", "-qm", "fragment"], { cwd: root });
     await checkDiffHasFragment(root, base);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("diff enforcement requires an added unreleased fragment", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nc-native-added-fragment-"));
+  try {
+    await execFileAsync("git", ["init", "-q"], { cwd: root });
+    await execFileAsync("git", ["config", "user.name", "Test"], { cwd: root });
+    await execFileAsync("git", ["config", "user.email", "test@example.invalid"], {
+      cwd: root,
+    });
+    await mkdir(path.join(root, "changes", "unreleased"), { recursive: true });
+    await writeFile(path.join(root, "app.txt"), "one\n");
+    await writeFile(
+      path.join(root, "changes", "unreleased", "42-feature.md"),
+      fragment(),
+    );
+    await execFileAsync("git", ["add", "."], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "base"], { cwd: root });
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+    });
+    const base = stdout.trim();
+
+    await writeFile(path.join(root, "app.txt"), "two\n");
+    await writeFile(
+      path.join(root, "changes", "unreleased", "42-feature.md"),
+      fragment({
+        summary: "Native collections now provide a revised list and detail workspace.",
+      }),
+    );
+    await execFileAsync("git", ["add", "."], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "modify old fragment"], {
+      cwd: root,
+    });
+    await assert.rejects(
+      checkDiffHasFragment(root, base),
+      /needs a newly added changelog fragment/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -264,7 +359,16 @@ test("diff enforcement protects archived fragments and permits release moves", a
     );
     const unreleased = path.join(root, "changes", "unreleased", "42-feature.md");
     await writeFile(unreleased, fragment());
-    await execFileAsync("git", ["add", "changes"], { cwd: root });
+    await mkdir(path.join(root, "docs", "release-notes"), { recursive: true });
+    await writeFile(
+      path.join(root, "CHANGELOG.md"),
+      "# Changelog\n\n## Unreleased\n\n## [0.1.0-alpha.1]\n\n### Fixes\n\n- First preview.\n",
+    );
+    await writeFile(
+      path.join(root, "docs", "release-notes", "0.1.0-alpha.1.md"),
+      "# Nextcloud Native 0.1.0-alpha.1\n\n## Fixes\n\n- First preview.\n",
+    );
+    await execFileAsync("git", ["add", "."], { cwd: root });
     await execFileAsync("git", ["commit", "-qm", "base"], { cwd: root });
     const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
       cwd: root,
@@ -307,10 +411,173 @@ test("diff enforcement protects archived fragments and permits release moves", a
       ],
       { cwd: root },
     );
+    await writeFile(
+      path.join(root, "CHANGELOG.md"),
+      [
+        "# Changelog",
+        "",
+        "## Unreleased",
+        "",
+        "## [0.2.0-alpha.1]",
+        "",
+        "### Features",
+        "",
+        "- Native collections now provide a focused list and detail workspace.",
+        "",
+        "## [0.1.0-alpha.1]",
+        "",
+        "### Fixes",
+        "",
+        "- First preview.",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(
+      path.join(root, "docs", "release-notes", "0.2.0-alpha.1.md"),
+      "# Nextcloud Native 0.2.0-alpha.1\n\n## Features\n\n- Native collections now provide a focused list and detail workspace.\n",
+    );
+    await execFileAsync("git", ["add", "."], { cwd: root });
     await execFileAsync("git", ["commit", "-qm", "archive release"], {
       cwd: root,
     });
     await checkDiffHasFragment(root, base);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("diff enforcement protects released changelog sections and release notes", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nc-native-release-history-"));
+  try {
+    await execFileAsync("git", ["init", "-q"], { cwd: root });
+    await execFileAsync("git", ["config", "user.name", "Test"], { cwd: root });
+    await execFileAsync("git", ["config", "user.email", "test@example.invalid"], {
+      cwd: root,
+    });
+    await mkdir(path.join(root, "changes", "unreleased"), { recursive: true });
+    await mkdir(path.join(root, "docs", "release-notes"), { recursive: true });
+    await writeFile(path.join(root, "app.txt"), "one\n");
+    await writeFile(
+      path.join(root, "CHANGELOG.md"),
+      "# Changelog\n\n## Unreleased\n\n## [0.1.0-alpha.1]\n\n### Features\n\n- First preview.\n",
+    );
+    await writeFile(
+      path.join(root, "docs", "release-notes", "0.1.0-alpha.1.md"),
+      "# Nextcloud Native 0.1.0-alpha.1\n\n## Features\n\n- First preview.\n",
+    );
+    await execFileAsync("git", ["add", "."], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "base"], { cwd: root });
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+    });
+    const base = stdout.trim();
+
+    await writeFile(path.join(root, "app.txt"), "two\n");
+    await writeFile(
+      path.join(root, "changes", "unreleased", "43-feature.md"),
+      fragment({ issue: "43" }),
+    );
+    await writeFile(
+      path.join(root, "CHANGELOG.md"),
+      "# Changelog\n\n## Unreleased\n\n## [0.1.0-alpha.1]\n\n### Features\n\n- Rewritten preview.\n",
+    );
+    await execFileAsync("git", ["add", "."], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "rewrite changelog"], {
+      cwd: root,
+    });
+    await assert.rejects(
+      checkDiffHasFragment(root, base),
+      /released section 0.1.0-alpha.1 is immutable/,
+    );
+
+    await execFileAsync("git", ["reset", "--hard", base], { cwd: root });
+    await mkdir(path.join(root, "changes", "unreleased"), { recursive: true });
+    await writeFile(path.join(root, "app.txt"), "two\n");
+    await writeFile(
+      path.join(root, "changes", "unreleased", "43-feature.md"),
+      fragment({ issue: "43" }),
+    );
+    await writeFile(
+      path.join(root, "docs", "release-notes", "0.1.0-alpha.1.md"),
+      "# Nextcloud Native 0.1.0-alpha.1\n\nChanged after release.\n",
+    );
+    await execFileAsync("git", ["add", "."], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "rewrite notes"], { cwd: root });
+    await assert.rejects(
+      checkDiffHasFragment(root, base),
+      /existing release-note files are immutable/,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("archived fragments reconcile with changelog and release notes", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nc-native-reconcile-"));
+  const version = "0.2.0-alpha.1";
+  const expected =
+    "[Android, Desktop] Native collections now provide a focused list and detail workspace.";
+  try {
+    const archive = path.join(root, "changes", "archive", version);
+    await mkdir(archive, { recursive: true });
+    await mkdir(path.join(root, "docs", "release-notes"), { recursive: true });
+    await writeFile(path.join(archive, "42-feature.md"), fragment());
+    const changelog = [
+      "# Changelog",
+      "",
+      "## Unreleased",
+      "",
+      `## [${version}]`,
+      "",
+      "### Features",
+      "",
+      `- ${expected.slice(0, -1)} (issue #42).`,
+      "",
+    ].join("\n");
+    await writeFile(path.join(root, "CHANGELOG.md"), changelog);
+    const releaseNotePath = path.join(
+      root,
+      "docs",
+      "release-notes",
+      `${version}.md`,
+    );
+    await writeFile(
+      releaseNotePath,
+      [
+        `# Nextcloud Native ${version}`,
+        "",
+        "## Features",
+        "",
+        `- ${expected}`,
+        "",
+        "## Known limitations",
+        "",
+        "- Testing build.",
+        "",
+      ].join("\n"),
+    );
+    await validateArchivedReleaseHistory(root);
+
+    await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## Unreleased\n");
+    await assert.rejects(
+      validateArchivedReleaseHistory(root),
+      /needs a corresponding released section/,
+    );
+    await writeFile(path.join(root, "CHANGELOG.md"), changelog);
+
+    await rm(releaseNotePath);
+    await assert.rejects(
+      validateArchivedReleaseHistory(root),
+      /archived fragments require this immutable release record/,
+    );
+    await writeFile(
+      releaseNotePath,
+      `# Nextcloud Native ${version}\n\n## Features\n\n- A different entry.\n`,
+    );
+    await assert.rejects(
+      validateArchivedReleaseHistory(root),
+      /release-notes.*do not match its archived fragments/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tools/changelog-fragments.test.mjs
+++ b/tools/changelog-fragments.test.mjs
@@ -50,6 +50,26 @@ test("strict fragment metadata parses into a stable record", () => {
   });
 });
 
+test("normal UTF-8 letters are accepted while control characters are rejected", () => {
+  const localized = parseFragment(
+    fragment({
+      summary: "Synchronisatie toont nu ge\u00ebxporteerde items in een overzicht.",
+    }),
+    "changes/unreleased/localized.md",
+  );
+  assert.equal(localized.summary.includes("ge\u00ebxporteerde"), true);
+  assert.throws(
+    () =>
+      parseFragment(
+        fragment({
+          summary: "A control character\u0007 is not valid changelog text.",
+        }),
+        "changes/unreleased/control.md",
+      ),
+    /must not contain control characters/,
+  );
+});
+
 test("internal work requires an explicit no-user-facing marker", () => {
   assert.throws(
     () =>
@@ -96,7 +116,7 @@ test("rendering is deterministic and omits internal implementation records", () 
     [
       "### Features",
       "",
-      "- Native collections now provide a focused list and detail workspace (issue #42).",
+      "- [Android, Desktop] Native collections now provide a focused list and detail workspace (issue #42).",
       "",
       "### Fixes",
       "",
@@ -134,6 +154,7 @@ test("release note preparation shares the user-facing aggregation", () => {
   const notes = composeReleaseNotes("0.2.0-alpha.1", [parsed]);
   assert.match(notes, /^# Nextcloud Native 0\.2\.0-alpha\.1/m);
   assert.match(notes, /^## Features$/m);
+  assert.match(notes, /\[Android, Desktop\]/);
   assert.doesNotMatch(notes, /issue #42/);
   assert.match(notes, /^## Known limitations$/m);
 });
@@ -206,6 +227,89 @@ test("diff enforcement accepts a fragment and rejects unrecorded work", async ()
     );
     await execFileAsync("git", ["add", "changes"], { cwd: root });
     await execFileAsync("git", ["commit", "-qm", "fragment"], { cwd: root });
+    await checkDiffHasFragment(root, base);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("diff enforcement protects archived fragments and permits release moves", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "nc-native-archive-diff-"));
+  try {
+    await execFileAsync("git", ["init", "-q"], { cwd: root });
+    await execFileAsync("git", ["config", "user.name", "Test"], { cwd: root });
+    await execFileAsync("git", ["config", "user.email", "test@example.invalid"], {
+      cwd: root,
+    });
+    await mkdir(path.join(root, "changes", "unreleased"), { recursive: true });
+    await mkdir(path.join(root, "changes", "archive", "0.1.0-alpha.1"), {
+      recursive: true,
+    });
+    const archived = path.join(
+      root,
+      "changes",
+      "archive",
+      "0.1.0-alpha.1",
+      "8-fix.md",
+    );
+    await writeFile(
+      archived,
+      fragment({
+        category: "fix",
+        issue: "none",
+        pull: "8",
+        platforms: "all",
+        summary: "The first preview now opens without duplicate navigation.",
+      }),
+    );
+    const unreleased = path.join(root, "changes", "unreleased", "42-feature.md");
+    await writeFile(unreleased, fragment());
+    await execFileAsync("git", ["add", "changes"], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "base"], { cwd: root });
+    const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+      cwd: root,
+    });
+    const base = stdout.trim();
+
+    await writeFile(
+      archived,
+      fragment({
+        category: "fix",
+        issue: "none",
+        pull: "8",
+        platforms: "all",
+        summary: "Published history was rewritten after the release shipped.",
+      }),
+    );
+    await execFileAsync("git", ["add", "changes"], { cwd: root });
+    await execFileAsync("git", ["commit", "-qm", "rewrite archive"], {
+      cwd: root,
+    });
+    await assert.rejects(
+      checkDiffHasFragment(root, base),
+      /archived changelog fragments are immutable/,
+    );
+
+    await execFileAsync("git", ["reset", "--hard", base], { cwd: root });
+    const releaseDirectory = path.join(
+      root,
+      "changes",
+      "archive",
+      "0.2.0-alpha.1",
+    );
+    await mkdir(releaseDirectory, { recursive: true });
+    await execFileAsync(
+      "git",
+      [
+        "mv",
+        "changes/unreleased/42-feature.md",
+        "changes/archive/0.2.0-alpha.1/42-feature.md",
+      ],
+      { cwd: root },
+    );
+    await execFileAsync("git", ["commit", "-qm", "archive release"], {
+      cwd: root,
+    });
     await checkDiffHasFragment(root, base);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/tools/check-repository.sh
+++ b/tools/check-repository.sh
@@ -18,6 +18,10 @@ if ! command -v rustc >/dev/null 2>&1; then
     printf 'Rust stable is required to run repository hygiene checks.\n' >&2
     exit 1
 fi
+if ! command -v node >/dev/null 2>&1; then
+    printf 'Node.js is required to validate changelog fragments.\n' >&2
+    exit 1
+fi
 
 temporary_directory="$(mktemp -d)"
 trap 'rm -rf -- "$temporary_directory"' EXIT
@@ -49,5 +53,7 @@ done
 
 bash tools/test-apksigner-certificate-parser.sh
 bash tools/test-build-jvm-criteria.sh
+node tools/changelog-fragments.mjs validate
+node --test tools/changelog-fragments.test.mjs
 
 printf 'Repository hygiene checks passed.\n'

--- a/website/README.md
+++ b/website/README.md
@@ -46,13 +46,15 @@ These surfaces intentionally serve different readers:
   boundaries, and UI wording current when the product changes.
 - per-version release notes are short installer-facing summaries and
   limitations under `/releases/`.
-- the dedicated `/changelog/` page renders the canonical root `CHANGELOG.md` as
-  concise chronological Added, Changed, Fixed, and Security records.
+- `changes/unreleased/*.md` provides the live user-facing entries contributed
+  by individual pull requests without a shared-file merge conflict.
+- the dedicated `/changelog/` page combines those validated fragments with the
+  immutable release history in the canonical root `CHANGELOG.md`.
 
-The content build uses a clearly marked empty changelog state before the first
-root changelog is present. It never manufactures changelog entries from news.
-Changelog entries and per-release notes are immutable historical records; later
-clarifications belong in a new entry or release, not a rewritten past artifact.
+The content build never manufactures changelog entries from news or pull
+request titles. Changelog entries and per-release notes are immutable
+historical records; later clarifications belong in a new entry or release, not
+a rewritten past artifact.
 
 ## Product screenshots
 

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "content": "node scripts/generate-content.mjs",
-    "test": "node scripts/run-tests.mjs",
+    "test": "node --test ../tools/changelog-fragments.test.mjs && node scripts/run-tests.mjs",
     "predev": "npm run content",
     "dev": "vite",
     "build": "npm run content && npm run test && vite build && vite build --ssr src/entry-server.js --outDir dist-ssr && node scripts/prerender.mjs",

--- a/website/scripts/content-surfaces.test.mjs
+++ b/website/scripts/content-surfaces.test.mjs
@@ -54,9 +54,10 @@ test("living news metadata and native feed share the canonical Markdown source",
 });
 
 test("changelog remains a dedicated root-sourced searchable surface", async () => {
-  assert.equal(changelog.file, "CHANGELOG.md");
+  assert.equal(changelog.file, "changes/unreleased and CHANGELOG.md");
   assert.equal(changelog.path, "/changelog/");
   assert.doesNotMatch(changelog.description, /product stor|development note/i);
+  assert.match(changelog.html, /Unreleased/);
 
   const searchIndex = JSON.parse(
     await readFile(path.join(websiteRoot, "public", "search-index.json"), "utf8"),

--- a/website/scripts/content-surfaces.test.mjs
+++ b/website/scripts/content-surfaces.test.mjs
@@ -66,6 +66,15 @@ test("changelog remains a dedicated root-sourced searchable surface", async () =
   assert.equal(indexed.length, 1);
   assert.equal(indexed[0].contentType, "Changelog");
   assert.ok(news.every((post) => post.path !== changelog.path));
+
+  const generator = await readFile(
+    path.join(websiteRoot, "scripts", "generate-content.mjs"),
+    "utf8",
+  );
+  assert.match(
+    generator,
+    /if \(changelogAvailable\) \{\s+changelogSource = composeChangelogSource/u,
+  );
 });
 
 test("marketing screenshots are rendered offscreen without an Android device", async () => {

--- a/website/scripts/generate-content.mjs
+++ b/website/scripts/generate-content.mjs
@@ -20,6 +20,10 @@ import {
   roadmapSnapshotFromLive,
   shippedPriorityItems,
 } from "./roadmap-data.mjs";
+import {
+  composeChangelogSource,
+  loadFragments,
+} from "../../tools/changelog-fragments.mjs";
 
 const websiteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = path.resolve(websiteRoot, "..");
@@ -238,15 +242,18 @@ if (
     "CHANGELOG.md must contain a Changelog title, a release section, and a Keep a Changelog category.",
   );
 }
+await loadFragments(repositoryRoot, { includeArchive: true });
+const unreleasedFragments = await loadFragments(repositoryRoot);
+changelogSource = composeChangelogSource(changelogSource, unreleasedFragments);
 const changelogBody = changelogSource.replace(/^#\s+Changelog\s*\n+/i, "");
 const changelogText = textOnly(changelogBody);
 const changelog = {
-  file: "CHANGELOG.md",
+  file: "changes/unreleased and CHANGELOG.md",
   path: changelogRoute,
   title: "Changelog",
   shortTitle: "Changelog",
   description:
-    "Concise Added, Changed, Fixed, and Security records for each Nextcloud Native release.",
+    "Concise user-facing changes from independent pull-request fragments and immutable release history.",
   html: markdown.render(changelogBody),
   text: changelogText,
   headings: headingsFrom(changelogBody),
@@ -255,7 +262,7 @@ const changelog = {
 };
 await writeFile(
   path.join(generatedDirectory, "changelog.js"),
-  `// Generated from the canonical root CHANGELOG.md when available. Do not edit.\nexport const changelog = ${JSON.stringify(changelog, null, 2)};\n`,
+  `// Generated from changes/unreleased and the canonical root CHANGELOG.md. Do not edit.\nexport const changelog = ${JSON.stringify(changelog, null, 2)};\n`,
 );
 
 const newsFiles = (await readdir(newsDirectory))

--- a/website/scripts/generate-content.mjs
+++ b/website/scripts/generate-content.mjs
@@ -23,6 +23,7 @@ import {
 import {
   composeChangelogSource,
   loadFragments,
+  validateArchivedReleaseHistory,
 } from "../../tools/changelog-fragments.mjs";
 
 const websiteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -242,9 +243,12 @@ if (
     "CHANGELOG.md must contain a Changelog title, a release section, and a Keep a Changelog category.",
   );
 }
-await loadFragments(repositoryRoot, { includeArchive: true });
+const allFragments = await loadFragments(repositoryRoot, { includeArchive: true });
+await validateArchivedReleaseHistory(repositoryRoot, allFragments);
 const unreleasedFragments = await loadFragments(repositoryRoot);
-changelogSource = composeChangelogSource(changelogSource, unreleasedFragments);
+if (changelogAvailable) {
+  changelogSource = composeChangelogSource(changelogSource, unreleasedFragments);
+}
 const changelogBody = changelogSource.replace(/^#\s+Changelog\s*\n+/i, "");
 const changelogText = textOnly(changelogBody);
 const changelog = {


### PR DESCRIPTION
## Summary

- add strict, conflict-free changelog fragments for user-facing and internal changes
- require one explicit fragment for substantive pull requests while keeping local iteration lightweight
- render the website changelog and curated prerelease notes from the same deterministic source
- document fragment authoring, validation, archiving, and release preparation

## Why

Editing one shared `Unreleased` section causes merge conflicts and makes release history depend on reconstructing merged pull requests. Independent fragments keep each change accountable at review time and let the website, changelog, and release tooling consume one source.

## Validation

- `bash tools/check-repository.sh`
- `node tools/changelog-fragments.mjs check-diff --base origin/main --head HEAD`
- 7 focused changelog parser and release preparation tests
- 20 website tests
- production website client, SSR, and prerender build
- `git diff --check`

Supports #103.

Progresses #103.