### PR TITLE
fix(release): harden changelog validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,12 @@ jobs:
           bash tools/test-prerelease-update-contract.sh
 
       - name: Require a changelog fragment
-        if: github.event_name != 'workflow_dispatch'
+        if: >-
+          github.event_name != 'workflow_dispatch' &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.user.login != 'dependabot[bot]'
+          )
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
           (
             github.event_name != 'pull_request' ||
             github.event.pull_request.user.login != 'dependabot[bot]'
+          ) &&
+          (
+            github.event_name != 'push' ||
+            github.event.head_commit.author.username != 'dependabot[bot]'
           )
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}

--- a/changes/README.md
+++ b/changes/README.md
@@ -23,10 +23,12 @@ user-facing: yes
 Standalone RAW photos can now open when the server has no generated preview.
 ```
 
-Allowed categories are `feature`, `fix`, `platform`, `docs`, and `internal`.
-Allowed platforms are `all`, `android`, `desktop`, `ios`, `linux`, `macos`,
-`website`, and `windows`. Use `none` when either the issue or pull request does
-not exist, but always provide at least one positive reference.
+Allowed categories are `feature`, `fix`, `security`, `platform`, `docs`, and
+`internal`. Use `security` for user-facing fixes to confidentiality, integrity,
+authentication, signing, or other security boundaries. Allowed platforms are
+`all`, `android`, `desktop`, `ios`, `linux`, `macos`, `website`, and `windows`.
+Use `none` when either the issue or pull request does not exist, but always
+provide at least one positive reference.
 
 Internal maintenance still needs a fragment so automation does not have to
 guess whether a missing entry was intentional:

--- a/changes/unreleased/103-changelog-review-follow-up.md
+++ b/changes/unreleased/103-changelog-review-follow-up.md
@@ -1,0 +1,7 @@
+category: internal
+issue: 103
+pull: none
+platforms: all
+user-facing: no
+
+Release checks now preserve security categories and allow configured dependency updates.

--- a/tools/changelog-fragments.mjs
+++ b/tools/changelog-fragments.mjs
@@ -10,10 +10,18 @@ const execFileAsync = promisify(execFile);
 const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
 export const defaultRepositoryRoot = path.resolve(moduleDirectory, "..");
 
-export const categoryOrder = ["feature", "fix", "platform", "docs", "internal"];
+export const categoryOrder = [
+  "feature",
+  "fix",
+  "security",
+  "platform",
+  "docs",
+  "internal",
+];
 export const categoryHeadings = {
   feature: "Features",
   fix: "Fixes",
+  security: "Security",
   platform: "Platform",
   docs: "Documentation",
   internal: "Internal",
@@ -374,22 +382,32 @@ function normalizeRenderedEntry(entry) {
 }
 
 function extractRenderedEntries(source) {
-  const headings = new Set(Object.values(categoryHeadings));
+  const headingCategories = new Map(
+    Object.entries(categoryHeadings).map(([category, heading]) => [
+      heading,
+      category,
+    ]),
+  );
   const entries = [];
-  let inCategory = false;
+  let currentCategory = null;
   let current = null;
   const flush = () => {
-    if (current !== null) entries.push(normalizeRenderedEntry(current));
+    if (current !== null && currentCategory !== null) {
+      entries.push({
+        category: currentCategory,
+        entry: normalizeRenderedEntry(current),
+      });
+    }
     current = null;
   };
   for (const line of source.split("\n")) {
     const heading = /^#{2,4}\s+(.+?)\s*$/u.exec(line);
     if (heading) {
       flush();
-      inCategory = headings.has(heading[1]);
+      currentCategory = headingCategories.get(heading[1]) ?? null;
       continue;
     }
-    if (!inCategory) continue;
+    if (currentCategory === null) continue;
     if (line.startsWith("- ")) {
       flush();
       current = line.slice(2);
@@ -413,10 +431,7 @@ async function readReleaseRecord(repositoryRoot, relativePath) {
 }
 
 function assertReleaseEntries(version, recordName, expected, actual) {
-  if (
-    expected.length !== actual.length ||
-    expected.some((entry, index) => entry !== actual[index])
-  ) {
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
     fail(
       `${recordName}: user-facing entries for ${version} do not match its archived fragments. ` +
         `Expected ${JSON.stringify(expected)} but found ${JSON.stringify(actual)}.`,
@@ -447,7 +462,10 @@ export async function validateArchivedReleaseHistory(
   for (const [version, archived] of [...archivedByVersion.entries()].sort()) {
     const expected = sortFragments(archived)
       .filter((fragment) => fragment.userFacing)
-      .map((fragment) => normalizeRenderedEntry(renderFragmentEntry(fragment, false)));
+      .map((fragment) => ({
+        category: fragment.category,
+        entry: normalizeRenderedEntry(renderFragmentEntry(fragment, false)),
+      }));
     const changelogSection = changelogSections.get(version);
     if (changelogSection === undefined) {
       fail(`CHANGELOG.md: archived version ${version} needs a corresponding released section.`);

--- a/tools/changelog-fragments.test.mjs
+++ b/tools/changelog-fragments.test.mjs
@@ -210,7 +210,7 @@ test("contributor Node.js guidance matches the website engine exactly", async ()
   );
 });
 
-test("CI enforces fragments on pushes and human pull requests without blocking Dependabot", async () => {
+test("CI enforces fragments without blocking GitHub-attributed Dependabot changes", async () => {
   const workflow = await readFile(
     path.join(defaultRepositoryRoot, ".github", "workflows", "ci.yml"),
     "utf8",
@@ -220,6 +220,10 @@ test("CI enforces fragments on pushes and human pull requests without blocking D
   assert.match(
     workflow,
     /github\.event\.pull_request\.user\.login != 'dependabot\[bot\]'/,
+  );
+  assert.match(
+    workflow,
+    /github\.event\.head_commit\.author\.username != 'dependabot\[bot\]'/,
   );
 });
 

--- a/tools/changelog-fragments.test.mjs
+++ b/tools/changelog-fragments.test.mjs
@@ -110,6 +110,19 @@ test("internal work requires an explicit no-user-facing marker", () => {
   assert.equal(parsed.userFacing, false);
 });
 
+test("security fragments retain their release category", () => {
+  const parsed = parseFragment(
+    fragment({
+      category: "security",
+      platforms: "all",
+      summary: "Release verification now rejects an unexpected signing identity.",
+    }),
+    "changes/unreleased/security.md",
+  );
+  assert.equal(parsed.category, "security");
+  assert.match(renderFragments([parsed]), /^### Security$/m);
+});
+
 test("rendering is deterministic and omits internal implementation records", () => {
   const feature = parseFragment(fragment(), "changes/unreleased/z-feature.md");
   const fix = parseFragment(
@@ -194,6 +207,19 @@ test("contributor Node.js guidance matches the website engine exactly", async ()
   assert.equal(
     contributing.includes(`Node.js \`${packageMetadata.engines.node}\``),
     true,
