### PR TITLE
feat(photos): add native Live Photo playback

### DIFF
--- a/changes/unreleased/182-live-photo-playback.md
+++ b/changes/unreleased/182-live-photo-playback.md
@@ -1,0 +1,7 @@
+category: feature
+issue: 182
+pull: none
+platforms: android
+user-facing: yes
+
+Photos now recognizes server-indexed Live Photos and Motion Photos, shows their motion state, and plays the motion component while keeping the still image as a reliable fallback.

--- a/changes/unreleased/182-live-photo-playback.md
+++ b/changes/unreleased/182-live-photo-playback.md
@@ -1,6 +1,6 @@
 category: feature
 issue: 182
-pull: none
+pull: 244
 platforms: android
 user-facing: yes
 

--- a/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.android.kt
+++ b/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.android.kt
@@ -25,12 +25,12 @@ internal actual val platformNativeVideoPlaybackAvailable: Boolean = true
 internal actual fun PlatformNativeVideoPlayer(
     session: NextcloudSession,
     userId: String,
-    file: NextcloudFile,
+    source: NativeVideoPlaybackSource,
     onError: (String) -> Unit,
     modifier: Modifier,
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
-    val player = remember(session.serverUrl, session.loginName, userId, file.path, file.etag) {
+    val player = remember(session.serverUrl, session.loginName, userId, source) {
         val authorization = Base64.encodeToString(
             "${session.loginName}:${session.appPassword}".toByteArray(Charsets.UTF_8),
             Base64.NO_WRAP,
@@ -42,15 +42,31 @@ internal actual fun PlatformNativeVideoPlayer(
         val sourceFactory = OkHttpDataSource.Factory(client)
             .setUserAgent("Nextcloud Native")
             .setDefaultRequestProperties(mapOf("Authorization" to "Basic $authorization"))
+        val mediaId = when (source) {
+            is NativeVideoPlaybackSource.DavFile ->
+                source.file.fileId?.toString() ?: source.file.path
+            is NativeVideoPlaybackSource.MemoriesLivePhoto ->
+                "live-photo:${source.source.fileId}"
+        }
+        val uri = when (source) {
+            is NativeVideoPlaybackSource.DavFile ->
+                buildNextcloudFileUrl(session.serverUrl, userId, source.file.path)
+            is NativeVideoPlaybackSource.MemoriesLivePhoto ->
+                buildNextcloudApiUrl(session.serverUrl, memoriesLivePhotoVideoRequest(source.source))
+        }
         val item = MediaItem.Builder()
-            .setMediaId(file.fileId?.toString() ?: file.path)
-            .setUri(buildNextcloudFileUrl(session.serverUrl, userId, file.path))
-            .setMimeType(file.mimeType)
+            .setMediaId(mediaId)
+            .setUri(uri)
+            .apply {
+                if (source is NativeVideoPlaybackSource.DavFile) {
+                    setMimeType(source.file.mimeType)
+                }
+            }
             .build()
         ExoPlayer.Builder(context.applicationContext).build().apply {
             setMediaSource(ProgressiveMediaSource.Factory(sourceFactory).createMediaSource(item))
             prepare()
-            playWhenReady = false
+            playWhenReady = source is NativeVideoPlaybackSource.MemoriesLivePhoto
         }
     }
     val currentOnError = rememberUpdatedState(onError)

--- a/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.android.kt
+++ b/ui/src/androidMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.android.kt
@@ -26,10 +26,13 @@ internal actual fun PlatformNativeVideoPlayer(
     session: NextcloudSession,
     userId: String,
     source: NativeVideoPlaybackSource,
+    onPlaybackEnded: () -> Unit,
     onError: (String) -> Unit,
     modifier: Modifier,
 ) {
     val context = androidx.compose.ui.platform.LocalContext.current
+    val currentOnPlaybackEnded = rememberUpdatedState(onPlaybackEnded)
+    val currentOnError = rememberUpdatedState(onError)
     val player = remember(session.serverUrl, session.loginName, userId, source) {
         val authorization = Base64.encodeToString(
             "${session.loginName}:${session.appPassword}".toByteArray(Charsets.UTF_8),
@@ -41,7 +44,9 @@ internal actual fun PlatformNativeVideoPlayer(
             .build()
         val sourceFactory = OkHttpDataSource.Factory(client)
             .setUserAgent("Nextcloud Native")
-            .setDefaultRequestProperties(mapOf("Authorization" to "Basic $authorization"))
+            .setDefaultRequestProperties(
+                source.authenticatedRequestProperties("Basic $authorization"),
+            )
         val mediaId = when (source) {
             is NativeVideoPlaybackSource.DavFile ->
                 source.file.fileId?.toString() ?: source.file.path
@@ -64,21 +69,28 @@ internal actual fun PlatformNativeVideoPlayer(
             }
             .build()
         ExoPlayer.Builder(context.applicationContext).build().apply {
+            addListener(
+                object : Player.Listener {
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (playbackState == Player.STATE_ENDED) {
+                            currentOnPlaybackEnded.value()
+                        }
+                    }
+
+                    override fun onPlayerError(error: PlaybackException) {
+                        currentOnError.value(
+                            error.message ?: "Android could not play this video format.",
+                        )
+                    }
+                },
+            )
             setMediaSource(ProgressiveMediaSource.Factory(sourceFactory).createMediaSource(item))
             prepare()
             playWhenReady = source is NativeVideoPlaybackSource.MemoriesLivePhoto
         }
     }
-    val currentOnError = rememberUpdatedState(onError)
     DisposableEffect(player) {
-        val listener = object : Player.Listener {
-            override fun onPlayerError(error: PlaybackException) {
-                currentOnError.value(error.message ?: "Android could not play this video format.")
-            }
-        }
-        player.addListener(listener)
         onDispose {
-            player.removeListener(listener)
             player.release()
         }
     }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotoDetection.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotoDetection.kt
@@ -1,0 +1,560 @@
+package dev.obiente.nextcloudnative.app
+
+/**
+ * A byte range within one immutable media object.
+ *
+ * The range is descriptive only. Reading it remains the responsibility of an ETag-bound platform
+ * transport so detection cannot silently combine bytes from different generations.
+ */
+data class LivePhotoByteRange(
+    val offset: Long,
+    val length: Long,
+) {
+    init {
+        require(offset >= 0L) { "The live-photo byte-range offset is invalid." }
+        require(length > 0L) { "The live-photo byte-range length is invalid." }
+        require(offset <= Long.MAX_VALUE - length) { "The live-photo byte range overflows." }
+    }
+
+    val endExclusive: Long
+        get() = offset + length
+}
+
+enum class AndroidMotionPhotoMetadataKind {
+    MotionPhotoV1,
+    LegacyMicroVideoV1,
+}
+
+/**
+ * Metadata evidence that identifies where an Android motion stream should begin.
+ *
+ * This is deliberately not a confirmed logical asset. Android's format warns that XMP can survive
+ * after an editor strips the appended video, so callers must validate a bounded probe with
+ * [confirmAndroidMotionPhoto].
+ */
+data class AndroidMotionPhotoCandidate(
+    val metadataKind: AndroidMotionPhotoMetadataKind,
+    val primaryMimeType: String,
+    val motionMimeType: String,
+    val videoRange: LivePhotoByteRange,
+    val photoPresentationTimestampUs: Long?,
+)
+
+data class LivePhotoVideoProbe(
+    val offset: Long,
+    val bytes: ByteArray,
+) {
+    init {
+        require(offset >= 0L) { "The live-photo probe offset is invalid." }
+        require(bytes.size <= MAX_LIVE_PHOTO_VIDEO_PROBE_BYTES) {
+            "The live-photo probe exceeds the bounded read limit."
+        }
+    }
+}
+
+sealed interface DetectedLivePhotoAsset {
+    data class EmbeddedAndroidMotionPhoto(
+        val metadataKind: AndroidMotionPhotoMetadataKind,
+        val primaryMimeType: String,
+        val motionMimeType: String,
+        val videoRange: LivePhotoByteRange,
+        val photoPresentationTimestampUs: Long?,
+    ) : DetectedLivePhotoAsset
+
+    data class PairedAppleLivePhoto(
+        val contentIdentifier: String,
+        val still: AppleLivePhotoComponent,
+        val pairedVideo: AppleLivePhotoComponent,
+    ) : DetectedLivePhotoAsset
+}
+
+enum class AppleLivePhotoComponentRole {
+    Still,
+    PairedVideo,
+}
+
+/**
+ * Metadata extracted from one original Apple Photos resource.
+ *
+ * Platform code owns extraction from HEIC/JPEG MakerApple metadata and QuickTime metadata. This
+ * platform-neutral model deliberately does not pair by basename, timestamp, or directory.
+ */
+data class AppleLivePhotoComponent(
+    /** Account- or library-scoped identity shared only by components eligible to pair. */
+    val pairingScopeIdentity: String,
+    val resourceIdentity: String,
+    val displayName: String,
+    val mimeType: String,
+    val role: AppleLivePhotoComponentRole,
+    val contentIdentifier: String?,
+)
+
+/**
+ * Parses bounded Android XMP into a candidate probe location.
+ *
+ * Modern Motion Photo metadata takes precedence over legacy MicroVideo metadata. An explicit
+ * `MotionPhoto=0` always falls back to an ordinary photo. Unknown versions, unsupported primary
+ * formats, inconsistent container items, and ranges outside [containerSize] are rejected.
+ */
+fun planAndroidMotionPhotoProbe(
+    primaryMimeType: String,
+    containerSize: Long,
+    xmpBytes: ByteArray,
+): AndroidMotionPhotoCandidate? {
+    if (containerSize <= 0L || xmpBytes.isEmpty() || xmpBytes.size > MAX_LIVE_PHOTO_XMP_BYTES) return null
+    val normalizedPrimaryMime = primaryMimeType.normalizedMediaMimeType() ?: return null
+    val elements = parseBoundedXml(xmpBytes) ?: return null
+
+    val motionPhotoValues = elements.namespacedValues(CAMERA_NAMESPACE, "MotionPhoto")
+    if (motionPhotoValues.isNotEmpty()) {
+        if (motionPhotoValues.size != 1) return null
+        val motionPhoto = motionPhotoValues.single()
+        if (motionPhoto != "1") return null
+        if (elements.namespacedValue(CAMERA_NAMESPACE, "MotionPhotoVersion") != "1") return null
+        if (normalizedPrimaryMime !in MODERN_MOTION_PHOTO_PRIMARY_MIME_TYPES) return null
+        val items = elements.motionPhotoContainerItems() ?: return null
+        if (items.firstOrNull()?.semantic != "Primary") return null
+        if (items.count { it.semantic == "Primary" } != 1) return null
+        val primary = items.first()
+        if (primary.mimeType != normalizedPrimaryMime) return null
+        if (
+            normalizedPrimaryMime in BOXED_MOTION_PHOTO_PRIMARY_MIME_TYPES &&
+            primary.padding != MOTION_PHOTO_VIDEO_DATA_BOX_BYTES
+        ) {
+            return null
+        }
+        val motionItems = items.filter { it.semantic == "MotionPhoto" }
+        if (motionItems.size != 1 || items.last() != motionItems.single()) return null
+        val motion = motionItems.single()
+        if (motion.mimeType !in MOTION_VIDEO_MIME_TYPES) return null
+        val videoLength = motion.length?.takeIf { it > 0L } ?: return null
+        val declaredTrailerBytes = items.drop(1).fold(primary.padding ?: 0L) { total, item ->
+            val itemLength = item.length ?: return null
+            if (total > Long.MAX_VALUE - itemLength) return null
+            total + itemLength
+        }
+        if (declaredTrailerBytes >= containerSize) return null
+        val videoRange = trailerRange(containerSize, videoLength) ?: return null
+        val presentationTimestamp = elements.presentationTimestampOrNull(
+            "MotionPhotoPresentationTimestampUs",
+        ) ?: return null
+        return AndroidMotionPhotoCandidate(
+            metadataKind = AndroidMotionPhotoMetadataKind.MotionPhotoV1,
+            primaryMimeType = normalizedPrimaryMime,
+            motionMimeType = motion.mimeType,
+            videoRange = videoRange,
+            photoPresentationTimestampUs = presentationTimestamp.value,
+        )
+    }
+
+    if (normalizedPrimaryMime != LEGACY_MOTION_PHOTO_PRIMARY_MIME_TYPE) return null
+    if (elements.namespacedValue(CAMERA_NAMESPACE, "MicroVideo") != "1") return null
+    if (elements.namespacedValue(CAMERA_NAMESPACE, "MicroVideoVersion") != "1") return null
+    val videoLength = elements.namespacedValue(CAMERA_NAMESPACE, "MicroVideoOffset")
+        ?.strictPositiveLong()
+        ?: return null
+    val videoRange = trailerRange(containerSize, videoLength) ?: return null
+    val presentationTimestamp = elements.presentationTimestampOrNull(
+        "MicroVideoPresentationTimestampUs",
+    ) ?: return null
+    return AndroidMotionPhotoCandidate(
+        metadataKind = AndroidMotionPhotoMetadataKind.LegacyMicroVideoV1,
+        primaryMimeType = normalizedPrimaryMime,
+        motionMimeType = "video/mp4",
+        videoRange = videoRange,
+        photoPresentationTimestampUs = presentationTimestamp.value,
+    )
+}
+
+/**
+ * Confirms that the candidate's exact trailer offset begins with a bounded ISO BMFF video probe.
+ *
+ * This prevents residual XMP from turning an edited ordinary photo into a false Motion Photo.
+ */
+fun confirmAndroidMotionPhoto(
+    candidate: AndroidMotionPhotoCandidate,
+    probe: LivePhotoVideoProbe,
+): DetectedLivePhotoAsset.EmbeddedAndroidMotionPhoto? {
+    if (probe.offset != candidate.videoRange.offset) return null
+    if (!probe.bytes.hasIsoBaseMediaFileTypeBox(candidate.videoRange.length)) return null
+    return DetectedLivePhotoAsset.EmbeddedAndroidMotionPhoto(
+        metadataKind = candidate.metadataKind,
+        primaryMimeType = candidate.primaryMimeType,
+        motionMimeType = candidate.motionMimeType,
+        videoRange = candidate.videoRange,
+        photoPresentationTimestampUs = candidate.photoPresentationTimestampUs,
+    )
+}
+
+/**
+ * Pairs original Apple still and MOV resources only when their extracted identifiers match exactly.
+ *
+ * Filename, stem, timestamp, and folder proximity are intentionally ignored because they are not
+ * authoritative pairing evidence.
+ */
+fun pairAppleLivePhoto(
+    still: AppleLivePhotoComponent,
+    pairedVideo: AppleLivePhotoComponent,
+): DetectedLivePhotoAsset.PairedAppleLivePhoto? {
+    if (still.role != AppleLivePhotoComponentRole.Still) return null
+    if (pairedVideo.role != AppleLivePhotoComponentRole.PairedVideo) return null
+    if (still.mimeType.normalizedMediaMimeType() !in APPLE_LIVE_PHOTO_STILL_MIME_TYPES) return null
+    if (pairedVideo.mimeType.normalizedMediaMimeType() != APPLE_LIVE_PHOTO_VIDEO_MIME_TYPE) return null
+    if (!still.hasSafeLivePhotoComponentIdentity() || !pairedVideo.hasSafeLivePhotoComponentIdentity()) return null
+    if (still.pairingScopeIdentity != pairedVideo.pairingScopeIdentity) return null
+    val stillIdentifier = still.contentIdentifier?.takeIf(String::isSafeAppleContentIdentifier) ?: return null
+    val videoIdentifier = pairedVideo.contentIdentifier?.takeIf(String::isSafeAppleContentIdentifier) ?: return null
+    if (stillIdentifier != videoIdentifier || still.resourceIdentity == pairedVideo.resourceIdentity) return null
+    return DetectedLivePhotoAsset.PairedAppleLivePhoto(
+        contentIdentifier = stillIdentifier,
+        still = still.copy(contentIdentifier = stillIdentifier),
+        pairedVideo = pairedVideo.copy(contentIdentifier = videoIdentifier),
+    )
+}
+
+private data class MotionPhotoContainerItem(
+    val mimeType: String,
+    val semantic: String,
+    val length: Long?,
+    val padding: Long?,
+)
+
+private data class OptionalPresentationTimestamp(val value: Long?)
+
+private data class ParsedXmlElement(
+    val namespaceUri: String?,
+    val localName: String,
+    val attributes: List<ParsedXmlAttribute>,
+) {
+    fun attribute(namespaceUri: String, localName: String): String? =
+        attributes.singleOrNull { it.namespaceUri == namespaceUri && it.localName == localName }?.value
+}
+
+private data class ParsedXmlAttribute(
+    val namespaceUri: String?,
+    val localName: String,
+    val value: String,
+)
+
+private data class OpenXmlElement(
+    val qualifiedName: String,
+    val namespaces: Map<String, String>,
+)
+
+private data class ParsedStartTag(
+    val qualifiedName: String,
+    val attributes: Map<String, String>,
+    val selfClosing: Boolean,
+)
+
+private fun List<ParsedXmlElement>.motionPhotoContainerItems(): List<MotionPhotoContainerItem>? {
+    val itemElements = filter { it.namespaceUri == CONTAINER_NAMESPACE && it.localName == "Item" }
+    if (itemElements.size !in 2..MAX_MOTION_PHOTO_CONTAINER_ITEMS) return null
+    return itemElements.map { element ->
+        val mimeType = element.attribute(CONTAINER_ITEM_NAMESPACE, "Mime")
+            ?.normalizedMediaMimeType()
+            ?: return null
+        val semantic = element.attribute(CONTAINER_ITEM_NAMESPACE, "Semantic")
+            ?.takeIf { it.isSafeMetadataToken(MAX_MOTION_PHOTO_SEMANTIC_LENGTH) }
+            ?: return null
+        val lengthText = element.attribute(CONTAINER_ITEM_NAMESPACE, "Length")
+        val length = when {
+            semantic == "Primary" && lengthText == null -> null
+            semantic == "Primary" && lengthText == "0" -> 0L
+            semantic == "Primary" -> return null
+            else -> lengthText?.strictNonNegativeLong() ?: return null
+        }
+        val paddingText = element.attribute(CONTAINER_ITEM_NAMESPACE, "Padding")
+        val padding = when {
+            semantic != "Primary" && paddingText != null -> return null
+            paddingText == null -> null
+            else -> paddingText.strictNonNegativeLong() ?: return null
+        }
+        MotionPhotoContainerItem(mimeType, semantic, length, padding)
+    }
+}
+
+private fun List<ParsedXmlElement>.presentationTimestampOrNull(
+    localName: String,
+): OptionalPresentationTimestamp? {
+    val values = namespacedValues(CAMERA_NAMESPACE, localName)
+    if (values.isEmpty()) return OptionalPresentationTimestamp(null)
+    if (values.size != 1) return null
+    val value = values.single()
+    return OptionalPresentationTimestamp(value.toLongOrNull()?.takeIf { it >= -1L } ?: return null)
+}
+
+private fun List<ParsedXmlElement>.namespacedValue(namespaceUri: String, localName: String): String? {
+    val values = namespacedValues(namespaceUri, localName)
+    return values.singleOrNull()
+}
+
+private fun List<ParsedXmlElement>.namespacedValues(namespaceUri: String, localName: String): List<String> =
+    flatMap { element ->
+        element.attributes.filter { it.namespaceUri == namespaceUri && it.localName == localName }
+    }.map(ParsedXmlAttribute::value)
+
+private fun trailerRange(containerSize: Long, trailerLength: Long): LivePhotoByteRange? {
+    if (trailerLength <= 0L || trailerLength >= containerSize) return null
+    return LivePhotoByteRange(offset = containerSize - trailerLength, length = trailerLength)
+}
+
+private fun ByteArray.hasIsoBaseMediaFileTypeBox(videoLength: Long): Boolean {
+    if (size < MIN_LIVE_PHOTO_VIDEO_PROBE_BYTES || videoLength < MIN_LIVE_PHOTO_VIDEO_PROBE_BYTES) return false
+    val boxSize = readUnsignedBigEndianInt(0)
+    if (boxSize !in MIN_LIVE_PHOTO_VIDEO_PROBE_BYTES.toLong()..videoLength) return false
+    return copyOfRange(4, 8).decodeToString() == "ftyp"
+}
+
+private fun ByteArray.readUnsignedBigEndianInt(offset: Int): Long {
+    if (offset < 0 || size - offset < Int.SIZE_BYTES) return -1L
+    return (0 until Int.SIZE_BYTES).fold(0L) { value, index ->
+        (value shl Byte.SIZE_BITS) or (this[offset + index].toLong() and 0xFFL)
+    }
+}
+
+private fun parseBoundedXml(bytes: ByteArray): List<ParsedXmlElement>? {
+    val xml = runCatching { bytes.decodeToString(throwOnInvalidSequence = true) }.getOrNull() ?: return null
+    if (xml.any { it.isISOControl() && it !in setOf('\t', '\n', '\r') }) return null
+    val elements = mutableListOf<ParsedXmlElement>()
+    val stack = mutableListOf<OpenXmlElement>()
+    var index = 0
+    var rootComplete = false
+    while (index < xml.length) {
+        val tagStart = xml.indexOf('<', index)
+        if (tagStart < 0) {
+            if (stack.isEmpty() && xml.substring(index).isNotBlank()) return null
+            break
+        }
+        if (stack.isEmpty() && xml.substring(index, tagStart).isNotBlank()) return null
+        when {
+            xml.startsWith("<?", tagStart) -> {
+                val end = xml.indexOf("?>", tagStart + 2)
+                if (end < 0) return null
+                index = end + 2
+            }
+            xml.startsWith("<!--", tagStart) -> {
+                val end = xml.indexOf("-->", tagStart + 4)
+                if (end < 0) return null
+                index = end + 3
+            }
+            xml.startsWith("<![CDATA[", tagStart) -> {
+                if (stack.isEmpty()) return null
+                val end = xml.indexOf("]]>", tagStart + 9)
+                if (end < 0) return null
+                index = end + 3
+            }
+            xml.startsWith("<!", tagStart) -> return null
+            xml.startsWith("</", tagStart) -> {
+                val end = xml.indexOf('>', tagStart + 2)
+                if (end < 0) return null
+                val qualifiedName = xml.substring(tagStart + 2, end).trim()
+                if (!qualifiedName.isValidQualifiedXmlName()) return null
+                if (stack.lastOrNull()?.qualifiedName != qualifiedName) return null
+                stack.removeAt(stack.lastIndex)
+                if (stack.isEmpty()) rootComplete = true
+                index = end + 1
+            }
+            else -> {
+                val end = xml.findXmlTagEnd(tagStart + 1) ?: return null
+                val startTag = parseStartTag(xml.substring(tagStart + 1, end)) ?: return null
+                if (stack.isEmpty() && rootComplete) return null
+                val namespaces = stack.lastOrNull()?.namespaces.orEmpty().toMutableMap()
+                startTag.attributes.forEach { (name, value) ->
+                    when {
+                        name == "xmlns" -> namespaces[""] = value
+                        name.startsWith("xmlns:") -> namespaces[name.substringAfter(':')] = value
+                    }
+                }
+                val elementName = resolveQualifiedName(startTag.qualifiedName, namespaces, defaultApplies = true)
+                    ?: return null
+                val attributes = startTag.attributes.mapNotNull { (name, value) ->
+                    if (name == "xmlns" || name.startsWith("xmlns:")) {
+                        null
+                    } else {
+                        val resolved = resolveQualifiedName(name, namespaces, defaultApplies = false)
+                            ?: return null
+                        ParsedXmlAttribute(resolved.first, resolved.second, value)
+                    }
+                }
+                elements += ParsedXmlElement(elementName.first, elementName.second, attributes)
+                if (startTag.selfClosing) {
+                    if (stack.isEmpty()) rootComplete = true
+                } else {
+                    stack += OpenXmlElement(startTag.qualifiedName, namespaces)
+                }
+                index = end + 1
+            }
+        }
+    }
+    return elements.takeIf { rootComplete && stack.isEmpty() && it.isNotEmpty() }
+}
+
+private fun String.findXmlTagEnd(start: Int): Int? {
+    var quote: Char? = null
+    for (index in start until length) {
+        val character = this[index]
+        if (quote != null) {
+            if (character == quote) quote = null
+        } else {
+            when (character) {
+                '\'', '"' -> quote = character
+                '>' -> return index
+                '<' -> return null
+            }
+        }
+    }
+    return null
+}
+
+private fun parseStartTag(source: String): ParsedStartTag? {
+    var content = source.trim()
+    val selfClosing = content.endsWith('/')
+    if (selfClosing) content = content.dropLast(1).trimEnd()
+    var index = 0
+    val nameEnd = content.indexOfFirst { it.isWhitespace() }.let { if (it < 0) content.length else it }
+    val qualifiedName = content.substring(0, nameEnd)
+    if (!qualifiedName.isValidQualifiedXmlName()) return null
+    index = nameEnd
+    val attributes = linkedMapOf<String, String>()
+    while (index < content.length) {
+        while (index < content.length && content[index].isWhitespace()) index++
+        if (index == content.length) break
+        val attributeStart = index
+        while (index < content.length && !content[index].isWhitespace() && content[index] != '=') index++
+        val attributeName = content.substring(attributeStart, index)
+        if (!attributeName.isValidQualifiedXmlName() || attributeName in attributes) return null
+        while (index < content.length && content[index].isWhitespace()) index++
+        if (index >= content.length || content[index] != '=') return null
+        index++
+        while (index < content.length && content[index].isWhitespace()) index++
+        if (index >= content.length || content[index] !in setOf('\'', '"')) return null
+        val quote = content[index++]
+        val valueStart = index
+        while (index < content.length && content[index] != quote) {
+            if (content[index] == '<') return null
+            index++
+        }
+        if (index >= content.length) return null
+        val value = decodeXmlAttributeValue(content.substring(valueStart, index)) ?: return null
+        attributes[attributeName] = value
+        index++
+    }
+    return ParsedStartTag(qualifiedName, attributes, selfClosing)
+}
+
+private fun resolveQualifiedName(
+    qualifiedName: String,
+    namespaces: Map<String, String>,
+    defaultApplies: Boolean,
+): Pair<String?, String>? {
+    val colon = qualifiedName.indexOf(':')
+    if (colon < 0) {
+        return (namespaces[""].takeIf { defaultApplies }) to qualifiedName
+    }
+    val prefix = qualifiedName.substring(0, colon)
+    val localName = qualifiedName.substring(colon + 1)
+    return (namespaces[prefix] ?: return null) to localName
+}
+
+private fun decodeXmlAttributeValue(value: String): String? {
+    if ('&' !in value) return value
+    val result = StringBuilder(value.length)
+    var index = 0
+    while (index < value.length) {
+        if (value[index] != '&') {
+            result.append(value[index++])
+            continue
+        }
+        val end = value.indexOf(';', index + 1)
+        if (end < 0) return null
+        val decoded = when (val entity = value.substring(index + 1, end)) {
+            "amp" -> '&'
+            "apos" -> '\''
+            "gt" -> '>'
+            "lt" -> '<'
+            "quot" -> '"'
+            else -> entity.decodeNumericXmlEntity() ?: return null
+        }
+        result.append(decoded)
+        index = end + 1
+    }
+    return result.toString()
+}
+
+private fun String.decodeNumericXmlEntity(): Char? {
+    if (!startsWith('#')) return null
+    val codePoint = if (startsWith("#x", ignoreCase = true)) {
+        substring(2).toIntOrNull(16)
+    } else {
+        substring(1).toIntOrNull()
+    } ?: return null
+    return codePoint.takeIf { it in 0..Char.MAX_VALUE.code }?.toChar()
+}
+
+private fun String.isValidQualifiedXmlName(): Boolean {
+    if (isEmpty() || count { it == ':' } > 1) return false
+    return split(':').all { part ->
+        part.isNotEmpty() &&
+            (part.first().isLetter() || part.first() == '_') &&
+            part.drop(1).all { it.isLetterOrDigit() || it in setOf('_', '-', '.') }
+    }
+}
+
+private fun String.normalizedMediaMimeType(): String? {
+    val normalized = substringBefore(';').trim().lowercase()
+    if (normalized.length !in 3..MAX_LIVE_PHOTO_MIME_LENGTH || normalized.count { it == '/' } != 1) return null
+    val type = normalized.substringBefore('/')
+    val subtype = normalized.substringAfter('/')
+    if (type.isEmpty() || subtype.isEmpty()) return null
+    if (!type.all(Char::isSafeMimeCharacter) || !subtype.all(Char::isSafeMimeCharacter)) return null
+    return normalized
+}
+
+private fun Char.isSafeMimeCharacter(): Boolean =
+    this in 'a'..'z' || this in '0'..'9' || this in "!#$&^_.+-"
+
+private fun String.strictPositiveLong(): Long? {
+    if (isEmpty() || any { it !in '0'..'9' }) return null
+    return toLongOrNull()?.takeIf { it > 0L }
+}
+
+private fun String.strictNonNegativeLong(): Long? {
+    if (isEmpty() || any { it !in '0'..'9' }) return null
+    return toLongOrNull()
+}
+
+private fun String.isSafeMetadataToken(maximumLength: Int): Boolean =
+    length in 1..maximumLength &&
+        none { it.isISOControl() || it == '\u007f' || it.category == CharCategory.FORMAT }
+
+private fun String.isSafeAppleContentIdentifier(): Boolean =
+    length in 1..MAX_APPLE_CONTENT_IDENTIFIER_LENGTH &&
+        this == trim() &&
+        none { it.isISOControl() || it == '\u007f' || it.category == CharCategory.FORMAT }
+
+private fun AppleLivePhotoComponent.hasSafeLivePhotoComponentIdentity(): Boolean =
+    pairingScopeIdentity.isSafeMetadataToken(MAX_LIVE_PHOTO_RESOURCE_IDENTITY_LENGTH) &&
+        resourceIdentity.isSafeMetadataToken(MAX_LIVE_PHOTO_RESOURCE_IDENTITY_LENGTH) &&
+        displayName.isSafeMetadataToken(MAX_LIVE_PHOTO_DISPLAY_NAME_LENGTH)
+
+private const val CAMERA_NAMESPACE = "http://ns.google.com/photos/1.0/camera/"
+private const val CONTAINER_NAMESPACE = "http://ns.google.com/photos/1.0/container/"
+private const val CONTAINER_ITEM_NAMESPACE = "http://ns.google.com/photos/1.0/container/item/"
+private const val LEGACY_MOTION_PHOTO_PRIMARY_MIME_TYPE = "image/jpeg"
+private const val APPLE_LIVE_PHOTO_VIDEO_MIME_TYPE = "video/quicktime"
+private const val MAX_LIVE_PHOTO_XMP_BYTES = 256 * 1024
+private const val MAX_LIVE_PHOTO_VIDEO_PROBE_BYTES = 4 * 1024
+private const val MIN_LIVE_PHOTO_VIDEO_PROBE_BYTES = 12
+private const val MAX_MOTION_PHOTO_CONTAINER_ITEMS = 32
+private const val MAX_MOTION_PHOTO_SEMANTIC_LENGTH = 64
+private const val MOTION_PHOTO_VIDEO_DATA_BOX_BYTES = 8L
+private const val MAX_LIVE_PHOTO_MIME_LENGTH = 127
+private const val MAX_APPLE_CONTENT_IDENTIFIER_LENGTH = 512
+private const val MAX_LIVE_PHOTO_RESOURCE_IDENTITY_LENGTH = 2_048
+private const val MAX_LIVE_PHOTO_DISPLAY_NAME_LENGTH = 512
+
+private val MODERN_MOTION_PHOTO_PRIMARY_MIME_TYPES = setOf("image/jpeg", "image/heic", "image/avif")
+private val BOXED_MOTION_PHOTO_PRIMARY_MIME_TYPES = setOf("image/heic", "image/avif")
+private val MOTION_VIDEO_MIME_TYPES = setOf("video/mp4", "video/quicktime")
+private val APPLE_LIVE_PHOTO_STILL_MIME_TYPES = setOf("image/jpeg", "image/heic", "image/heif")

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotos.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotos.kt
@@ -1,5 +1,6 @@
 package dev.obiente.nextcloudnative.app
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -14,6 +15,43 @@ private const val MAX_LIVE_PHOTO_LOOKUP_BYTES = 256L * 1_024L
 private const val MAX_LIVE_PHOTO_DAY_BYTES = 16L * 1_024L * 1_024L
 private const val MAX_LIVE_PHOTO_DAY_ITEMS = 10_000
 private const val MAX_LIVE_PHOTO_ETAG_LENGTH = 1_024
+private const val MAX_MEMORIES_DESCRIBE_BYTES = 64L * 1_024L
+
+/**
+ * Evidence that the connected Memories app exposes the Live Photo route family used here.
+ *
+ * The public describe endpoint first shipped in Memories 5.2.0. The route family is verified
+ * against upstream Memories source through 8.1.0. Versions outside that audited range remain
+ * disabled until their route contract is reviewed.
+ */
+sealed interface MemoriesLivePhotoCapability {
+    data object NotAdvertised : MemoriesLivePhotoCapability
+
+    data object Unverified : MemoriesLivePhotoCapability
+
+    data class UnsupportedVersion(
+        val installedVersion: String,
+    ) : MemoriesLivePhotoCapability
+
+    data class CompatibleVersion(
+        val installedVersion: String,
+    ) : MemoriesLivePhotoCapability
+
+    /** A validated `liveid` returned by a Memories media response. */
+    data object ObservedReference : MemoriesLivePhotoCapability
+}
+
+private data class MemoriesVersion(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+) : Comparable<MemoriesVersion> {
+    override fun compareTo(other: MemoriesVersion): Int =
+        compareValuesBy(this, other, MemoriesVersion::major, MemoriesVersion::minor, MemoriesVersion::patch)
+}
+
+private val minimumDescribedLivePhotoVersion = MemoriesVersion(5, 2, 0)
+private val maximumAuditedLivePhotoVersion = MemoriesVersion(8, 1, 0)
 
 internal fun String.isSafeLivePhotoToken(): Boolean =
     isNotEmpty() &&
@@ -53,12 +91,70 @@ internal fun NextcloudFile.livePhotoDiscoveryIdentity(): LivePhotoDiscoveryIdent
     )
 
 internal fun NextcloudFile.shouldDiscoverMemoriesLivePhoto(
-    memoriesAvailable: Boolean,
+    capability: MemoriesLivePhotoCapability,
     nativePlaybackAvailable: Boolean,
 ): Boolean =
-    memoriesAvailable &&
+    capability.supportsLivePhotoRoutes() &&
         nativePlaybackAvailable &&
         canResolveMemoriesLivePhoto()
+
+internal fun NextcloudFile.effectiveLivePhotoCapability(
+    describedCapability: MemoriesLivePhotoCapability,
+): MemoriesLivePhotoCapability =
+    if (livePhoto != null) MemoriesLivePhotoCapability.ObservedReference else describedCapability
+
+internal fun memoriesDescribeRequest(): NextcloudApiRequest =
+    NextcloudApiRequest(
+        method = NextcloudApiMethod.GET,
+        relativePath = "/index.php/apps/memories/api/describe",
+        maximumResponseBytes = MAX_MEMORIES_DESCRIBE_BYTES,
+        cachePolicy = NextcloudApiCachePolicy.ForceNetwork,
+    ).requireSafe()
+
+internal fun parseMemoriesLivePhotoCapability(
+    response: NextcloudApiResponse,
+): MemoriesLivePhotoCapability {
+    if (response.status !in 200..299) return MemoriesLivePhotoCapability.Unverified
+    val root = runCatching {
+        livePhotoJson.parseToJsonElement(response.body.decodeToString()) as? JsonObject
+    }.getOrNull() ?: return MemoriesLivePhotoCapability.Unverified
+    val installedVersion = (root["version"] as? JsonPrimitive)
+        ?.contentOrNull
+        ?.takeIf(String::isSafeMemoriesVersionText)
+        ?: return MemoriesLivePhotoCapability.Unverified
+    val parsed = installedVersion.parseMemoriesVersion()
+        ?: return MemoriesLivePhotoCapability.Unverified
+    return if (parsed in minimumDescribedLivePhotoVersion..maximumAuditedLivePhotoVersion) {
+        MemoriesLivePhotoCapability.CompatibleVersion(installedVersion)
+    } else {
+        MemoriesLivePhotoCapability.UnsupportedVersion(installedVersion)
+    }
+}
+
+suspend fun discoverMemoriesLivePhotoCapability(
+    services: NextcloudPlatformServices,
+    session: NextcloudSession,
+): MemoriesLivePhotoCapability =
+    try {
+        parseMemoriesLivePhotoCapability(
+            services.executeNextcloudApi(session, memoriesDescribeRequest()),
+        )
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        MemoriesLivePhotoCapability.Unverified
+    }
+
+internal suspend fun <T> livePhotoLookupOrNull(
+    lookup: suspend () -> T,
+): T? =
+    try {
+        lookup()
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        null
+    }
 
 fun memoriesLivePhotoInfoRequest(fileId: Long): NextcloudApiRequest {
     require(fileId > 0L) { "The Live Photo file ID is invalid." }
@@ -190,6 +286,24 @@ private fun String.isSafeLivePhotoEtag(): Boolean =
         none { character -> character.isISOControl() || character == '\u007f' }
 
 private val livePhotoJson = Json { ignoreUnknownKeys = true }
+
+private fun MemoriesLivePhotoCapability.supportsLivePhotoRoutes(): Boolean =
+    this is MemoriesLivePhotoCapability.CompatibleVersion ||
+        this is MemoriesLivePhotoCapability.ObservedReference
+
+private fun String.isSafeMemoriesVersionText(): Boolean =
+    isNotBlank() &&
+        length <= 64 &&
+        none { character -> character.isISOControl() || character == '\u007f' }
+
+private fun String.parseMemoriesVersion(): MemoriesVersion? {
+    val match = Regex("""^([0-9]+)\.([0-9]+)\.([0-9]+)$""").matchEntire(this) ?: return null
+    return MemoriesVersion(
+        major = match.groupValues[1].toIntOrNull() ?: return null,
+        minor = match.groupValues[2].toIntOrNull() ?: return null,
+        patch = match.groupValues[3].toIntOrNull() ?: return null,
+    )
+}
 
 private fun NextcloudApiResponse.livePhotoJsonObject(label: String): JsonObject =
     runCatching { livePhotoJson.parseToJsonElement(body.decodeToString()) as? JsonObject }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotos.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotos.kt
@@ -31,6 +31,35 @@ data class MemoriesLivePhotoSource(
     }
 }
 
+internal data class LivePhotoDiscoveryIdentity(
+    val path: String,
+    val fileId: Long?,
+    val etag: String?,
+    val size: Long?,
+    val lastModified: String?,
+    val mimeType: String?,
+    val serverReference: String?,
+)
+
+internal fun NextcloudFile.livePhotoDiscoveryIdentity(): LivePhotoDiscoveryIdentity =
+    LivePhotoDiscoveryIdentity(
+        path = path,
+        fileId = fileId,
+        etag = etag,
+        size = size,
+        lastModified = lastModified,
+        mimeType = mimeType,
+        serverReference = livePhoto?.serverToken,
+    )
+
+internal fun NextcloudFile.shouldDiscoverMemoriesLivePhoto(
+    memoriesAvailable: Boolean,
+    nativePlaybackAvailable: Boolean,
+): Boolean =
+    memoriesAvailable &&
+        nativePlaybackAvailable &&
+        canResolveMemoriesLivePhoto()
+
 fun memoriesLivePhotoInfoRequest(fileId: Long): NextcloudApiRequest {
     require(fileId > 0L) { "The Live Photo file ID is invalid." }
     return NextcloudApiRequest(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotos.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotos.kt
@@ -1,0 +1,178 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.longOrNull
+
+internal const val MAX_LIVE_PHOTO_TOKEN_LENGTH = 1_024
+private const val MAX_LIVE_PHOTO_LOOKUP_BYTES = 256L * 1_024L
+private const val MAX_LIVE_PHOTO_DAY_BYTES = 16L * 1_024L * 1_024L
+private const val MAX_LIVE_PHOTO_DAY_ITEMS = 10_000
+private const val MAX_LIVE_PHOTO_ETAG_LENGTH = 1_024
+
+internal fun String.isSafeLivePhotoToken(): Boolean =
+    isNotEmpty() &&
+        length <= MAX_LIVE_PHOTO_TOKEN_LENGTH &&
+        none { character -> character.isISOControl() || character == '\u007f' }
+
+data class MemoriesLivePhotoSource(
+    val fileId: Long,
+    val reference: NextcloudLivePhotoReference,
+    val etag: String?,
+) {
+    init {
+        require(fileId > 0L) { "The Live Photo file ID is invalid." }
+        require(etag == null || etag.isSafeLivePhotoEtag()) { "The Live Photo ETag is invalid." }
+    }
+}
+
+fun memoriesLivePhotoInfoRequest(fileId: Long): NextcloudApiRequest {
+    require(fileId > 0L) { "The Live Photo file ID is invalid." }
+    return NextcloudApiRequest(
+        method = NextcloudApiMethod.GET,
+        relativePath = "/index.php/apps/memories/api/image/info/$fileId",
+        queryParameters = mapOf("basic" to "1"),
+        ocsApiRequest = true,
+        maximumResponseBytes = MAX_LIVE_PHOTO_LOOKUP_BYTES,
+    ).requireSafe()
+}
+
+fun parseMemoriesLivePhotoDayId(
+    response: NextcloudApiResponse,
+    expectedFileId: Long,
+): Long {
+    require(expectedFileId > 0L) { "The expected Live Photo file ID is invalid." }
+    require(response.status in 200..299) {
+        "Memories could not inspect this photo (HTTP ${response.status})."
+    }
+    val root = response.livePhotoJsonObject("Memories photo information")
+    require(root.positiveLong("fileid") == expectedFileId) {
+        "Memories returned information for another photo."
+    }
+    return root.positiveLong("dayid")
+}
+
+fun memoriesLivePhotoDayRequest(dayId: Long): NextcloudApiRequest {
+    require(dayId > 0L) { "The Live Photo day ID is invalid." }
+    return NextcloudApiRequest(
+        method = NextcloudApiMethod.GET,
+        relativePath = "/index.php/apps/memories/api/days/$dayId",
+        ocsApiRequest = true,
+        maximumResponseBytes = MAX_LIVE_PHOTO_DAY_BYTES,
+    ).requireSafe()
+}
+
+fun parseMemoriesLivePhotoSource(
+    response: NextcloudApiResponse,
+    expectedFileId: Long,
+    expectedDayId: Long,
+): MemoriesLivePhotoSource? {
+    require(expectedFileId > 0L) { "The expected Live Photo file ID is invalid." }
+    require(expectedDayId > 0L) { "The expected Live Photo day ID is invalid." }
+    require(response.status in 200..299) {
+        "Memories could not inspect this photo's day (HTTP ${response.status})."
+    }
+    val items = response.livePhotoJsonArray("Memories photo day")
+    require(items.size <= MAX_LIVE_PHOTO_DAY_ITEMS) {
+        "The Memories photo day contains too many items."
+    }
+    val matches = items.mapIndexedNotNull { index, element ->
+        val item = element as? JsonObject
+            ?: error("Memories photo day item $index is not an object.")
+        val fileId = item.positiveLong("fileid")
+        val dayId = item.positiveLong("dayid")
+        require(dayId == expectedDayId) { "Memories returned media from another day." }
+        if (fileId == expectedFileId) item else null
+    }
+    require(matches.size <= 1) { "Memories returned duplicate photo records." }
+    val item = matches.singleOrNull() ?: return null
+    val token = item.optionalText("liveid") ?: return null
+    require(token.isSafeLivePhotoToken()) { "Memories returned an invalid Live Photo reference." }
+    val etag = item.optionalText("etag")
+    require(etag == null || etag.isSafeLivePhotoEtag()) {
+        "Memories returned an invalid Live Photo ETag."
+    }
+    return MemoriesLivePhotoSource(
+        fileId = expectedFileId,
+        reference = NextcloudLivePhotoReference(token),
+        etag = etag,
+    )
+}
+
+suspend fun resolveMemoriesLivePhotoSource(
+    services: NextcloudPlatformServices,
+    session: NextcloudSession,
+    file: NextcloudFile,
+): MemoriesLivePhotoSource? {
+    val fileId = file.fileId ?: return null
+    file.livePhoto?.let { reference ->
+        return MemoriesLivePhotoSource(fileId, reference, file.etag)
+    }
+    if (!file.canResolveMemoriesLivePhoto()) return null
+    val infoResponse = services.executeNextcloudApi(session, memoriesLivePhotoInfoRequest(fileId))
+    val dayId = withContext(Dispatchers.Default) {
+        parseMemoriesLivePhotoDayId(
+            response = infoResponse,
+            expectedFileId = fileId,
+        )
+    }
+    val dayResponse = services.executeNextcloudApi(session, memoriesLivePhotoDayRequest(dayId))
+    return withContext(Dispatchers.Default) {
+        parseMemoriesLivePhotoSource(
+            response = dayResponse,
+            expectedFileId = fileId,
+            expectedDayId = dayId,
+        )
+    }
+}
+
+fun memoriesLivePhotoVideoRequest(source: MemoriesLivePhotoSource): NextcloudApiRequest =
+    NextcloudApiRequest(
+        method = NextcloudApiMethod.GET,
+        relativePath = "/index.php/apps/memories/api/video/livephoto/${source.fileId}",
+        queryParameters = buildMap {
+            put("liveid", source.reference.serverToken)
+            source.etag?.let { put("etag", it) }
+        },
+        ocsApiRequest = true,
+        maximumResponseBytes = 1L,
+    ).requireSafe()
+
+internal fun NextcloudFile.canResolveMemoriesLivePhoto(): Boolean {
+    if (
+        isDirectory ||
+        fileId == null ||
+        mediaAssetFormat() !in setOf(MediaAssetFormat.Jpeg, MediaAssetFormat.Image)
+    ) {
+        return false
+    }
+    val extension = name.substringAfterLast('.', missingDelimiterValue = "").lowercase()
+    return extension in setOf("jpg", "jpeg", "heic", "heif", "avif")
+}
+
+private fun String.isSafeLivePhotoEtag(): Boolean =
+    isNotBlank() &&
+        length <= MAX_LIVE_PHOTO_ETAG_LENGTH &&
+        none { character -> character.isISOControl() || character == '\u007f' }
+
+private val livePhotoJson = Json { ignoreUnknownKeys = true }
+
+private fun NextcloudApiResponse.livePhotoJsonObject(label: String): JsonObject =
+    runCatching { livePhotoJson.parseToJsonElement(body.decodeToString()) as? JsonObject }
+        .getOrNull() ?: error("The $label response is not a JSON object.")
+
+private fun NextcloudApiResponse.livePhotoJsonArray(label: String): JsonArray =
+    runCatching { livePhotoJson.parseToJsonElement(body.decodeToString()) as? JsonArray }
+        .getOrNull() ?: error("The $label response is not a JSON array.")
+
+private fun JsonObject.positiveLong(key: String): Long =
+    (get(key) as? JsonPrimitive)?.longOrNull?.takeIf { it > 0L }
+        ?: error("Memories returned an invalid $key value.")
+
+private fun JsonObject.optionalText(key: String): String? =
+    (get(key) as? JsonPrimitive)?.contentOrNull?.trim()?.takeIf(String::isNotEmpty)

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionBrowser.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionBrowser.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -323,7 +325,11 @@ fun NativeMediaCollectionContent(
     modifier: Modifier = Modifier,
 ) {
     val files = remember(collection.key, items, resolvedFiles) {
-        items.map { media -> resolvedFiles[media.fileId] ?: media.toNextcloudFile(collection.key) }
+        items.map { media ->
+            resolvedFiles[media.fileId]
+                ?.copy(livePhoto = media.livePhoto)
+                ?: media.toNextcloudFile(collection.key)
+        }
     }
     LazyVerticalGrid(
         columns = GridCells.Adaptive(112.dp),
@@ -335,7 +341,9 @@ fun NativeMediaCollectionContent(
     ) {
         items(items, key = NativeMediaItem::fileId) { media ->
             val file = remember(collection.key, media, resolvedFiles) {
-                resolvedFiles[media.fileId] ?: media.toNextcloudFile(collection.key)
+                resolvedFiles[media.fileId]
+                    ?.copy(livePhoto = media.livePhoto)
+                    ?: media.toNextcloudFile(collection.key)
             }
             NativeMediaItemTile(
                 media = media,
@@ -373,6 +381,9 @@ private fun NativeMediaItemTile(
     Box(
         modifier = Modifier.fillMaxWidth().aspectRatio(1f)
             .background(NextcloudTheme.colors.appIconContainer)
+            .semantics {
+                if (media.livePhoto != null) stateDescription = "Motion Photo"
+            }
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick,
@@ -426,17 +437,43 @@ private fun NativeMediaItemTile(
                 }
             }
         }
-        if (media.rawStackFileIds.isNotEmpty()) {
-            Surface(
-                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f),
-                shape = RoundedCornerShape(NextcloudRadii.Pill),
+        if (media.livePhoto != null || media.rawStackFileIds.isNotEmpty()) {
+            Column(
                 modifier = Modifier.align(Alignment.BottomEnd).padding(5.dp),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                Text(
-                    "+${media.rawStackFileIds.size} RAW",
-                    style = MaterialTheme.typography.labelSmall,
-                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp),
-                )
+                if (media.livePhoto != null) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f),
+                        shape = RoundedCornerShape(NextcloudRadii.Pill),
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp),
+                            horizontalArrangement = Arrangement.spacedBy(3.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                NextcloudIcons.Play,
+                                contentDescription = null,
+                                modifier = Modifier.size(12.dp),
+                            )
+                            Text("Motion", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+                if (media.rawStackFileIds.isNotEmpty()) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.88f),
+                        shape = RoundedCornerShape(NextcloudRadii.Pill),
+                    ) {
+                        Text(
+                            "+${media.rawStackFileIds.size} RAW",
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 3.dp),
+                        )
+                    }
+                }
             }
         }
         backupStatus?.let { status ->

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollections.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollections.kt
@@ -180,6 +180,7 @@ data class NativeMediaItem(
     val videoDurationSeconds: Int?,
     val isFavorite: Boolean,
     val rawStackFileIds: List<Long> = emptyList(),
+    val livePhoto: NextcloudLivePhotoReference? = null,
     /** Normalized recognized-face geometry when the active Memories filter supplied one. */
     val faceRectangle: NativeFaceRectangle? = null,
 ) {
@@ -214,6 +215,7 @@ data class NativeMediaItem(
             hasPreview = true,
             etag = etag,
             originalAccessAllowed = false,
+            livePhoto = livePhoto,
         )
     }
 }
@@ -528,6 +530,8 @@ private fun parseMemoriesMediaItem(
         videoDurationSeconds = item.optionalNonNegativeInt("video_duration"),
         isFavorite = item.optionalBoolean("isfavorite") ?: false,
         rawStackFileIds = rawStackIds,
+        livePhoto = item.optionalText("liveid", MAX_LIVE_PHOTO_TOKEN_LENGTH)
+            ?.let(::NextcloudLivePhotoReference),
         faceRectangle = item.faceRectangleOrNull(),
     )
 }

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
@@ -144,6 +144,10 @@ fun NextcloudMediaViewer(
     var externalOpening by remember(selected.path) { mutableStateOf(false) }
     var externalError by remember(selected.path) { mutableStateOf<String?>(null) }
     var nativeVideoError by remember(selected.path) { mutableStateOf<String?>(null) }
+    var livePhotoSource by remember(selected.path, selected.etag) {
+        mutableStateOf<MemoriesLivePhotoSource?>(null)
+    }
+    var motionPlaying by remember(selected.path, selected.etag) { mutableStateOf(false) }
     var viewerAction by remember(selected.path) { mutableStateOf<MediaViewerAction?>(null) }
     val scope = rememberCoroutineScope()
     val viewerActions = remember(
@@ -202,6 +206,19 @@ fun NextcloudMediaViewer(
     }
 
     fun openInMediaApp() = handoffToExternalApp(ExternalFileHandoffAction.OpenWith)
+
+    LaunchedEffect(selected, taggingAvailable, session) {
+        livePhotoSource = null
+        motionPlaying = false
+        if (!taggingAvailable || !selected.canResolveMemoriesLivePhoto()) return@LaunchedEffect
+        livePhotoSource = runCatching {
+            resolveMemoriesLivePhotoSource(
+                services = services,
+                session = session,
+                file = selected,
+            )
+        }.getOrNull()
+    }
 
     LaunchedEffect(sourceLoadIdentity, selected.fileId, session, retryKey, sourcePlan.previewCandidates) {
         previewState = MediaPreviewState.Loading
@@ -387,6 +404,20 @@ fun NextcloudMediaViewer(
         val viewerLayout = remember(sourcePlan.choices.size) {
             resolveMediaViewerLayout(sourcePlan.choices.size)
         }
+        val playbackSource = remember(
+            selected,
+            userId,
+            livePhotoSource,
+            motionPlaying,
+            platformNativeVideoPlaybackAvailable,
+        ) {
+            selected.nativeVideoPlaybackSource(
+                userId = userId,
+                nativePlaybackAvailable = platformNativeVideoPlaybackAvailable,
+                livePhotoSource = livePhotoSource,
+                motionPlaying = motionPlaying,
+            )
+        }
         val mediaCanvasModifier = when (viewerLayout.contentLayout) {
             MediaViewerContentLayout.FullCanvasBehindChrome -> Modifier.fillMaxSize()
         }
@@ -400,16 +431,17 @@ fun NextcloudMediaViewer(
                 onCancel = { editing = false },
                 modifier = Modifier.fillMaxSize(),
             )
-        } else if (selected.canUsePlatformNativeVideoPlayback(
-                userId = userId,
-                nativePlaybackAvailable = platformNativeVideoPlaybackAvailable,
-            )
-        ) {
+        } else if (playbackSource != null) {
             PlatformNativeVideoPlayer(
                 session = session,
                 userId = userId,
-                file = selected,
-                onError = { message -> nativeVideoError = message },
+                source = playbackSource,
+                onError = { message ->
+                    nativeVideoError = message
+                    if (playbackSource is NativeVideoPlaybackSource.MemoriesLivePhoto) {
+                        motionPlaying = false
+                    }
+                },
                 modifier = mediaCanvasModifier,
             )
         } else when (val state = previewState) {
@@ -470,6 +502,23 @@ fun NextcloudMediaViewer(
         }
 
         if (!editing) {
+            if (
+                livePhotoSource != null &&
+                !motionPlaying &&
+                previewState is MediaPreviewState.Ready &&
+                platformNativeVideoPlaybackAvailable
+            ) {
+                Button(
+                    onClick = {
+                        nativeVideoError = null
+                        motionPlaying = true
+                    },
+                    modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 88.dp),
+                ) {
+                    Icon(NextcloudIcons.Play, contentDescription = null, modifier = Modifier.size(20.dp))
+                    Text("Play motion", modifier = Modifier.padding(start = 8.dp))
+                }
+            }
             if (
                 selected.mediaAssetFormat() == MediaAssetFormat.Video &&
                 !platformNativeVideoPlaybackAvailable &&
@@ -1178,6 +1227,20 @@ internal fun NextcloudFile.canUsePlatformNativeVideoPlayback(
     nativePlaybackAvailable &&
         mediaAssetFormat() == MediaAssetFormat.Video &&
         hasAuthoritativeMediaDavAccess(userId)
+
+internal fun NextcloudFile.nativeVideoPlaybackSource(
+    userId: String,
+    nativePlaybackAvailable: Boolean,
+    livePhotoSource: MemoriesLivePhotoSource?,
+    motionPlaying: Boolean,
+): NativeVideoPlaybackSource? {
+    if (!nativePlaybackAvailable) return null
+    if (motionPlaying && livePhotoSource != null && livePhotoSource.fileId == fileId) {
+        return NativeVideoPlaybackSource.MemoriesLivePhoto(livePhotoSource)
+    }
+    return takeIf { canUsePlatformNativeVideoPlayback(userId, nativePlaybackAvailable) }
+        ?.let { NativeVideoPlaybackSource.DavFile(it) }
+}
 
 private const val MAXIMUM_PREVIEW_IMAGE_DIMENSION = 1_600
 private const val MAXIMUM_DISPLAY_IMAGE_DIMENSION = 4_096

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
@@ -119,6 +119,9 @@ fun NextcloudMediaViewer(
             candidates = fullQualityGeneration,
         )
     }
+    val livePhotoDiscoveryIdentity = remember(selected) {
+        selected.livePhotoDiscoveryIdentity()
+    }
     val selectedIndex = items.indexOfFirst { it.path == selected.path }.coerceAtLeast(0)
     val canGoPrevious = selectedIndex > 0
     val canGoNext = selectedIndex < items.lastIndex
@@ -144,10 +147,20 @@ fun NextcloudMediaViewer(
     var externalOpening by remember(selected.path) { mutableStateOf(false) }
     var externalError by remember(selected.path) { mutableStateOf<String?>(null) }
     var nativeVideoError by remember(selected.path) { mutableStateOf<String?>(null) }
-    var livePhotoSource by remember(selected.path, selected.etag) {
+    var livePhotoSource by remember(
+        session.serverUrl,
+        session.loginName,
+        livePhotoDiscoveryIdentity,
+    ) {
         mutableStateOf<MemoriesLivePhotoSource?>(null)
     }
-    var motionPlaying by remember(selected.path, selected.etag) { mutableStateOf(false) }
+    var motionPlaying by remember(
+        session.serverUrl,
+        session.loginName,
+        livePhotoDiscoveryIdentity,
+    ) {
+        mutableStateOf(false)
+    }
     var viewerAction by remember(selected.path) { mutableStateOf<MediaViewerAction?>(null) }
     val scope = rememberCoroutineScope()
     val viewerActions = remember(
@@ -207,10 +220,22 @@ fun NextcloudMediaViewer(
 
     fun openInMediaApp() = handoffToExternalApp(ExternalFileHandoffAction.OpenWith)
 
-    LaunchedEffect(selected, taggingAvailable, session) {
+    LaunchedEffect(
+        livePhotoDiscoveryIdentity,
+        taggingAvailable,
+        platformNativeVideoPlaybackAvailable,
+        session,
+    ) {
         livePhotoSource = null
         motionPlaying = false
-        if (!taggingAvailable || !selected.canResolveMemoriesLivePhoto()) return@LaunchedEffect
+        if (
+            !selected.shouldDiscoverMemoriesLivePhoto(
+                memoriesAvailable = taggingAvailable,
+                nativePlaybackAvailable = platformNativeVideoPlaybackAvailable,
+            )
+        ) {
+            return@LaunchedEffect
+        }
         livePhotoSource = runCatching {
             resolveMemoriesLivePhotoSource(
                 services = services,
@@ -436,6 +461,11 @@ fun NextcloudMediaViewer(
                 session = session,
                 userId = userId,
                 source = playbackSource,
+                onPlaybackEnded = {
+                    if (playbackSource.restoresStillAfterPlaybackEnds()) {
+                        motionPlaying = false
+                    }
+                },
                 onError = { message ->
                     nativeVideoError = message
                     if (playbackSource is NativeVideoPlaybackSource.MemoriesLivePhoto) {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudMediaViewer.kt
@@ -89,6 +89,7 @@ fun NextcloudMediaViewer(
     userId: String,
     services: NextcloudPlatformServices,
     taggingAvailable: Boolean,
+    memoriesLivePhotoCapability: MemoriesLivePhotoCapability,
     sharingCapabilities: NextcloudFileSharingCapabilities,
     onSelect: (NextcloudFile) -> Unit,
     onSourceRemoved: (NextcloudFile) -> Unit,
@@ -222,7 +223,7 @@ fun NextcloudMediaViewer(
 
     LaunchedEffect(
         livePhotoDiscoveryIdentity,
-        taggingAvailable,
+        memoriesLivePhotoCapability,
         platformNativeVideoPlaybackAvailable,
         session,
     ) {
@@ -230,19 +231,19 @@ fun NextcloudMediaViewer(
         motionPlaying = false
         if (
             !selected.shouldDiscoverMemoriesLivePhoto(
-                memoriesAvailable = taggingAvailable,
+                capability = selected.effectiveLivePhotoCapability(memoriesLivePhotoCapability),
                 nativePlaybackAvailable = platformNativeVideoPlaybackAvailable,
             )
         ) {
             return@LaunchedEffect
         }
-        livePhotoSource = runCatching {
+        livePhotoSource = livePhotoLookupOrNull {
             resolveMemoriesLivePhotoSource(
                 services = services,
                 session = session,
                 file = selected,
             )
-        }.getOrNull()
+        }
     }
 
     LaunchedEffect(sourceLoadIdentity, selected.fileId, session, retryKey, sourcePlan.previewCandidates) {

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudNativeApp.kt
@@ -484,6 +484,9 @@ private fun AuthenticatedApp(
         stateSaver = enumSaver<NextcloudDestination>(),
     ) { mutableStateOf(NextcloudDestination.Home) }
     var serverInfo by remember(session) { mutableStateOf<NextcloudServerInfo?>(null) }
+    var memoriesLivePhotoCapability by remember(session) {
+        mutableStateOf<MemoriesLivePhotoCapability>(MemoriesLivePhotoCapability.NotAdvertised)
+    }
     val cachedAppDiscoveries = remember(session) { mutableStateMapOf<String, DynamicDescriptorDiscovery>() }
     var discoveryError by remember(session) { mutableStateOf<String?>(null) }
     var discoveryAttempt by remember(session) { mutableStateOf(0) }
@@ -498,6 +501,13 @@ private fun AuthenticatedApp(
         runCatching { services.loadServerInfo(session) }
             .onSuccess { serverInfo = it }
             .onFailure { discoveryError = it.message ?: "Could not load server details." }
+    }
+
+    LaunchedEffect(session, serverInfo?.apps) {
+        memoriesLivePhotoCapability = MemoriesLivePhotoCapability.NotAdvertised
+        if (serverInfo?.apps?.any { app -> app.id == "memories" } == true) {
+            memoriesLivePhotoCapability = discoverMemoriesLivePhotoCapability(services, session)
+        }
     }
 
     fun openApp(app: NextcloudAppEntry, from: NextcloudDestination) {
@@ -871,6 +881,7 @@ private fun AuthenticatedApp(
             userId = serverInfo?.userId.orEmpty(),
             services = services,
             taggingAvailable = serverInfo?.apps?.any { it.id == "memories" } == true,
+            memoriesLivePhotoCapability = memoriesLivePhotoCapability,
             sharingCapabilities = serverInfo?.fileSharing ?: NextcloudFileSharingCapabilities.Unavailable,
             onSelect = { screen = current.copy(selected = it) },
             onSourceRemoved = { screen = current.returnTo },
@@ -5378,7 +5389,7 @@ private fun PersonMediaScreen(
     val mediaGridState = rememberLazyGridState()
     val mediaFiles = remember(personReference, mediaItems, resolvedMediaFiles) {
         mediaItems?.map { item ->
-            resolvedMediaFiles[item.fileId] ?: item.toPersonMediaFile(personReference)
+            item.toPersonMediaFile(personReference, resolvedMediaFiles[item.fileId])
         }
     }
     val actionSupport = remember(currentUserId, person.id, person.backend, recognizeBridge) {
@@ -5809,7 +5820,7 @@ private fun PersonMediaScreen(
                     verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     items(loadedItems, key = NativeMediaItem::fileId) { item ->
-                        val file = resolvedMediaFiles[item.fileId] ?: item.toPersonMediaFile(personReference)
+                        val file = item.toPersonMediaFile(personReference, resolvedMediaFiles[item.fileId])
                         val selectable = !file.isDirectory && file.fileId != null
                         MediaTile(
                             services = services,

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
@@ -69,6 +69,16 @@ data class NextcloudServerInfo(
 )
 
 @Serializable
+data class NextcloudLivePhotoReference(
+    /** Opaque server token returned by Memories. It must never be parsed or reconstructed. */
+    val serverToken: String,
+) {
+    init {
+        require(serverToken.isSafeLivePhotoToken()) { "The Live Photo reference is invalid." }
+    }
+}
+
+@Serializable
 data class NextcloudFile(
     val path: String,
     val name: String,
@@ -97,6 +107,8 @@ data class NextcloudFile(
     val permissions: String? = null,
     /** Strong content identities supplied by DAV clients, for example `SHA256:<hex>`. */
     val checksums: List<String> = emptyList(),
+    /** Optional Memories relationship for the motion component of this still image. */
+    val livePhoto: NextcloudLivePhotoReference? = null,
 )
 
 data class NextcloudFileContent(

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PersonMediaPaging.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PersonMediaPaging.kt
@@ -93,19 +93,24 @@ class NextcloudPersonMediaReadService internal constructor(
     }
 }
 
-fun NativeMediaItem.toPersonMediaFile(person: PersonMediaReference): NextcloudFile = NextcloudFile(
-    path = "memories/people/${person.backend.apiValue}/${person.clusterId}/$dayId/$fileId",
-    name = name,
-    isDirectory = false,
-    mimeType = mimeType,
-    size = null,
-    lastModified = takenAtEpochSeconds?.toString(),
-    fileId = fileId,
-    hasPreview = true,
-    etag = etag,
-    originalAccessAllowed = false,
-    davPathAuthoritative = false,
-)
+fun NativeMediaItem.toPersonMediaFile(
+    person: PersonMediaReference,
+    resolvedFile: NextcloudFile? = null,
+): NextcloudFile =
+    resolvedFile?.copy(livePhoto = livePhoto ?: resolvedFile.livePhoto) ?: NextcloudFile(
+        path = "memories/people/${person.backend.apiValue}/${person.clusterId}/$dayId/$fileId",
+        name = name,
+        isDirectory = false,
+        mimeType = mimeType,
+        size = null,
+        lastModified = takenAtEpochSeconds?.toString(),
+        fileId = fileId,
+        hasPreview = true,
+        etag = etag,
+        originalAccessAllowed = false,
+        davPathAuthoritative = false,
+        livePhoto = livePhoto,
+    )
 
 /**
  * Builds a preview-only file for the legacy platform person-media readers.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.kt
@@ -11,11 +11,24 @@ internal sealed interface NativeVideoPlaybackSource {
     data class MemoriesLivePhoto(val source: MemoriesLivePhotoSource) : NativeVideoPlaybackSource
 }
 
+internal fun NativeVideoPlaybackSource.authenticatedRequestProperties(
+    authorization: String,
+): Map<String, String> = buildMap {
+    put("Authorization", authorization)
+    if (this@authenticatedRequestProperties is NativeVideoPlaybackSource.MemoriesLivePhoto) {
+        put("OCS-APIRequest", "true")
+    }
+}
+
+internal fun NativeVideoPlaybackSource.restoresStillAfterPlaybackEnds(): Boolean =
+    this is NativeVideoPlaybackSource.MemoriesLivePhoto
+
 @Composable
 internal expect fun PlatformNativeVideoPlayer(
     session: NextcloudSession,
     userId: String,
     source: NativeVideoPlaybackSource,
+    onPlaybackEnded: () -> Unit,
     onError: (String) -> Unit,
     modifier: Modifier = Modifier,
 )

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.kt
@@ -5,11 +5,17 @@ import androidx.compose.ui.Modifier
 
 internal expect val platformNativeVideoPlaybackAvailable: Boolean
 
+internal sealed interface NativeVideoPlaybackSource {
+    data class DavFile(val file: NextcloudFile) : NativeVideoPlaybackSource
+
+    data class MemoriesLivePhoto(val source: MemoriesLivePhotoSource) : NativeVideoPlaybackSource
+}
+
 @Composable
 internal expect fun PlatformNativeVideoPlayer(
     session: NextcloudSession,
     userId: String,
-    file: NextcloudFile,
+    source: NativeVideoPlaybackSource,
     onError: (String) -> Unit,
     modifier: Modifier = Modifier,
 )

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotoDetectionTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotoDetectionTest.kt
@@ -1,0 +1,332 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class LivePhotoDetectionTest {
+    @Test
+    fun detectsModernAndroidMotionPhotoOnlyAfterExactVideoProbe() {
+        val fixture = SyntheticLivePhotoFixtures.modernAndroid
+
+        val candidate = planAndroidMotionPhotoProbe(
+            primaryMimeType = fixture.primaryMimeType,
+            containerSize = fixture.containerSize,
+            xmpBytes = fixture.xmp,
+        )
+
+        assertEquals(AndroidMotionPhotoMetadataKind.MotionPhotoV1, candidate?.metadataKind)
+        assertEquals(LivePhotoByteRange(8_192L, 2_048L), candidate?.videoRange)
+        assertEquals(750_000L, candidate?.photoPresentationTimestampUs)
+        val detected = confirmAndroidMotionPhoto(
+            requireNotNull(candidate),
+            LivePhotoVideoProbe(candidate.videoRange.offset, fixture.videoProbe),
+        )
+        assertIs<DetectedLivePhotoAsset.EmbeddedAndroidMotionPhoto>(detected)
+        assertEquals("video/mp4", detected.motionMimeType)
+    }
+
+    @Test
+    fun supportsNamespaceAliasesAndQuickTimeMotionItem() {
+        val fixture = SyntheticLivePhotoFixtures.modernAndroid.copy(
+            primaryMimeType = "image/heic",
+            xmp = SyntheticLivePhotoFixtures.modernXmp(
+                primaryMimeType = "image/heic",
+                motionMimeType = "video/quicktime",
+                videoLength = 2_048L,
+                cameraPrefix = "Camera",
+                containerPrefix = "Media",
+                itemPrefix = "Part",
+                primaryPadding = 8L,
+            ).decodeToString()
+                .replace(" Camera:MotionPhotoPresentationTimestampUs=\"750000\"", "")
+                .encodeToByteArray(),
+        )
+
+        val candidate = planAndroidMotionPhotoProbe(
+            fixture.primaryMimeType,
+            fixture.containerSize,
+            fixture.xmp,
+        )
+
+        assertEquals("image/heic", candidate?.primaryMimeType)
+        assertEquals("video/quicktime", candidate?.motionMimeType)
+        assertNull(candidate?.photoPresentationTimestampUs)
+    }
+
+    @Test
+    fun detectsLegacyMicroVideoTrailer() {
+        val fixture = SyntheticLivePhotoFixtures.legacyAndroid
+
+        val candidate = planAndroidMotionPhotoProbe(
+            fixture.primaryMimeType,
+            fixture.containerSize,
+            fixture.xmp,
+        )
+
+        assertEquals(AndroidMotionPhotoMetadataKind.LegacyMicroVideoV1, candidate?.metadataKind)
+        assertEquals(LivePhotoByteRange(7_168L, 3_072L), candidate?.videoRange)
+        assertEquals(-1L, candidate?.photoPresentationTimestampUs)
+        assertIs<DetectedLivePhotoAsset.EmbeddedAndroidMotionPhoto>(
+            confirmAndroidMotionPhoto(
+                requireNotNull(candidate),
+                LivePhotoVideoProbe(candidate.videoRange.offset, fixture.videoProbe),
+            ),
+        )
+    }
+
+    @Test
+    fun residualOrMismatchedMetadataRemainsAnOrdinaryPhoto() {
+        val fixture = SyntheticLivePhotoFixtures.modernAndroid
+        val candidate = requireNotNull(
+            planAndroidMotionPhotoProbe(fixture.primaryMimeType, fixture.containerSize, fixture.xmp),
+        )
+
+        assertNull(
+            confirmAndroidMotionPhoto(
+                candidate,
+                LivePhotoVideoProbe(candidate.videoRange.offset, "not a video".encodeToByteArray()),
+            ),
+        )
+        assertNull(
+            confirmAndroidMotionPhoto(
+                candidate,
+                LivePhotoVideoProbe(candidate.videoRange.offset + 1L, fixture.videoProbe),
+            ),
+        )
+        assertNull(
+            planAndroidMotionPhotoProbe(
+                fixture.primaryMimeType,
+                fixture.containerSize,
+                fixture.xmp.decodeToString()
+                    .replace("Camera:MotionPhoto=\"1\"", "Camera:MotionPhoto=\"0\"")
+                    .encodeToByteArray(),
+            ),
+        )
+    }
+
+    @Test
+    fun rejectsMalformedTruncatedAndContradictoryModernMetadata() {
+        val fixture = SyntheticLivePhotoFixtures.modernAndroid
+        val malformed = listOf(
+            fixture.xmp.copyOf(fixture.xmp.size - 7),
+            fixture.xmp.decodeToString()
+                .replace("Item:Length=\"2048\"", "Item:Length=\"999999\"")
+                .encodeToByteArray(),
+            fixture.xmp.decodeToString()
+                .replace("Item:Semantic=\"MotionPhoto\"", "Item:Semantic=\"Primary\"")
+                .encodeToByteArray(),
+            fixture.xmp.decodeToString()
+                .replace(
+                    "Camera:MotionPhotoPresentationTimestampUs=\"750000\"",
+                    "Camera:MotionPhotoPresentationTimestampUs=\"invalid\"",
+                )
+                .encodeToByteArray(),
+            fixture.xmp.decodeToString()
+                .replace(
+                    "Camera:MotionPhotoVersion=\"1\"",
+                    "Camera:MotionPhotoVersion=\"1\" CameraAlias:MotionPhotoVersion=\"1\"",
+                )
+                .replace(
+                    "xmlns:Camera=\"http://ns.google.com/photos/1.0/camera/\"",
+                    """
+                        xmlns:Camera="http://ns.google.com/photos/1.0/camera/"
+                        xmlns:CameraAlias="http://ns.google.com/photos/1.0/camera/"
+                    """.trimIndent(),
+                )
+                .encodeToByteArray(),
+            fixture.xmp.decodeToString()
+                .replace("</rdf:Seq>", "<Container:Item")
+                .encodeToByteArray(),
+            byteArrayOf(0xC3.toByte(), 0x28),
+        )
+
+        malformed.forEach { xmp ->
+            assertNull(planAndroidMotionPhotoProbe(fixture.primaryMimeType, fixture.containerSize, xmp))
+        }
+    }
+
+    @Test
+    fun rejectsUnknownVersionsUnsupportedRawAndLegacyOverflows() {
+        val modern = SyntheticLivePhotoFixtures.modernAndroid
+        val legacy = SyntheticLivePhotoFixtures.legacyAndroid
+
+        assertNull(
+            planAndroidMotionPhotoProbe(
+                modern.primaryMimeType,
+                modern.containerSize,
+                modern.xmp.decodeToString()
+                    .replace("Camera:MotionPhotoVersion=\"1\"", "Camera:MotionPhotoVersion=\"2\"")
+                    .encodeToByteArray(),
+            ),
+        )
+        assertNull(planAndroidMotionPhotoProbe("image/x-fuji-raf", modern.containerSize, modern.xmp))
+        assertNull(
+            planAndroidMotionPhotoProbe(
+                legacy.primaryMimeType,
+                legacy.containerSize,
+                legacy.xmp.decodeToString()
+                    .replace("Camera:MicroVideoOffset=\"3072\"", "Camera:MicroVideoOffset=\"10240\"")
+                    .encodeToByteArray(),
+            ),
+        )
+    }
+
+    @Test
+    fun pairsAppleStillAndMovOnlyByExactContentIdentifier() {
+        val still = SyntheticLivePhotoFixtures.appleStill
+        val video = SyntheticLivePhotoFixtures.appleVideo
+
+        val paired = pairAppleLivePhoto(still, video)
+
+        assertIs<DetectedLivePhotoAsset.PairedAppleLivePhoto>(paired)
+        assertEquals(SyntheticLivePhotoFixtures.appleContentIdentifier, paired.contentIdentifier)
+        assertEquals(still.resourceIdentity, paired.still.resourceIdentity)
+        assertEquals(video.resourceIdentity, paired.pairedVideo.resourceIdentity)
+    }
+
+    @Test
+    fun appleFilenameAndTimestampStyleSimilarityNeverOverridesIdentifierEvidence() {
+        val still = SyntheticLivePhotoFixtures.appleStill
+        val video = SyntheticLivePhotoFixtures.appleVideo
+
+        assertNull(pairAppleLivePhoto(still, video.copy(contentIdentifier = "different-identifier")))
+        assertNull(pairAppleLivePhoto(still.copy(contentIdentifier = null), video))
+        assertNull(pairAppleLivePhoto(still, video.copy(contentIdentifier = " ${video.contentIdentifier}")))
+        assertNull(pairAppleLivePhoto(still, video.copy(mimeType = "video/mp4")))
+        assertNull(pairAppleLivePhoto(still.copy(mimeType = "image/x-canon-cr3"), video))
+        assertNull(pairAppleLivePhoto(still, video.copy(resourceIdentity = still.resourceIdentity)))
+        assertNull(pairAppleLivePhoto(still, video.copy(pairingScopeIdentity = "another-account")))
+        assertNull(
+            pairAppleLivePhoto(
+                still.copy(displayName = "renamed-still.heic"),
+                video.copy(
+                    displayName = "unrelated-name.mov",
+                    contentIdentifier = "different-identifier",
+                ),
+            ),
+        )
+    }
+}
+
+private data class SyntheticEmbeddedMotionPhotoFixture(
+    val primaryMimeType: String,
+    val containerSize: Long,
+    val xmp: ByteArray,
+    val videoProbe: ByteArray,
+)
+
+private object SyntheticLivePhotoFixtures {
+    const val appleContentIdentifier = "8EA9DEB3-47C6-4B3F-894B-27A79D7EE012"
+
+    val modernAndroid = SyntheticEmbeddedMotionPhotoFixture(
+        primaryMimeType = "image/jpeg",
+        containerSize = 10_240L,
+        xmp = modernXmp(
+            primaryMimeType = "image/jpeg",
+            motionMimeType = "video/mp4",
+            videoLength = 2_048L,
+            cameraPrefix = "Camera",
+            containerPrefix = "Container",
+            itemPrefix = "Item",
+            primaryPadding = 0L,
+        ),
+        videoProbe = isoBaseMediaVideoProbe("isom"),
+    )
+
+    val legacyAndroid = SyntheticEmbeddedMotionPhotoFixture(
+        primaryMimeType = "image/jpeg",
+        containerSize = 10_240L,
+        xmp = """
+            <?xpacket begin=""?>
+            <x:xmpmeta xmlns:x="adobe:ns:meta/">
+              <rdf:RDF
+                  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                  xmlns:Camera="http://ns.google.com/photos/1.0/camera/">
+                <rdf:Description
+                    Camera:MicroVideo="1"
+                    Camera:MicroVideoVersion="1"
+                    Camera:MicroVideoOffset="3072"
+                    Camera:MicroVideoPresentationTimestampUs="-1"/>
+              </rdf:RDF>
+            </x:xmpmeta>
+            <?xpacket end="w"?>
+        """.trimIndent().encodeToByteArray(),
+        videoProbe = isoBaseMediaVideoProbe("mp42"),
+    )
+
+    val appleStill = AppleLivePhotoComponent(
+        pairingScopeIdentity = "account:test:photos-asset:42",
+        resourceIdentity = "photos-resource:still:42",
+        displayName = "IMG_0042.HEIC",
+        mimeType = "image/heic",
+        role = AppleLivePhotoComponentRole.Still,
+        contentIdentifier = appleContentIdentifier,
+    )
+
+    val appleVideo = AppleLivePhotoComponent(
+        pairingScopeIdentity = "account:test:photos-asset:42",
+        resourceIdentity = "photos-resource:paired-video:42",
+        displayName = "IMG_0042.MOV",
+        mimeType = "video/quicktime",
+        role = AppleLivePhotoComponentRole.PairedVideo,
+        contentIdentifier = appleContentIdentifier,
+    )
+
+    fun modernXmp(
+        primaryMimeType: String,
+        motionMimeType: String,
+        videoLength: Long,
+        cameraPrefix: String,
+        containerPrefix: String,
+        itemPrefix: String,
+        primaryPadding: Long,
+    ): ByteArray = """
+        <?xpacket begin=""?>
+        <x:xmpmeta xmlns:x="adobe:ns:meta/">
+          <rdf:RDF
+              xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              xmlns:$cameraPrefix="http://ns.google.com/photos/1.0/camera/"
+              xmlns:$containerPrefix="http://ns.google.com/photos/1.0/container/"
+              xmlns:$itemPrefix="http://ns.google.com/photos/1.0/container/item/">
+            <rdf:Description
+                $cameraPrefix:MotionPhoto="1"
+                $cameraPrefix:MotionPhotoVersion="1"
+                $cameraPrefix:MotionPhotoPresentationTimestampUs="750000">
+              <$containerPrefix:Directory>
+                <rdf:Seq>
+                  <rdf:li rdf:parseType="Resource">
+                    <$containerPrefix:Item
+                        $itemPrefix:Mime="$primaryMimeType"
+                        $itemPrefix:Semantic="Primary"
+                        $itemPrefix:Length="0"
+                        $itemPrefix:Padding="$primaryPadding"/>
+                  </rdf:li>
+                  <rdf:li rdf:parseType="Resource">
+                    <$containerPrefix:Item
+                        $itemPrefix:Mime="$motionMimeType"
+                        $itemPrefix:Semantic="MotionPhoto"
+                        $itemPrefix:Length="$videoLength"/>
+                  </rdf:li>
+                </rdf:Seq>
+              </$containerPrefix:Directory>
+            </rdf:Description>
+          </rdf:RDF>
+        </x:xmpmeta>
+        <?xpacket end="w"?>
+    """.trimIndent().encodeToByteArray()
+
+    private fun isoBaseMediaVideoProbe(majorBrand: String): ByteArray =
+        byteArrayOf(
+            0x00, 0x00, 0x00, 0x18,
+            'f'.code.toByte(), 't'.code.toByte(), 'y'.code.toByte(), 'p'.code.toByte(),
+            majorBrand[0].code.toByte(),
+            majorBrand[1].code.toByte(),
+            majorBrand[2].code.toByte(),
+            majorBrand[3].code.toByte(),
+            0x00, 0x00, 0x00, 0x00,
+            'i'.code.toByte(), 's'.code.toByte(), 'o'.code.toByte(), 'm'.code.toByte(),
+            'm'.code.toByte(), 'p'.code.toByte(), '4'.code.toByte(), '2'.code.toByte(),
+        )
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotosTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotosTest.kt
@@ -74,6 +74,76 @@ class LivePhotosTest {
     }
 
     @Test
+    fun discoveryRequiresMemoriesAndNativePlayback() {
+        val candidate = photo("ordinary.jpg", "image/jpeg")
+
+        assertTrue(
+            candidate.shouldDiscoverMemoriesLivePhoto(
+                memoriesAvailable = true,
+                nativePlaybackAvailable = true,
+            ),
+        )
+        assertFalse(
+            candidate.shouldDiscoverMemoriesLivePhoto(
+                memoriesAvailable = false,
+                nativePlaybackAvailable = true,
+            ),
+        )
+        assertFalse(
+            candidate.shouldDiscoverMemoriesLivePhoto(
+                memoriesAvailable = true,
+                nativePlaybackAvailable = false,
+            ),
+        )
+        assertFalse(
+            photo("capture.png", "image/png").shouldDiscoverMemoriesLivePhoto(
+                memoriesAvailable = true,
+                nativePlaybackAvailable = true,
+            ),
+        )
+    }
+
+    @Test
+    fun discoveryIdentityChangesWithRemoteGeneration() {
+        val first = photo("ordinary.jpg", "image/jpeg")
+        val second = first.copy(etag = "generation-2")
+        val third = second.copy(
+            size = 2_048L,
+            lastModified = "2026-07-28T12:00:00Z",
+        )
+
+        assertFalse(first.livePhotoDiscoveryIdentity() == second.livePhotoDiscoveryIdentity())
+        assertFalse(second.livePhotoDiscoveryIdentity() == third.livePhotoDiscoveryIdentity())
+    }
+
+    @Test
+    fun memoriesPlaybackAddsOcsHeaderAndRestoresStillAtEnd() {
+        val authorization = "Basic opaque"
+        val still = photo("motion.jpg", "image/jpeg")
+        val live = MemoriesLivePhotoSource(
+            fileId = 42L,
+            reference = NextcloudLivePhotoReference("self__trailer"),
+            etag = "generation-1",
+        )
+        val davSource = NativeVideoPlaybackSource.DavFile(still)
+        val memoriesSource = NativeVideoPlaybackSource.MemoriesLivePhoto(live)
+
+        assertEquals(
+            mapOf("Authorization" to authorization),
+            davSource.authenticatedRequestProperties(authorization),
+        )
+        assertEquals(
+            mapOf(
+                "Authorization" to authorization,
+                "OCS-APIRequest" to "true",
+            ),
+            memoriesSource.authenticatedRequestProperties(authorization),
+        )
+        assertFalse(davSource.restoresStillAfterPlaybackEnds())
+        assertTrue(memoriesSource.restoresStillAfterPlaybackEnds())
+    }
+
+    @Test
     fun rejectsWrongIdentitiesDaysDuplicatesAndUnsafeTokens() {
         assertFailsWith<IllegalArgumentException> {
             parseMemoriesLivePhotoDayId(

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotosTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotosTest.kt
@@ -1,0 +1,162 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LivePhotosTest {
+    @Test
+    fun plansBoundedSameOriginLookupAndEncodedPlaybackUrl() {
+        val info = memoriesLivePhotoInfoRequest(42L)
+        val day = memoriesLivePhotoDayRequest(20260727L)
+        val source = MemoriesLivePhotoSource(
+            fileId = 42L,
+            reference = NextcloudLivePhotoReference("motion id/with+symbols"),
+            etag = "generation-1",
+        )
+        val playback = memoriesLivePhotoVideoRequest(source)
+
+        assertEquals("/index.php/apps/memories/api/image/info/42", info.relativePath)
+        assertEquals(mapOf("basic" to "1"), info.queryParameters)
+        assertTrue(info.ocsApiRequest)
+        assertEquals("/index.php/apps/memories/api/days/20260727", day.relativePath)
+        assertEquals(
+            "https://cloud.invalid/index.php/apps/memories/api/video/livephoto/42" +
+                "?etag=generation-1&liveid=motion%20id%2Fwith%2Bsymbols",
+            buildNextcloudApiUrl("https://cloud.invalid", playback),
+        )
+    }
+
+    @Test
+    fun resolvesOnlyTheRequestedFileFromTheReportedDay() {
+        val dayId = parseMemoriesLivePhotoDayId(
+            apiResponse(200, """{"fileid":42,"dayid":20260727,"ignored":true}"""),
+            expectedFileId = 42L,
+        )
+        val source = parseMemoriesLivePhotoSource(
+            apiResponse(
+                200,
+                """[
+                    {"fileid":41,"dayid":20260727,"etag":"still","basename":"ordinary.jpg"},
+                    {"fileid":42,"dayid":20260727,"etag":"motion","liveid":"self__trailer"}
+                ]""",
+            ),
+            expectedFileId = 42L,
+            expectedDayId = dayId,
+        )
+
+        assertEquals(20260727L, dayId)
+        assertEquals(42L, source?.fileId)
+        assertEquals("self__trailer", source?.reference?.serverToken)
+        assertEquals("motion", source?.etag)
+    }
+
+    @Test
+    fun ordinaryPhotosRemainOrdinaryAndUnsupportedFormatsSkipLookup() {
+        val source = parseMemoriesLivePhotoSource(
+            apiResponse(
+                200,
+                """[{"fileid":42,"dayid":20260727,"etag":"still","basename":"ordinary.jpg"}]""",
+            ),
+            expectedFileId = 42L,
+            expectedDayId = 20260727L,
+        )
+
+        assertNull(source)
+        assertTrue(photo("ordinary.jpg", "image/jpeg").canResolveMemoriesLivePhoto())
+        assertTrue(photo("capture.heic", "image/heic").canResolveMemoriesLivePhoto())
+        assertFalse(photo("capture.png", "image/png").canResolveMemoriesLivePhoto())
+        assertFalse(photo("capture.raf", "image/x-fuji-raf").canResolveMemoriesLivePhoto())
+    }
+
+    @Test
+    fun rejectsWrongIdentitiesDaysDuplicatesAndUnsafeTokens() {
+        assertFailsWith<IllegalArgumentException> {
+            parseMemoriesLivePhotoDayId(
+                apiResponse(200, """{"fileid":41,"dayid":20260727}"""),
+                expectedFileId = 42L,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            parseMemoriesLivePhotoSource(
+                apiResponse(200, """[{"fileid":42,"dayid":20260726,"liveid":"self__trailer"}]"""),
+                expectedFileId = 42L,
+                expectedDayId = 20260727L,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            parseMemoriesLivePhotoSource(
+                apiResponse(
+                    200,
+                    """[
+                        {"fileid":42,"dayid":20260727,"liveid":"self__trailer"},
+                        {"fileid":42,"dayid":20260727,"liveid":"self__trailer"}
+                    ]""",
+                ),
+                expectedFileId = 42L,
+                expectedDayId = 20260727L,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            NextcloudLivePhotoReference("unsafe\u0000token")
+        }
+    }
+
+    @Test
+    fun playbackUsesMotionOnlyAfterExplicitActivation() {
+        val photo = photo("motion.jpg", "image/jpeg")
+        val live = MemoriesLivePhotoSource(
+            fileId = 42L,
+            reference = NextcloudLivePhotoReference("self__trailer"),
+            etag = "generation-1",
+        )
+
+        assertNull(
+            photo.nativeVideoPlaybackSource(
+                userId = "user",
+                nativePlaybackAvailable = true,
+                livePhotoSource = live,
+                motionPlaying = false,
+            ),
+        )
+        assertIs<NativeVideoPlaybackSource.MemoriesLivePhoto>(
+            photo.nativeVideoPlaybackSource(
+                userId = "user",
+                nativePlaybackAvailable = true,
+                livePhotoSource = live,
+                motionPlaying = true,
+            ),
+        )
+        assertNull(
+            photo.nativeVideoPlaybackSource(
+                userId = "user",
+                nativePlaybackAvailable = false,
+                livePhotoSource = live,
+                motionPlaying = true,
+            ),
+        )
+    }
+
+    private fun photo(name: String, mimeType: String) = NextcloudFile(
+        path = "Photos/$name",
+        name = name,
+        isDirectory = false,
+        mimeType = mimeType,
+        size = 1_024L,
+        lastModified = "2026-07-27T12:00:00Z",
+        fileId = 42L,
+        hasPreview = true,
+        etag = "generation-1",
+    )
+
+    private fun apiResponse(status: Int, body: String) = NextcloudApiResponse(
+        status = status,
+        body = body.encodeToByteArray(),
+        contentType = "application/json",
+        etag = null,
+    )
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotosTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LivePhotosTest.kt
@@ -1,5 +1,7 @@
 package dev.obiente.nextcloudnative.app
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -74,33 +76,100 @@ class LivePhotosTest {
     }
 
     @Test
-    fun discoveryRequiresMemoriesAndNativePlayback() {
+    fun discoveryRequiresVerifiedMemoriesRoutesAndNativePlayback() {
         val candidate = photo("ordinary.jpg", "image/jpeg")
+        val compatible = MemoriesLivePhotoCapability.CompatibleVersion("8.1.0")
 
         assertTrue(
             candidate.shouldDiscoverMemoriesLivePhoto(
-                memoriesAvailable = true,
+                capability = compatible,
                 nativePlaybackAvailable = true,
             ),
         )
         assertFalse(
             candidate.shouldDiscoverMemoriesLivePhoto(
-                memoriesAvailable = false,
+                capability = MemoriesLivePhotoCapability.NotAdvertised,
                 nativePlaybackAvailable = true,
             ),
         )
         assertFalse(
             candidate.shouldDiscoverMemoriesLivePhoto(
-                memoriesAvailable = true,
+                capability = MemoriesLivePhotoCapability.UnsupportedVersion("9.0.0"),
+                nativePlaybackAvailable = true,
+            ),
+        )
+        assertFalse(
+            candidate.shouldDiscoverMemoriesLivePhoto(
+                capability = compatible,
                 nativePlaybackAvailable = false,
             ),
         )
         assertFalse(
             photo("capture.png", "image/png").shouldDiscoverMemoriesLivePhoto(
-                memoriesAvailable = true,
+                capability = compatible,
                 nativePlaybackAvailable = true,
             ),
         )
+    }
+
+    @Test
+    fun describeCapabilityAcceptsOnlyTheAuditedMemoriesVersionRange() {
+        val request = memoriesDescribeRequest()
+
+        assertEquals(NextcloudApiMethod.GET, request.method)
+        assertEquals("/index.php/apps/memories/api/describe", request.relativePath)
+        assertTrue(request.maximumResponseBytes <= 64L * 1_024L)
+        assertEquals(NextcloudApiCachePolicy.ForceNetwork, request.cachePolicy)
+        assertIs<MemoriesLivePhotoCapability.CompatibleVersion>(
+            parseMemoriesLivePhotoCapability(apiResponse(200, """{"version":"5.2.0"}""")),
+        )
+        assertIs<MemoriesLivePhotoCapability.CompatibleVersion>(
+            parseMemoriesLivePhotoCapability(apiResponse(200, """{"version":"8.1.0"}""")),
+        )
+        assertIs<MemoriesLivePhotoCapability.UnsupportedVersion>(
+            parseMemoriesLivePhotoCapability(apiResponse(200, """{"version":"5.1.0"}""")),
+        )
+        assertIs<MemoriesLivePhotoCapability.UnsupportedVersion>(
+            parseMemoriesLivePhotoCapability(apiResponse(200, """{"version":"8.1.1"}""")),
+        )
+        assertIs<MemoriesLivePhotoCapability.Unverified>(
+            parseMemoriesLivePhotoCapability(apiResponse(404, """{"version":"8.1.0"}""")),
+        )
+        assertIs<MemoriesLivePhotoCapability.Unverified>(
+            parseMemoriesLivePhotoCapability(apiResponse(200, """{"version":"next"}""")),
+        )
+    }
+
+    @Test
+    fun validatedMediaReferenceIsDirectCapabilityEvidence() {
+        val candidate = photo("motion.jpg", "image/jpeg").copy(
+            livePhoto = NextcloudLivePhotoReference("self__trailer"),
+        )
+
+        assertIs<MemoriesLivePhotoCapability.ObservedReference>(
+            candidate.effectiveLivePhotoCapability(MemoriesLivePhotoCapability.Unverified),
+        )
+        assertTrue(
+            candidate.shouldDiscoverMemoriesLivePhoto(
+                capability = candidate.effectiveLivePhotoCapability(
+                    MemoriesLivePhotoCapability.Unverified,
+                ),
+                nativePlaybackAvailable = true,
+            ),
+        )
+    }
+
+    @Test
+    fun lookupFailuresNeverConsumeCancellation() = runBlocking {
+        assertEquals("motion", livePhotoLookupOrNull { "motion" })
+        assertNull(livePhotoLookupOrNull<String> { error("lookup failed") })
+
+        val cancellation = CancellationException("selected photo changed")
+        val thrown = assertFailsWith<CancellationException> {
+            livePhotoLookupOrNull<String> { throw cancellation }
+        }
+
+        assertTrue(thrown === cancellation)
     }
 
     @Test

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionsTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/NativeMediaCollectionsTest.kt
@@ -152,7 +152,7 @@ class NativeMediaCollectionsTest {
                 200,
                 """[
                     {"fileid":41,"dayid":20260723,"basename":"clip.mp4","mimetype":"video/mp4","etag":"a","w":1920,"h":1080,"epoch":1720000000,"isvideo":1,"video_duration":12,"isfavorite":true},
-                    {"fileid":42,"dayid":20260723,"basename":"photo.jpg","mimetype":"image/jpeg","etag":"b","w":6240,"h":4160,"isvideo":false,"facerect":{"x":-0.1,"y":0.8,"w":0.4,"h":0.5},"stackraw":[{"fileid":43},{"fileid":44}]}
+                    {"fileid":42,"dayid":20260723,"basename":"photo.jpg","mimetype":"image/jpeg","etag":"b","w":6240,"h":4160,"isvideo":false,"liveid":"self__trailer","facerect":{"x":-0.1,"y":0.8,"w":0.4,"h":0.5},"stackraw":[{"fileid":43},{"fileid":44}]}
                 ]""",
             ),
             collection,
@@ -164,6 +164,7 @@ class NativeMediaCollectionsTest {
         assertEquals(12, media.first().videoDurationSeconds)
         assertTrue(media.first().isFavorite)
         assertEquals(listOf(43L, 44L), media.last().rawStackFileIds)
+        assertEquals("self__trailer", media.last().livePhoto?.serverToken)
         assertEquals(
             NativeFaceRectangle(x = 0f, y = 0.8f, width = 0.3f, height = 0.2f),
             media.last().faceRectangle,
@@ -172,6 +173,7 @@ class NativeMediaCollectionsTest {
         val previewOnlyFile = media.last().toNextcloudFile(collection.key)
         assertEquals("memories/collections/album:ada/Summer/20260723/42", previewOnlyFile.path)
         assertFalse(previewOnlyFile.originalAccessAllowed)
+        assertEquals("self__trailer", previewOnlyFile.livePhoto?.serverToken)
     }
 
     @Test

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/PersonMediaPagingTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/PersonMediaPagingTest.kt
@@ -39,6 +39,7 @@ class PersonMediaPagingTest {
                           "basename":"photo-$dayId.jpg",
                           "mimetype":"image/jpeg",
                           "etag":"etag-$dayId",
+                          "liveid":"motion-$dayId",
                           "epoch":1784800000,
                           "w":6240,
                           "h":4160,
@@ -72,6 +73,14 @@ class PersonMediaPagingTest {
         val personFile = first.items.first().toPersonMediaFile(person)
         assertFalse(personFile.originalAccessAllowed)
         assertFalse(personFile.davPathAuthoritative)
+        assertEquals("motion-${dayIds.first()}", personFile.livePhoto?.serverToken)
+        val resolvedFile = personFile.copy(
+            path = "Photos/resolved.jpg",
+            livePhoto = null,
+        )
+        val resolvedPersonFile = first.items.first().toPersonMediaFile(person, resolvedFile)
+        assertEquals("Photos/resolved.jpg", resolvedPersonFile.path)
+        assertEquals("motion-${dayIds.first()}", resolvedPersonFile.livePhoto?.serverToken)
         assertEquals(3, observed.size)
         assertTrue(observed.all { it.method == NextcloudApiMethod.GET && it.body == null })
         assertTrue(observed.drop(1).all {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.desktop.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.desktop.kt
@@ -10,7 +10,7 @@ internal actual val platformNativeVideoPlaybackAvailable: Boolean = false
 internal actual fun PlatformNativeVideoPlayer(
     session: NextcloudSession,
     userId: String,
-    file: NextcloudFile,
+    source: NativeVideoPlaybackSource,
     onError: (String) -> Unit,
     modifier: Modifier,
 ) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.desktop.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.desktop.kt
@@ -11,6 +11,7 @@ internal actual fun PlatformNativeVideoPlayer(
     session: NextcloudSession,
     userId: String,
     source: NativeVideoPlaybackSource,
+    onPlaybackEnded: () -> Unit,
     onError: (String) -> Unit,
     modifier: Modifier,
 ) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/RawMediaMarketingCapture.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/RawMediaMarketingCapture.kt
@@ -7,6 +7,7 @@ import dev.obiente.nextcloudnative.app.MAX_RAW_DISPLAY_PREVIEW_BYTES
 import dev.obiente.nextcloudnative.app.MediaDisplayPayloadKind
 import dev.obiente.nextcloudnative.app.MediaViewerReadiness
 import dev.obiente.nextcloudnative.app.MediaViewerStateObservation
+import dev.obiente.nextcloudnative.app.MemoriesLivePhotoCapability
 import dev.obiente.nextcloudnative.app.NextcloudApiMethod
 import dev.obiente.nextcloudnative.app.NextcloudApiRequest
 import dev.obiente.nextcloudnative.app.NextcloudApiResponse
@@ -53,6 +54,7 @@ internal class RawMediaMarketingCapture private constructor(
                     userId = FIXTURE_USER_ID,
                     services = services,
                     taggingAvailable = false,
+                    memoriesLivePhotoCapability = MemoriesLivePhotoCapability.NotAdvertised,
                     sharingCapabilities = NextcloudFileSharingCapabilities.Unavailable,
                     onSelect = { selected ->
                         check(selected.path == RAW_PATH) {


### PR DESCRIPTION
## Summary

- recognize server-indexed Live Photos and Android Motion Photos without changing ordinary still-photo behavior
- lazily discover motion companions for JPEG, HEIC, HEIF, and AVIF photos when the Memories API is available
- play the motion component through the native Android media player after an explicit user action
- keep the still image visible as the reliable fallback when motion is absent, unavailable, or invalid
- add strict embedded Motion Photo and Apple still/video pair detection without filename or timestamp guessing
- expose motion state in native media collections

## User impact

Ordinary photos continue to open as normal. If an exact motion companion is available, the viewer adds a Play motion action. Unsupported photos do not run the lookup and a failed motion stream does not replace the still image with an error screen.

This is the first playback and detection slice. Pair-preserving upload, download, move, share, and offline workflows remain follow-up work.

Advances #182

## Validation

- `:ui:desktopTest --tests dev.obiente.nextcloudnative.app.LivePhotosTest --tests dev.obiente.nextcloudnative.app.LivePhotoDetectionTest --tests dev.obiente.nextcloudnative.app.NativeMediaCollectionsTest`
- `:androidApp:assembleDebug`
- repository hygiene and changelog validation
- APK installed successfully on the visible Android emulator
- Android emulator smoke test passed
