### PR TITLE
fix(photos): keep optional raw search from blocking timeline

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
@@ -120,6 +120,8 @@ import dev.obiente.nextcloudnative.app.dynamicReadCacheIdentity
 import dev.obiente.nextcloudnative.app.collectMediaSearchDavPages
 import dev.obiente.nextcloudnative.app.mediaSearchDavRequests
 import dev.obiente.nextcloudnative.app.MediaSearchDavTransportResponse
+import dev.obiente.nextcloudnative.app.RawMediaSearchCompatibilityPolicy
+import dev.obiente.nextcloudnative.app.isRawPhoto
 import dev.obiente.nextcloudnative.app.mergeMediaSearchResultPages
 import dev.obiente.nextcloudnative.app.normalizeSystemTagsDavResponse
 import dev.obiente.nextcloudnative.app.parseNextcloudFileSharingCapabilities
@@ -652,6 +654,8 @@ internal class AndroidNextcloudServices(
                 MediaSearchDavTransportResponse(response.status, response.body)
             },
             parse = { body -> parseDavFiles(body, userId) },
+            shouldSearchRaw = { files -> files.any(NextcloudFile::isRawPhoto) },
+            rawCompatibilityPolicy = RawMediaSearchCompatibilityPolicy.KeepAvailableResults,
         )
         mergeMediaSearchResultPages(pages)
     }

--- a/changes/unreleased/239-optional-raw-search.md
+++ b/changes/unreleased/239-optional-raw-search.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 239
-pull: none
+pull: 241
 platforms: android, desktop
 user-facing: yes
 

--- a/changes/unreleased/239-optional-raw-search.md
+++ b/changes/unreleased/239-optional-raw-search.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 239
+pull: none
+platforms: android, desktop
+user-facing: yes
+
+Photos now loads normal media without probing unsupported RAW searches and keeps the available timeline when optional RAW discovery is rejected.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaSearchDav.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MediaSearchDav.kt
@@ -11,6 +11,11 @@ enum class MediaSearchDavPartition {
     Raw,
 }
 
+enum class RawMediaSearchCompatibilityPolicy {
+    Fail,
+    KeepAvailableResults,
+}
+
 data class MediaSearchDavRequest(
     val partition: MediaSearchDavPartition,
     val body: String,
@@ -132,10 +137,21 @@ fun mediaSearchDavRequests(
         }
 }
 
+/**
+ * Collects the required MIME pages before considering optional filename-based RAW enrichment.
+ *
+ * The caller must explicitly decide whether the parsed MIME results justify RAW discovery. This
+ * keeps ordinary photo libraries from paying for unsupported RAW queries. When compatibility
+ * fallback is enabled, only RAW-specific 400/422 responses and the bounded request limit keep the
+ * already available MIME pages; authentication, transport, parsing, and server failures remain
+ * visible.
+ */
 suspend fun <T> collectMediaSearchDavPages(
     requests: List<MediaSearchDavRequest>,
     execute: suspend (body: String) -> MediaSearchDavTransportResponse,
     parse: (body: ByteArray) -> List<T>,
+    shouldSearchRaw: (List<T>) -> Boolean,
+    rawCompatibilityPolicy: RawMediaSearchCompatibilityPolicy = RawMediaSearchCompatibilityPolicy.Fail,
 ): List<List<T>> {
     require(requests.getOrNull(0)?.partition == MediaSearchDavPartition.ImageMime)
     require(requests.getOrNull(1)?.partition == MediaSearchDavPartition.VideoMime)
@@ -157,14 +173,19 @@ suspend fun <T> collectMediaSearchDavPages(
         }
         pages += parse(response.body)
     }