+  );
+});
+
+test("CI enforces fragments on pushes and human pull requests without blocking Dependabot", async () => {
+  const workflow = await readFile(
+    path.join(defaultRepositoryRoot, ".github", "workflows", "ci.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /github\.event_name != 'workflow_dispatch'/);
+  assert.match(workflow, /github\.event_name != 'pull_request'/);
+  assert.match(
+    workflow,
+    /github\.event\.pull_request\.user\.login != 'dependabot\[bot\]'/,
   );
 });
 
@@ -557,6 +583,45 @@ test("archived fragments reconcile with changelog and release notes", async () =
       ].join("\n"),
     );
     await validateArchivedReleaseHistory(root);
+
+    const wrongCategoryChangelog = changelog.replace(
+      "### Features",
+      "### Fixes",
+    );
+    const wrongCategoryReleaseNote = [
+      `# Nextcloud Native ${version}`,
+      "",
+      "## Fixes",
+      "",
+      `- ${expected}`,
+      "",
+      "## Known limitations",
+      "",
+      "- Testing build.",
+      "",
+    ].join("\n");
+    await writeFile(path.join(root, "CHANGELOG.md"), wrongCategoryChangelog);
+    await writeFile(releaseNotePath, wrongCategoryReleaseNote);
+    await assert.rejects(
+      validateArchivedReleaseHistory(root),
+      /do not match its archived fragments/,
+    );
+    await writeFile(path.join(root, "CHANGELOG.md"), changelog);
+    await writeFile(
+      releaseNotePath,
+      [
+        `# Nextcloud Native ${version}`,
+        "",
+        "## Features",
+        "",
+        `- ${expected}`,
+        "",
+        "## Known limitations",
+        "",
+        "- Testing build.",
+        "",
+      ].join("\n"),
+    );
 
     await writeFile(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## Unreleased\n");
     await assert.rejects(


### PR DESCRIPTION
Relates to #103.

## Summary
- preserve changelog categories when validating archived release records
- support dedicated security fragments and release headings
- keep fragment enforcement on pushes and human pull requests while allowing Dependabot updates
- add regression coverage for category drift and workflow conditions

## Validation
- `node --test tools/changelog-fragments.test.mjs`
- `node tools/changelog-fragments.mjs validate`
- `bash tools/check-repository.sh`
- `git diff --check`