### PR TITLE
feat(updates): add selectable release channels

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
@@ -187,9 +187,8 @@ internal class AndroidNextcloudServices(
 
     override fun loadAppUpdateChannel(): AndroidUpdateChannel = projectContent.updateChannel()
 
-    override fun saveAppUpdateChannel(channel: AndroidUpdateChannel) {
+    override fun saveAppUpdateChannel(channel: AndroidUpdateChannel): Boolean =
         projectContent.saveUpdateChannel(channel)
-    }
 
     override suspend fun checkForAppUpdate(channel: AndroidUpdateChannel): AppUpdateCheckResult =
         withContext(Dispatchers.IO) { projectContent.checkForUpdate(channel) }

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClient.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClient.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
+import android.content.pm.PackageInstaller
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
@@ -23,6 +24,7 @@ import dev.obiente.nextcloudnative.app.MAX_PROJECT_NEWS_IMAGE_BYTES
 import dev.obiente.nextcloudnative.app.PROJECT_NEWS_FEED_URL
 import dev.obiente.nextcloudnative.app.ProjectNewsResult
 import dev.obiente.nextcloudnative.app.ProjectNewsImage
+import dev.obiente.nextcloudnative.app.canSelectAppUpdateChannel
 import dev.obiente.nextcloudnative.app.isNewerAndroidRelease
 import dev.obiente.nextcloudnative.app.isCanonicalAndroidUpdateManifestUrl
 import dev.obiente.nextcloudnative.app.isCanonicalProjectNewsImageUrl
@@ -80,17 +82,32 @@ internal class AndroidProjectContentClient(
     @Volatile private var updateCancellationRequested = false
 
     fun support(): AppUpdateSupport {
-        val source = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        val installSource = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             runCatching {
                 appContext.packageManager
                     .getInstallSourceInfo(appContext.packageName)
-                    .installingPackageName
             }.getOrNull()
         } else {
+            null
+        }
+        val installerPackage = installSource?.installingPackageName ?: if (
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.R
+        ) {
             @Suppress("DEPRECATION")
             appContext.packageManager.getInstallerPackageName(appContext.packageName)
+        } else {
+            null
         }
-        val channel = classifyAndroidDistribution(source, BuildConfig.DEBUG)
+        val packageSource = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            installSource?.packageSource
+        } else {
+            null
+        }
+        val channel = classifyAndroidDistribution(
+            installerPackage = installerPackage,
+            debugBuild = BuildConfig.DEBUG,
+            packageSource = packageSource,
+        )
         val directUpdatesEnabled = canCheckAndroidDirectUpdates(
             channel = channel,
             directApkBuild = BuildConfig.DIRECT_APK_UPDATES,
@@ -173,17 +190,35 @@ internal class AndroidProjectContentClient(
     fun updateChannel(): AndroidUpdateChannel =
         parseAndroidUpdateChannel(preferences.getString(KEY_UPDATE_CHANNEL, null))
 
-    fun saveUpdateChannel(channel: AndroidUpdateChannel) {
-        preferences.edit().putString(KEY_UPDATE_CHANNEL, channel.manifestChannel).apply()
+    fun saveUpdateChannel(channel: AndroidUpdateChannel): Boolean {
+        if (!canSelectAppUpdateChannel(support(), channel)) return false
+        preferences.edit().putString(KEY_UPDATE_CHANNEL, channel.storageValue).apply()
+        return true
     }
 
     fun checkForUpdate(channel: AndroidUpdateChannel): AppUpdateCheckResult {
         val support = support()
         if (!support.canCheckDirectUpdates) return AppUpdateCheckResult.Unavailable(support)
+        if (!channel.available) {
+            return AppUpdateCheckResult.Failed(
+                support,
+                "${channel.name} updates are not available yet.",
+            )
+        }
+        if (channel != updateChannel()) {
+            return AppUpdateCheckResult.Failed(
+                support,
+                "The update channel changed. Check again using the saved channel.",
+            )
+        }
         return runCatching {
             val metadataUrl = channel.manifestUrl()
-            val metadata = getBounded(metadataUrl, MAX_ANDROID_UPDATE_METADATA_BYTES.toLong())
-            val release = parseAndroidDirectRelease(metadata, metadataUrl)
+            val metadata = getBounded(
+                metadataUrl,
+                MAX_ANDROID_UPDATE_METADATA_BYTES.toLong(),
+                updateChannel = channel,
+            )
+            val release = parseAndroidDirectRelease(metadata, metadataUrl, channel)
             if (isNewerAndroidRelease(support.currentVersionCode, release)) {
                 AppUpdateCheckResult.Available(support, release)
             } else {
@@ -217,7 +252,14 @@ internal class AndroidProjectContentClient(
         if (!isNewerAndroidRelease(support.currentVersionCode, release)) {
             return AppUpdateInstallResult.Rejected("This release is not newer than the installed app.")
         }
-        validateAndroidDirectRelease(release)
+        val selectedChannel = updateChannel()
+        runCatching {
+            validateAndroidDirectRelease(release, selectedChannel)
+        }.getOrElse {
+            return AppUpdateInstallResult.Rejected(
+                "The update metadata is invalid for the selected ${selectedChannel.name} channel.",
+            )
+        }
         val foregroundActivity = activity
             ?: return AppUpdateInstallResult.Rejected("Open the app before installing an update.")
         if (!appContext.packageManager.canRequestPackageInstalls()) {
@@ -363,10 +405,17 @@ internal class AndroidProjectContentClient(
         parseProjectNewsFeed(newsCache.readBytes())
     }.getOrNull()
 
-    private fun getBounded(url: String, maximumBytes: Long): ByteArray {
+    private fun getBounded(
+        url: String,
+        maximumBytes: Long,
+        updateChannel: AndroidUpdateChannel? = null,
+    ): ByteArray {
         require(
             url == PROJECT_NEWS_FEED_URL ||
-                isCanonicalAndroidUpdateManifestUrl(url) ||
+                (
+                    updateChannel != null &&
+                        isCanonicalAndroidUpdateManifestUrl(url, updateChannel)
+                    ) ||
                 isCanonicalProjectNewsImageUrl(url),
         )
         val request = Request.Builder().url(url).get().build()
@@ -775,11 +824,19 @@ internal fun executeWithTrustedGitHubReleaseRedirect(
 internal fun classifyAndroidDistribution(
     installerPackage: String?,
     debugBuild: Boolean,
+    packageSource: Int? = null,
 ): AppDistributionChannel = when {
     debugBuild -> AppDistributionChannel.Development
     installerPackage == "com.android.vending" -> AppDistributionChannel.GooglePlay
     installerPackage in setOf("org.fdroid.fdroid", "org.fdroid.basic") ->
         AppDistributionChannel.FDroid
+    packageSource == PackageInstaller.PACKAGE_SOURCE_STORE ->
+        AppDistributionChannel.OtherStore
+    packageSource == PackageInstaller.PACKAGE_SOURCE_LOCAL_FILE ||
+        packageSource == PackageInstaller.PACKAGE_SOURCE_DOWNLOADED_FILE ->
+        AppDistributionChannel.DirectApk
+    packageSource == PackageInstaller.PACKAGE_SOURCE_OTHER ->
+        AppDistributionChannel.OtherStore
     installerPackage == null ||
         installerPackage in setOf(
             "com.android.packageinstaller",

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClientTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClientTest.kt
@@ -1,5 +1,6 @@
 package dev.obiente.nextcloudnative
 
+import android.content.pm.PackageInstaller
 import android.content.pm.PackageManager
 import dev.obiente.nextcloudnative.app.AppDistributionChannel
 import java.nio.file.Files
@@ -168,6 +169,38 @@ class AndroidProjectContentClientTest {
         assertEquals(
             AppDistributionChannel.Development,
             classifyAndroidDistribution(null, debugBuild = true),
+        )
+        assertEquals(
+            AppDistributionChannel.DirectApk,
+            classifyAndroidDistribution(
+                installerPackage = "com.oneplus.packageinstaller",
+                debugBuild = false,
+                packageSource = PackageInstaller.PACKAGE_SOURCE_LOCAL_FILE,
+            ),
+        )
+        assertEquals(
+            AppDistributionChannel.DirectApk,
+            classifyAndroidDistribution(
+                installerPackage = "com.oplus.packageinstaller",
+                debugBuild = false,
+                packageSource = PackageInstaller.PACKAGE_SOURCE_DOWNLOADED_FILE,
+            ),
+        )
+        assertEquals(
+            AppDistributionChannel.OtherStore,
+            classifyAndroidDistribution(
+                installerPackage = null,
+                debugBuild = false,
+                packageSource = PackageInstaller.PACKAGE_SOURCE_STORE,
+            ),
+        )
+        assertEquals(
+            AppDistributionChannel.GooglePlay,
+            classifyAndroidDistribution(
+                installerPackage = "com.android.vending",
+                debugBuild = false,
+                packageSource = PackageInstaller.PACKAGE_SOURCE_LOCAL_FILE,
+            ),
         )
         assertTrue(
             canCheckAndroidDirectUpdates(

--- a/changes/unreleased/228-selectable-update-channels.md
+++ b/changes/unreleased/228-selectable-update-channels.md
@@ -1,0 +1,7 @@
+category: feature
+issue: 228
+pull: 229
+platforms: android
+user-facing: yes
+
+Direct APK installations can now choose between signed Alpha and Nightly update channels while preserving channel, version, checksum, package, and signer validation.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannels.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannels.kt
@@ -1,0 +1,73 @@
+package dev.obiente.nextcloudnative.app
+
+data class AppUpdateChannelOptionPresentation(
+    val channel: AndroidUpdateChannel,
+    val label: String,
+    val description: String,
+    val selected: Boolean,
+    val enabled: Boolean,
+    val availabilityLabel: String?,
+)
+
+data class AppUpdateChannelPresentation(
+    val selectorVisible: Boolean,
+    val selectorEnabled: Boolean,
+    val selectedChannel: AndroidUpdateChannel,
+    val options: List<AppUpdateChannelOptionPresentation>,
+)
+
+fun canSelectAppUpdateChannel(
+    support: AppUpdateSupport,
+    requested: AndroidUpdateChannel,
+): Boolean =
+    support.channel == AppDistributionChannel.DirectApk &&
+        support.canCheckDirectUpdates &&
+        requested.available
+
+fun retainedAppUpdateCheckResult(
+    previousChannel: AndroidUpdateChannel,
+    selectedChannel: AndroidUpdateChannel,
+    previousResult: AppUpdateCheckResult?,
+): AppUpdateCheckResult? =
+    previousResult.takeIf { previousChannel == selectedChannel }
+
+fun appUpdateChannelPresentation(
+    support: AppUpdateSupport,
+    selectedChannel: AndroidUpdateChannel,
+): AppUpdateChannelPresentation {
+    val selectorVisible = support.channel == AppDistributionChannel.DirectApk
+    val selectorEnabled = selectorVisible && support.canCheckDirectUpdates
+    return AppUpdateChannelPresentation(
+        selectorVisible = selectorVisible,
+        selectorEnabled = selectorEnabled,
+        selectedChannel = selectedChannel,
+        options = AndroidUpdateChannel.entries.map { channel ->
+            AppUpdateChannelOptionPresentation(
+                channel = channel,
+                label = channel.label(),
+                description = channel.description(),
+                selected = channel == selectedChannel,
+                enabled = selectorEnabled && channel.available,
+                availabilityLabel = if (channel.available) null else "Coming later",
+            )
+        },
+    )
+}
+
+private fun AndroidUpdateChannel.label(): String = when (this) {
+    AndroidUpdateChannel.Alpha -> "Alpha"
+    AndroidUpdateChannel.Nightly -> "Nightly"
+    AndroidUpdateChannel.Beta -> "Beta"
+    AndroidUpdateChannel.Stable -> "Stable"
+}
+
+private fun AndroidUpdateChannel.description(): String = when (this) {
+    AndroidUpdateChannel.Alpha ->
+        "Signed prerelease builds for broader testing. Updates arrive with reviewed alpha releases."
+    AndroidUpdateChannel.Nightly ->
+        "The latest signed build from main. It changes frequently and may be less stable."
+    AndroidUpdateChannel.Beta ->
+        "Feature-complete testing builds with fewer changes between updates."
+    AndroidUpdateChannel.Stable ->
+        "Production-ready releases after prerelease testing is complete."
+}

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -52,6 +53,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -77,6 +79,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -7283,6 +7286,12 @@ private fun ProjectNewsArticleScreen(
 private fun AppUpdateSettingsCard(services: NextcloudPlatformServices) {
     val scope = rememberCoroutineScope()
     val support = remember(services) { services.appUpdateSupport() }
+    var updateChannel by remember(services) {
+        mutableStateOf(services.loadAppUpdateChannel())
+    }
+    val channelPresentation = remember(support, updateChannel) {
+        appUpdateChannelPresentation(support, updateChannel)
+    }
     val updateState by remember(services) {
         services.observeAppUpdateInstallState()
     }.collectAsState(AppUpdateInstallState.Idle)
@@ -7290,9 +7299,6 @@ private fun AppUpdateSettingsCard(services: NextcloudPlatformServices) {
     var installing by remember { mutableStateOf(false) }
     var checkResult by remember { mutableStateOf<AppUpdateCheckResult?>(null) }
     var installMessage by remember { mutableStateOf<String?>(null) }
-    var updateChannel by remember(services) {
-        mutableStateOf(services.loadAppUpdateChannel())
-    }
     fun beginInstall(release: AndroidDirectRelease) {
         installing = true
         installMessage = null
@@ -7332,16 +7338,21 @@ private fun AppUpdateSettingsCard(services: NextcloudPlatformServices) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text("App updates", style = MaterialTheme.typography.titleMedium)
                     Text(
-                        "Version ${support.currentVersionName} · ${support.channel.name}",
+                        if (channelPresentation.selectorVisible) {
+                            "Version ${support.currentVersionName} - ${updateChannel.name} channel"
+                        } else {
+                            "Version ${support.currentVersionName} - ${support.channel.name}"
+                        },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 if (support.canCheckDirectUpdates) {
                     TextButton(
-                        enabled = !checking,
+                        enabled = !checking && updateChannel.available,
                         onClick = {
                             checking = true
+                            checkResult = null
                             installMessage = null
                             scope.launch {
                                 checkResult = services.checkForAppUpdate(updateChannel)
@@ -7362,46 +7373,63 @@ private fun AppUpdateSettingsCard(services: NextcloudPlatformServices) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            if (support.canCheckDirectUpdates) {
+            if (channelPresentation.selectorVisible) {
                 Text(
                     "Update channel",
-                    style = MaterialTheme.typography.labelMedium,
+                    style = MaterialTheme.typography.titleSmall,
                 )
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    AndroidUpdateChannel.entries.forEach { channel ->
-                        FilterChip(
-                            selected = updateChannel == channel,
-                            enabled = !checking && !installing,
-                            onClick = {
-                                updateChannel = channel
-                                services.saveAppUpdateChannel(channel)
-                                checkResult = null
-                                installMessage = null
-                            },
-                            label = {
-                                Text(
-                                    when (channel) {
-                                        AndroidUpdateChannel.Alpha -> "Alpha"
-                                        AndroidUpdateChannel.Nightly -> "Nightly"
-                                    },
-                                )
-                            },
+                channelPresentation.options.forEach { option ->
+                    val enabled = option.enabled && !checking && !installing
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                selected = option.selected,
+                                enabled = enabled,
+                                role = Role.RadioButton,
+                                onClick = {
+                                    if (services.saveAppUpdateChannel(option.channel)) {
+                                        checkResult = retainedAppUpdateCheckResult(
+                                            previousChannel = updateChannel,
+                                            selectedChannel = option.channel,
+                                            previousResult = checkResult,
+                                        )
+                                        updateChannel = option.channel
+                                        installMessage = null
+                                    }
+                                },
+                            )
+                            .padding(vertical = NextcloudSpacing.Small),
+                        horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = option.selected,
+                            enabled = enabled,
+                            onClick = null,
                         )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(option.label, style = MaterialTheme.typography.titleSmall)
+                                option.availabilityLabel?.let { label ->
+                                    Text(
+                                        label,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                            Text(
+                                option.description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
-                Text(
-                    when (updateChannel) {
-                        AndroidUpdateChannel.Alpha ->
-                            "Alpha follows curated prereleases."
-                        AndroidUpdateChannel.Nightly ->
-                            "Nightly follows the latest successful main build."
-                    },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
             when (val checked = checkResult) {
                 is AppUpdateCheckResult.Available -> {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -7378,55 +7379,57 @@ private fun AppUpdateSettingsCard(services: NextcloudPlatformServices) {
                     "Update channel",
                     style = MaterialTheme.typography.titleSmall,
                 )
-                channelPresentation.options.forEach { option ->
-                    val enabled = option.enabled && !checking && !installing
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .selectable(
+                Column(modifier = Modifier.selectableGroup()) {
+                    channelPresentation.options.forEach { option ->
+                        val enabled = option.enabled && !checking && !installing
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = option.selected,
+                                    enabled = enabled,
+                                    role = Role.RadioButton,
+                                    onClick = {
+                                        if (services.saveAppUpdateChannel(option.channel)) {
+                                            checkResult = retainedAppUpdateCheckResult(
+                                                previousChannel = updateChannel,
+                                                selectedChannel = option.channel,
+                                                previousResult = checkResult,
+                                            )
+                                            updateChannel = option.channel
+                                            installMessage = null
+                                        }
+                                    },
+                                )
+                                .padding(vertical = NextcloudSpacing.Small),
+                            horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            RadioButton(
                                 selected = option.selected,
                                 enabled = enabled,
-                                role = Role.RadioButton,
-                                onClick = {
-                                    if (services.saveAppUpdateChannel(option.channel)) {
-                                        checkResult = retainedAppUpdateCheckResult(
-                                            previousChannel = updateChannel,
-                                            selectedChannel = option.channel,
-                                            previousResult = checkResult,
+                                onClick = null,
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Text(option.label, style = MaterialTheme.typography.titleSmall)
+                                    option.availabilityLabel?.let { label ->
+                                        Text(
+                                            label,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
-                                        updateChannel = option.channel
-                                        installMessage = null
                                     }
-                                },
-                            )
-                            .padding(vertical = NextcloudSpacing.Small),
-                        horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = option.selected,
-                            enabled = enabled,
-                            onClick = null,
-                        )
-                        Column(modifier = Modifier.weight(1f)) {
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(NextcloudSpacing.Small),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Text(option.label, style = MaterialTheme.typography.titleSmall)
-                                option.availabilityLabel?.let { label ->
-                                    Text(
-                                        label,
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
                                 }
+                                Text(
+                                    option.description,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
                             }
-                            Text(
-                                option.description,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
                         }
                     }
                 }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
@@ -320,7 +320,12 @@ interface NextcloudPlatformServices {
 
     fun loadAppUpdateChannel(): AndroidUpdateChannel = AndroidUpdateChannel.Alpha
 
-    fun saveAppUpdateChannel(channel: AndroidUpdateChannel) = Unit
+    /**
+     * Persists an available direct update channel.
+     *
+     * Store-owned and unsupported installations return false and remain unchanged.
+     */
+    fun saveAppUpdateChannel(channel: AndroidUpdateChannel): Boolean = false
 
     suspend fun checkForAppUpdate(
         channel: AndroidUpdateChannel = loadAppUpdateChannel(),

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt
@@ -128,20 +128,33 @@ data class AndroidDirectRelease(
 )
 
 enum class AndroidUpdateChannel(
+    val storageValue: String,
     val manifestChannel: String,
     val pointerTag: String,
+    val available: Boolean,
 ) {
-    Alpha("prerelease-v1", "channel-prerelease"),
-    Nightly("nightly-v1", "channel-nightly"),
+    Alpha("alpha", "prerelease-v1", "channel-prerelease", true),
+    Nightly("nightly", "nightly-v1", "channel-nightly", true),
+    Beta("beta", "beta-v1", "channel-beta", false),
+    Stable("stable", "stable-v1", "channel-stable", false),
 }
 
-fun AndroidUpdateChannel.manifestUrl(): String =
-    "https://github.com/Obiente/nc-native/releases/download/$pointerTag/update-manifest.json"
+fun AndroidUpdateChannel.manifestUrl(): String {
+    require(available) { "$name updates are not available yet." }
+    return "https://github.com/Obiente/nc-native/releases/download/$pointerTag/update-manifest.json"
+}
 
 fun parseAndroidUpdateChannel(value: String?): AndroidUpdateChannel =
-    AndroidUpdateChannel.entries.singleOrNull { channel ->
-        channel.name == value || channel.manifestChannel == value
-    } ?: AndroidUpdateChannel.Alpha
+    AndroidUpdateChannel.entries
+        .singleOrNull { channel ->
+            channel.available &&
+                (
+                    channel.name == value ||
+                        channel.storageValue == value ||
+                        channel.manifestChannel == value
+                    )
+        }
+        ?: AndroidUpdateChannel.Alpha
 
 sealed interface AppUpdateCheckResult {
     data class Current(val support: AppUpdateSupport) : AppUpdateCheckResult
@@ -236,21 +249,22 @@ private fun StringBuilder.appendRevisionField(value: String) {
 fun parseAndroidDirectRelease(
     bytes: ByteArray,
     metadataUrl: String,
+    expectedChannel: AndroidUpdateChannel,
 ): AndroidDirectRelease {
     require(bytes.isNotEmpty() && bytes.size <= MAX_ANDROID_UPDATE_METADATA_BYTES)
-    require(isCanonicalAndroidUpdateManifestUrl(metadataUrl))
+    require(isCanonicalAndroidUpdateManifestUrl(metadataUrl, expectedChannel))
     val release = publicContentJson.decodeFromString<AndroidDirectRelease>(bytes.decodeToString())
-    return validateAndroidDirectRelease(release, metadataUrl)
+    return validateAndroidDirectRelease(release, expectedChannel, metadataUrl)
 }
 
 fun validateAndroidDirectRelease(
     release: AndroidDirectRelease,
-    metadataUrl: String = release.canonicalMetadataUrl(),
+    expectedChannel: AndroidUpdateChannel,
+    metadataUrl: String = release.canonicalMetadataUrl(expectedChannel),
 ): AndroidDirectRelease {
+    require(expectedChannel.available)
     require(release.schemaVersion == 1)
-    val updateChannel = AndroidUpdateChannel.entries.singleOrNull {
-        it.manifestChannel == release.channel
-    } ?: throw IllegalArgumentException("Unsupported Android update channel.")
+    require(release.channel == expectedChannel.manifestChannel)
     require(release.versionName.isBoundedPublicText(64) && release.versionCode > 0)
     require(release.packageName == "dev.obiente.nextcloudnative")
     require(release.minimumAndroidSdk in 26..64)
@@ -263,9 +277,9 @@ fun validateAndroidDirectRelease(
             release.signingCertificateSha256Digests.size &&
             release.signingCertificateSha256Digests.all(String::isSha256),
     )
-    val tag = release.releaseTag(updateChannel)
+    val tag = release.releaseTag(expectedChannel)
     require(
-        metadataUrl == updateChannel.manifestUrl() ||
+        metadataUrl == expectedChannel.manifestUrl() ||
             metadataUrl ==
             "https://github.com/Obiente/nc-native/releases/download/$tag/update-manifest.json",
     )
@@ -290,14 +304,15 @@ fun isCanonicalAndroidPrereleaseManifestUrl(url: String): Boolean {
 }
 
 fun isCanonicalAndroidUpdateManifestUrl(url: String): Boolean =
-    AndroidUpdateChannel.entries.any { channel ->
+    AndroidUpdateChannel.entries.filter { it.available }.any { channel ->
         isCanonicalAndroidUpdateManifestUrl(url, channel)
     }
 
-private fun isCanonicalAndroidUpdateManifestUrl(
+fun isCanonicalAndroidUpdateManifestUrl(
     url: String,
     channel: AndroidUpdateChannel,
 ): Boolean {
+    if (!channel.available) return false
     if (url == channel.manifestUrl()) return true
     val prefix = "https://github.com/Obiente/nc-native/releases/download/"
     if (!url.hasCanonicalPathUnder(prefix, trailingSlash = false)) return false
@@ -312,6 +327,9 @@ private fun AndroidUpdateChannel.releaseTagPattern(): Regex = when (this) {
         Regex("v0\\.[0-9]+\\.[0-9]+-(?:alpha|beta|rc)\\.[0-9]+")
     AndroidUpdateChannel.Nightly ->
         Regex("nightly-[0-9]{8}-[0-9]{4}-run[1-9][0-9]*-[a-f0-9]{8}")
+    AndroidUpdateChannel.Beta,
+    AndroidUpdateChannel.Stable,
+    -> error("$name updates are not available yet.")
 }
 
 private fun AndroidDirectRelease.releaseTag(channel: AndroidUpdateChannel): String = when (channel) {
@@ -323,14 +341,18 @@ private fun AndroidDirectRelease.releaseTag(channel: AndroidUpdateChannel): Stri
         require(versionName.matches(channel.releaseTagPattern()))
         versionName
     }
+    AndroidUpdateChannel.Beta,
+    AndroidUpdateChannel.Stable,
+    -> error("${channel.name} updates are not available yet.")
 }
 
-private fun AndroidDirectRelease.canonicalMetadataUrl(): String {
-    val updateChannel = AndroidUpdateChannel.entries.singleOrNull {
-        it.manifestChannel == channel
-    } ?: throw IllegalArgumentException("Unsupported Android update channel.")
+private fun AndroidDirectRelease.canonicalMetadataUrl(
+    expectedChannel: AndroidUpdateChannel,
+): String {
+    require(expectedChannel.available)
+    require(channel == expectedChannel.manifestChannel)
     return "https://github.com/Obiente/nc-native/releases/download/" +
-        "${releaseTag(updateChannel)}/update-manifest.json"
+        "${releaseTag(expectedChannel)}/update-manifest.json"
 }
 
 fun isCanonicalProjectNewsImageUrl(url: String): Boolean =

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannelsTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannelsTest.kt
@@ -1,0 +1,230 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class AppUpdateChannelsTest {
+    private val directSupport = AppUpdateSupport(
+        channel = AppDistributionChannel.DirectApk,
+        currentVersionName = "0.1.0-alpha.1",
+        currentVersionCode = 20_000_012,
+        canCheckDirectUpdates = true,
+        explanation = "Direct updates are available.",
+    )
+
+    @Test
+    fun persistedChannelRestoresAvailableValuesAndSafelyDefaultsFutureValues() {
+        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel(null))
+        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel(""))
+        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("unknown"))
+        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("alpha"))
+        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("prerelease-v1"))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("Nightly"))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("nightly-v1"))
+        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("beta"))
+        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("stable-v1"))
+    }
+
+    @Test
+    fun onlyAvailableDirectChannelsCanBeSelected() {
+        assertTrue(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Alpha))
+        assertTrue(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Nightly))
+        assertFalse(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Beta))
+        assertFalse(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Stable))
+        assertFalse(
+            canSelectAppUpdateChannel(
+                directSupport.copy(
+                    channel = AppDistributionChannel.GooglePlay,
+                    canCheckDirectUpdates = false,
+                ),
+                AndroidUpdateChannel.Nightly,
+            ),
+        )
+    }
+
+    @Test
+    fun presentationExposesRiskAndFutureChannelsWithoutEnablingThem() {
+        val presentation = appUpdateChannelPresentation(
+            directSupport,
+            selectedChannel = AndroidUpdateChannel.Nightly,
+        )
+
+        assertTrue(presentation.selectorVisible)
+        assertTrue(presentation.selectorEnabled)
+        assertEquals(AndroidUpdateChannel.entries.toList(), presentation.options.map { it.channel })
+        val nightly = presentation.options.single { it.channel == AndroidUpdateChannel.Nightly }
+        assertTrue(nightly.selected)
+        assertTrue(nightly.enabled)
+        assertTrue(nightly.description.contains("less stable"))
+        listOf(AndroidUpdateChannel.Beta, AndroidUpdateChannel.Stable).forEach { channel ->
+            val option = presentation.options.single { it.channel == channel }
+            assertFalse(option.enabled)
+            assertEquals("Coming later", option.availabilityLabel)
+        }
+
+        val storePresentation = appUpdateChannelPresentation(
+            directSupport.copy(
+                channel = AppDistributionChannel.FDroid,
+                canCheckDirectUpdates = false,
+            ),
+            selectedChannel = AndroidUpdateChannel.Alpha,
+        )
+        assertFalse(storePresentation.selectorVisible)
+        assertFalse(storePresentation.selectorEnabled)
+        assertTrue(storePresentation.options.none { it.enabled })
+    }
+
+    @Test
+    fun changingChannelInvalidatesAResultFromThePreviousChannel() {
+        val result = AppUpdateCheckResult.Current(directSupport)
+        assertEquals(
+            result,
+            retainedAppUpdateCheckResult(
+                previousChannel = AndroidUpdateChannel.Alpha,
+                selectedChannel = AndroidUpdateChannel.Alpha,
+                previousResult = result,
+            ),
+        )
+        assertNull(
+            retainedAppUpdateCheckResult(
+                previousChannel = AndroidUpdateChannel.Alpha,
+                selectedChannel = AndroidUpdateChannel.Nightly,
+                previousResult = result,
+            ),
+        )
+    }
+
+    @Test
+    fun onlyAvailableChannelsResolveCanonicalMetadataPointers() {
+        assertEquals(
+            "https://github.com/Obiente/nc-native/releases/download/" +
+                "channel-prerelease/update-manifest.json",
+            AndroidUpdateChannel.Alpha.manifestUrl(),
+        )
+        assertEquals(
+            "https://github.com/Obiente/nc-native/releases/download/" +
+                "channel-nightly/update-manifest.json",
+            AndroidUpdateChannel.Nightly.manifestUrl(),
+        )
+        listOf(AndroidUpdateChannel.Beta, AndroidUpdateChannel.Stable).forEach { channel ->
+            assertFailsWith<IllegalArgumentException> {
+                channel.manifestUrl()
+            }
+            assertFalse(
+                isCanonicalAndroidUpdateManifestUrl(
+                    "https://github.com/Obiente/nc-native/releases/download/" +
+                        "${channel.pointerTag}/update-manifest.json",
+                    channel,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun metadataIsBoundToTheSelectedChannelAndImmutableReleaseAssets() {
+        val alpha = release(
+            channel = AndroidUpdateChannel.Alpha,
+            versionName = "0.2.0-alpha.3",
+            versionCode = 20_000_032,
+            tag = "v0.2.0-alpha.3",
+        )
+        val nightlyTag = "nightly-20260726-0145-run123-abcdef12"
+        val nightly = release(
+            channel = AndroidUpdateChannel.Nightly,
+            versionName = nightlyTag,
+            versionCode = 20_000_041,
+            tag = nightlyTag,
+        )
+
+        assertEquals(
+            alpha,
+            parseAndroidDirectRelease(
+                Json.encodeToString(alpha).encodeToByteArray(),
+                AndroidUpdateChannel.Alpha.manifestUrl(),
+                AndroidUpdateChannel.Alpha,
+            ),
+        )
+        assertEquals(
+            nightly,
+            parseAndroidDirectRelease(
+                Json.encodeToString(nightly).encodeToByteArray(),
+                AndroidUpdateChannel.Nightly.manifestUrl(),
+                AndroidUpdateChannel.Nightly,
+            ),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            parseAndroidDirectRelease(
+                Json.encodeToString(alpha).encodeToByteArray(),
+                AndroidUpdateChannel.Alpha.manifestUrl(),
+                AndroidUpdateChannel.Nightly,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            validateAndroidDirectRelease(alpha, AndroidUpdateChannel.Nightly)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            validateAndroidDirectRelease(
+                nightly.copy(signingCertificateSha256Digests = listOf("invalid")),
+                AndroidUpdateChannel.Nightly,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            validateAndroidDirectRelease(
+                nightly.copy(
+                    apkUrl =
+                        "https://github.com/Obiente/nc-native/releases/download/" +
+                            "nightly-20260726-0145-run124-abcdef12/" +
+                            "nextcloud-native-$nightlyTag-android.apk",
+                ),
+                AndroidUpdateChannel.Nightly,
+            )
+        }
+    }
+
+    @Test
+    fun versionCodeOrderingPreventsDowngradesAcrossChannels() {
+        val newerNightly = release(
+            channel = AndroidUpdateChannel.Nightly,
+            versionName = "nightly-20260726-0145-run123-abcdef12",
+            versionCode = 20_000_041,
+            tag = "nightly-20260726-0145-run123-abcdef12",
+        )
+        val olderAlpha = release(
+            channel = AndroidUpdateChannel.Alpha,
+            versionName = "0.2.0-alpha.3",
+            versionCode = 20_000_032,
+            tag = "v0.2.0-alpha.3",
+        )
+
+        assertTrue(isNewerAndroidRelease(20_000_032, newerNightly))
+        assertFalse(isNewerAndroidRelease(20_000_041, olderAlpha))
+        assertFalse(isNewerAndroidRelease(20_000_041, newerNightly))
+    }
+
+    private fun release(
+        channel: AndroidUpdateChannel,
+        versionName: String,
+        versionCode: Long,
+        tag: String,
+    ) = AndroidDirectRelease(
+        schemaVersion = 1,
+        channel = channel.manifestChannel,
+        versionName = versionName,
+        versionCode = versionCode,
+        packageName = "dev.obiente.nextcloudnative",
+        minimumAndroidSdk = 26,
+        apkUrl =
+            "https://github.com/Obiente/nc-native/releases/download/$tag/" +
+                "nextcloud-native-$versionName-android.apk",
+        apkSize = 123_456,
+        apkSha256 = "a".repeat(64),
+        signingCertificateSha256Digests = listOf("b".repeat(64)),
+        releaseNotesUrl = "https://github.com/Obiente/nc-native/releases/tag/$tag",
+    )
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdatesTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdatesTest.kt
@@ -154,19 +154,27 @@ class ProjectNewsAndUpdatesTest {
             "https://github.com/Obiente/nc-native/releases/download/" +
                 "v0.1.0-alpha.1/update-manifest.json"
 
-        assertEquals(release, parseAndroidDirectRelease(encoded, metadataUrl))
-        assertEquals(release, parseAndroidDirectRelease(encoded, immutableMetadataUrl))
+        assertEquals(
+            release,
+            parseAndroidDirectRelease(encoded, metadataUrl, AndroidUpdateChannel.Alpha),
+        )
+        assertEquals(
+            release,
+            parseAndroidDirectRelease(encoded, immutableMetadataUrl, AndroidUpdateChannel.Alpha),
+        )
         assertTrue(isNewerAndroidRelease(0, release))
         assertFalse(isNewerAndroidRelease(1, release))
         assertTrue(isCanonicalAndroidPrereleaseManifestUrl(metadataUrl))
         assertFailsWith<IllegalArgumentException> {
             validateAndroidDirectRelease(
                 release.copy(apkUrl = "https://downloads.invalid/nc-native.apk"),
+                AndroidUpdateChannel.Alpha,
             )
         }
         assertFailsWith<IllegalArgumentException> {
             validateAndroidDirectRelease(
                 release.copy(signingCertificateSha256Digests = listOf("unknown")),
+                AndroidUpdateChannel.Alpha,
             )
         }
         listOf(
@@ -178,7 +186,10 @@ class ProjectNewsAndUpdatesTest {
             "https://github.com/Obiente/nc-native/releases/download/v0.1.0-alpha.1/update.zip",
         ).forEach { invalidUrl ->
             assertFailsWith<IllegalArgumentException>(invalidUrl) {
-                validateAndroidDirectRelease(release.copy(apkUrl = invalidUrl))
+                validateAndroidDirectRelease(
+                    release.copy(apkUrl = invalidUrl),
+                    AndroidUpdateChannel.Alpha,
+                )
             }
         }
         listOf(
@@ -187,7 +198,10 @@ class ProjectNewsAndUpdatesTest {
             "https://github.com/Obiente/nc-native/releases/tag/v0.1.0-alpha.1?source=app",
         ).forEach { invalidUrl ->
             assertFailsWith<IllegalArgumentException>(invalidUrl) {
-                validateAndroidDirectRelease(release.copy(releaseNotesUrl = invalidUrl))
+                validateAndroidDirectRelease(
+                    release.copy(releaseNotesUrl = invalidUrl),
+                    AndroidUpdateChannel.Alpha,
+                )
             }
         }
     }
@@ -215,18 +229,32 @@ class ProjectNewsAndUpdatesTest {
         val immutableMetadataUrl =
             "https://github.com/Obiente/nc-native/releases/download/$tag/update-manifest.json"
 
-        assertEquals(release, parseAndroidDirectRelease(encoded, metadataUrl))
-        assertEquals(release, parseAndroidDirectRelease(encoded, immutableMetadataUrl))
+        assertEquals(
+            release,
+            parseAndroidDirectRelease(encoded, metadataUrl, AndroidUpdateChannel.Nightly),
+        )
+        assertEquals(
+            release,
+            parseAndroidDirectRelease(
+                encoded,
+                immutableMetadataUrl,
+                AndroidUpdateChannel.Nightly,
+            ),
+        )
         assertTrue(isCanonicalAndroidUpdateManifestUrl(metadataUrl))
         assertTrue(isCanonicalAndroidUpdateManifestUrl(immutableMetadataUrl))
         assertFailsWith<IllegalArgumentException> {
             parseAndroidDirectRelease(
                 encoded,
                 AndroidUpdateChannel.Alpha.manifestUrl(),
+                AndroidUpdateChannel.Nightly,
             )
         }
         assertFailsWith<IllegalArgumentException> {
-            validateAndroidDirectRelease(release.copy(channel = "stable-v1"))
+            validateAndroidDirectRelease(
+                release.copy(channel = "stable-v1"),
+                AndroidUpdateChannel.Nightly,
+            )
         }
     }
 


### PR DESCRIPTION
## What changed

- add an accessible Alpha and Nightly selector for direct APK installations
- represent Beta and Stable as disabled future-compatible channels
- persist stable lowercase channel identifiers and migrate older stored values
- bind metadata checks and installation to the currently selected channel
- invalidate stale check results when the channel changes
- reject unavailable channels, cross-channel metadata, and Android version-code downgrades
- classify Android 13+ local and downloaded package sources as direct APK installs while keeping known and unknown stores conservative
- keep package, SDK, asset-size, checksum, release URL, signer, and signer-lineage validation in the install path

## User impact

People who install Nextcloud Native directly can choose curated Alpha releases or the latest signed Nightly build without reinstalling or relying on an app store. Store-managed installations continue to follow their store and do not expose the selector.

## Validation

- 7 update-channel presentation and policy tests pass
- 5 release metadata and channel-binding tests pass
- 13 Android project-content and installer-source tests pass
- repository hygiene, release contracts, ASCII hygiene, and diff checks pass
- Android and shared tests run with JDK 21 and one build worker

Closes #228