+    if (!shouldSearchRaw(pages.flatten())) return pages
 
     var rawOffset = 0
     var rawChunkSize = MAXIMUM_RAW_MEDIA_SEARCH_PATTERNS_PER_REQUEST
     var rawRequests = 0
     while (rawOffset < plannedRawPatterns.size) {
-        check(++rawRequests <= MAXIMUM_RAW_MEDIA_SEARCH_REQUESTS) {
-            "WebDAV RAW media search exceeded the compatibility request limit."
+        if (rawRequests == MAXIMUM_RAW_MEDIA_SEARCH_REQUESTS) {
+            if (rawCompatibilityPolicy == RawMediaSearchCompatibilityPolicy.KeepAvailableResults) {
+                return pages
+            }
+            error("WebDAV RAW media search exceeded the compatibility request limit.")
         }
+        rawRequests += 1
         val patterns = plannedRawPatterns.drop(rawOffset).take(rawChunkSize)
         val request = rawMediaSearchDavRequest(
             rawContext.userId,
@@ -181,6 +202,9 @@ suspend fun <T> collectMediaSearchDavPages(
                 rawChunkSize = (patterns.size + 1) / 2
             }
             isMediaSearchCompatibilityRejection(response.status) -> {
+                if (rawCompatibilityPolicy == RawMediaSearchCompatibilityPolicy.KeepAvailableResults) {
+                    return pages
+                }
                 error("WebDAV RAW media search is not supported by this server (HTTP ${response.status}).")
             }
             else -> error("WebDAV media search failed (HTTP ${response.status}).")

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/MediaStackingTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/MediaStackingTest.kt
@@ -80,6 +80,79 @@ class MediaStackingTest {
     }
 
     @Test
+    fun mediaSearchDoesNotProbeRawWhenMimeResultsContainNoRawFiles() = runBlocking {
+        val requests = mediaSearchDavRequests("account")
+        val executed = mutableListOf<String>()
+        val image = file("Photos/holiday.jpg", "image/jpeg")
+        val video = file("Photos/clip.mp4", "video/mp4")
+
+        val pages = collectMediaSearchDavPages(
+            requests = requests,
+            execute = { body ->
+                executed += body
+                val marker = when (body) {
+                    requests[0].body -> "image"
+                    requests[1].body -> "video"
+                    else -> error("A RAW request was executed without a detected RAW file.")
+                }
+                MediaSearchDavTransportResponse(207, marker.encodeToByteArray())
+            },
+            parse = { body ->
+                when (body.decodeToString()) {
+                    "image" -> listOf(image)
+                    "video" -> listOf(video)
+                    else -> error("Unexpected response marker.")
+                }
+            },
+            shouldSearchRaw = { files -> files.any(NextcloudFile::isRawPhoto) },
+            rawCompatibilityPolicy = RawMediaSearchCompatibilityPolicy.KeepAvailableResults,
+        )
+
+        assertEquals(2, executed.size)
+        assertEquals(2, pages.size)
+        assertEquals(listOf(image, video), pages.flatten())
+        assertEquals(requests.take(2).map(MediaSearchDavRequest::body), executed)
+    }
+
+    @Test
+    fun optionalRawCompatibilityFailureKeepsMimeResults() = runBlocking {
+        val requests = mediaSearchDavRequests("account")
+        val executed = mutableListOf<String>()
+        val image = file("Photos/holiday.jpg", "image/jpeg")
+        val raf = file("Photos/DSCF0001.RAF", "image/x-fuji-raf")
+        val video = file("Photos/clip.mp4", "video/mp4")
+
+        val pages = collectMediaSearchDavPages(
+            requests = requests,
+            execute = { body ->
+                executed += body
+                val isRawRequest = rawPhotoFileNameSearchPatterns().any { pattern -> pattern in body }
+                if (isRawRequest) {
+                    MediaSearchDavTransportResponse(400, "unsupported".encodeToByteArray())
+                } else {
+                    val marker = if (body == requests[0].body) "image" else "video"
+                    MediaSearchDavTransportResponse(207, marker.encodeToByteArray())
+                }
+            },
+            parse = { body ->
+                when (body.decodeToString()) {
+                    "image" -> listOf(image, raf)
+                    "video" -> listOf(video)
+                    else -> error("A rejected RAW response must not be parsed.")
+                }
+            },
+            shouldSearchRaw = { files -> files.any(NextcloudFile::isRawPhoto) },
+            rawCompatibilityPolicy = RawMediaSearchCompatibilityPolicy.KeepAvailableResults,
+        )
+
+        assertEquals(listOf(image, raf, video), pages.flatten())
+        assertEquals(2, executed.count { body -> body in requests.take(2).map(MediaSearchDavRequest::body) })
+        assertEquals(4, executed.count { body ->
+            rawPhotoFileNameSearchPatterns().any { pattern -> pattern in body }
+        })
+    }
+
+    @Test
     fun rawCompatibilityRejectionReducesGlobalChunkSizeWithoutRefetchingMime() = runBlocking {
         val requests = mediaSearchDavRequests("account")
         val executed = mutableListOf<String>()
@@ -101,6 +174,7 @@ class MediaStackingTest {
                 }
             },
             parse = { body -> listOf(body.decodeToString()) },
+            shouldSearchRaw = { true },
         )
 
         val successfulBodies = pages.flatten()
@@ -142,6 +216,7 @@ class MediaStackingTest {
                         }
                     },
                     parse = { body -> listOf(body.decodeToString()) },
+                    shouldSearchRaw = { true },
                 )
             }
         }
@@ -189,6 +264,7 @@ class MediaStackingTest {
                         }
                     },
                     parse = { body -> listOf(body.decodeToString()) },
+                    shouldSearchRaw = { true },
                 )
             }
         }
@@ -222,6 +298,7 @@ class MediaStackingTest {
                             }
                         },
                         parse = { body -> listOf(body.decodeToString()) },
+                        shouldSearchRaw = { true },
                     )
                 }
             }
@@ -249,6 +326,7 @@ class MediaStackingTest {
                 }
             },
             parse = { body -> listOf(body.decodeToString()) },
+            shouldSearchRaw = { true },
         )
 
         assertEquals(8, rawSizes.first())
@@ -276,6 +354,7 @@ class MediaStackingTest {
                 }
             },
             parse = { body -> listOf(body.decodeToString()) },
+            shouldSearchRaw = { true },
         )
 
         assertEquals(listOf(8, 8, 8, 2, 1, 1), rawSizes)
@@ -295,6 +374,7 @@ class MediaStackingTest {
                             )
                         },
                         parse = { body -> listOf(body.decodeToString()) },
+                        shouldSearchRaw = { true },
                     )
                 }
             }
@@ -324,6 +404,7 @@ class MediaStackingTest {
                             }
                         },
                         parse = { body -> listOf(body.decodeToString()) },
+                        shouldSearchRaw = { true },
                     )
                 }
             }
@@ -345,6 +426,7 @@ class MediaStackingTest {
                     )
                 },
                 parse = { throw IllegalArgumentException("Malformed DAV response.") },
+                shouldSearchRaw = { true },
             )
         }
 
@@ -383,6 +465,7 @@ class MediaStackingTest {
                     }
                     listOf(body.decodeToString())
                 },
+                shouldSearchRaw = { true },
             )
         }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -664,6 +664,8 @@ class DesktopNextcloudServices(
                     MediaSearchDavTransportResponse(response.status, response.body)
                 },
                 parse = { body -> parseDavFiles(body, userId) },
+                shouldSearchRaw = { files -> files.any(NextcloudFile::isRawPhoto) },
+                rawCompatibilityPolicy = RawMediaSearchCompatibilityPolicy.KeepAvailableResults,
             )
             mergeMediaSearchResultPages(pages)
         }


### PR DESCRIPTION
## Summary

- load and parse the required image and video MIME partitions before deciding whether RAW discovery is needed
- skip RAW filename SEARCH requests when the available media contains no RAW item
- preserve the normal timeline when optional RAW discovery receives a compatibility rejection or reaches its bounded request limit
- keep authentication, permission, transport, parsing, and server failures visible
- require every caller to provide an explicit RAW-search predicate

## Validation

- JDK 21 focused `MediaStackingTest` suite
- JDK 21 Android debug compilation and APK assembly
- repository, text, changelog, signing, update-manifest, and nightly-publisher hygiene checks
- visible Android emulator with an enforced read-only imported session against a real Nextcloud server
- cold relaunch and repeated Photos navigation with a populated media grid
- UI dump and logcat inspection confirming no RAW compatibility error

Closes #239
