### PR TITLE
fix(linux): verify versioned package metadata

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -288,6 +288,7 @@ jobs:
             -PncMacosPackageVersion="${NIGHTLY_DESKTOP_VERSION}" \
             -PncVersionName="${{ needs.source.outputs.version }}" \
             -PncVersionCode="${{ needs.source.outputs.version-code }}" \
+            -PncAppStreamReleaseDate="$(git show -s --format=%cs HEAD)" \
             -PncDesktopReleaseBuild=true \
             -PncDirectDesktopPackageUpdates="${{ matrix.direct_updates }}" \
             ${{ matrix.tasks }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -180,6 +180,7 @@ jobs:
             -PncMacosPackageVersion="${RELEASE_DESKTOP_VERSION}" \
             -PncVersionName="${GITHUB_REF_NAME#v}" \
             -PncVersionCode="${{ needs.authorize-signing.outputs.version-code }}" \
+            -PncAppStreamReleaseDate="$(git show -s --format=%cs HEAD)" \
             -PncDesktopReleaseBuild=true \
             -PncDirectDesktopPackageUpdates="${{ matrix.direct_updates }}" \
             ${{ matrix.tasks }}

--- a/changes/unreleased/267-linux-release-metadata-regression.md
+++ b/changes/unreleased/267-linux-release-metadata-regression.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 267
+pull: none
+platforms: linux
+user-facing: yes
+
+Linux DEB and RPM packages now include release details that match the packaged version, and RPM verification inspects the actual metadata and artwork instead of checking filenames alone.

--- a/release/linux/dev.obiente.nextcloudnative.metainfo.xml
+++ b/release/linux/dev.obiente.nextcloudnative.metainfo.xml
@@ -10,6 +10,7 @@
     <name>Obiente</name>
   </developer>
   <icon type="stock">dev.obiente.nextcloudnative</icon>
+  <icon type="remote" width="512" height="512">https://nc-native.obiente.dev/icon-512.png</icon>
   <launchable type="desktop-id">nextcloudnative-NextcloudNative.desktop</launchable>
   <provides>
     <binary>NextcloudNative</binary>

--- a/tools/render-linux-appstream-metadata.py
+++ b/tools/render-linux-appstream-metadata.py
@@ -62,7 +62,7 @@ release = ET.Element(
 description = ET.SubElement(release, "description")
 paragraph = ET.SubElement(description, "p")
 if release_type == "development":
-    paragraph.text = f"Development build {release_name} from verified Nextcloud Native source."
+    paragraph.text = f"Nextcloud Native development build {release_name}."
 else:
     paragraph.text = f"Nextcloud Native {release_name}."
 releases.insert(0, release)

--- a/tools/render-linux-appstream-metadata.py
+++ b/tools/render-linux-appstream-metadata.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+import xml.etree.ElementTree as ET
+from datetime import date
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+if len(sys.argv) != 6:
+    fail(
+        "Usage: render-linux-appstream-metadata.py "
+        "SOURCE OUTPUT PACKAGE_VERSION RELEASE_NAME RELEASE_DATE"
+    )
+
+source = Path(sys.argv[1])
+output = Path(sys.argv[2])
+package_version = sys.argv[3]
+release_name = sys.argv[4]
+release_date = sys.argv[5]
+
+if not source.is_file():
+    fail(f"AppStream source does not exist: {source}")
+if source.resolve() == output.resolve():
+    fail("AppStream output must differ from its source.")
+if not re.fullmatch(r"[0-9]+(?:\.[0-9]+){1,3}", package_version):
+    fail(f"Invalid desktop package version: {package_version}")
+if not release_name or any(ord(character) < 0x20 for character in release_name):
+    fail("Release name must be non-empty text without control characters.")
+if not re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}", release_date):
+    fail(f"Invalid AppStream release date: {release_date}")
+try:
+    date.fromisoformat(release_date)
+except ValueError:
+    fail(f"Invalid AppStream release date: {release_date}")
+
+tree = ET.parse(source)
+component = tree.getroot()
+if component.tag != "component" or component.attrib.get("type") != "desktop-application":
+    fail("AppStream source is not a desktop application component.")
+
+releases = component.find("releases")
+if releases is None:
+    releases = ET.SubElement(component, "releases")
+for existing in list(releases):
+    if existing.tag == "release" and existing.attrib.get("version") == package_version:
+        releases.remove(existing)
+
+release_type = "development" if "-" in release_name or release_name.startswith("nightly") else "stable"
+release = ET.Element(
+    "release",
+    {
+        "version": package_version,
+        "date": release_date,
+        "type": release_type,
+    },
+)
+description = ET.SubElement(release, "description")
+paragraph = ET.SubElement(description, "p")
+if release_type == "development":
+    paragraph.text = f"Development build {release_name} from verified Nextcloud Native source."
+else:
+    paragraph.text = f"Nextcloud Native {release_name}."
+releases.insert(0, release)
+
+output.parent.mkdir(parents=True, exist_ok=True)
+ET.indent(tree, space="  ")
+tree.write(output, encoding="UTF-8", xml_declaration=True)

--- a/tools/test-linux-package-metadata.sh
+++ b/tools/test-linux-package-metadata.sh
@@ -24,6 +24,7 @@ assert root.findtext("pkgname") == "nextcloudnative"
 assert root.findtext("metadata_license") == "CC0-1.0"
 assert root.findtext("project_license") == "AGPL-3.0-or-later"
 assert root.find("icon[@type='stock']").text == "dev.obiente.nextcloudnative"
+assert root.find("icon[@type='remote']").text == "https://nc-native.obiente.dev/icon-512.png"
 assert root.findtext("launchable") == "nextcloudnative-NextcloudNative.desktop"
 assert root.find("url[@type='homepage']").text == "https://nc-native.obiente.dev/"
 screenshots = root.findall("./screenshots/screenshot")
@@ -68,6 +69,25 @@ grep -Fq 'tools/verify-rpm-package.sh' \
   "$project_root/tools/repackage-rpm-with-metadata.sh"
 grep -Fq 'repackageRpmWithMetadata' "$project_root/ui/build.gradle.kts"
 
+rendered_metadata="$temporary/rendered.metainfo.xml"
+python3 "$project_root/tools/render-linux-appstream-metadata.py" \
+  "$metadata" "$rendered_metadata" 1.0.2971 \
+  nightly-20260801-1830-run406-03ebaf9d 2026-08-01
+python3 - "$rendered_metadata" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+root = ET.parse(sys.argv[1]).getroot()
+release = root.find("./releases/release")
+assert release is not None
+assert release.attrib == {
+    "version": "1.0.2971",
+    "date": "2026-08-01",
+    "type": "development",
+}
+assert "nightly-20260801-1830-run406-03ebaf9d" in " ".join(release.itertext())
+PY
+
 printf '%s\n' \
   '#!/usr/bin/env bash' \
   'set -euo pipefail' \
@@ -77,18 +97,39 @@ printf '%s\n' \
   '#!/usr/bin/env bash' \
   'set -euo pipefail' \
   'cat >/dev/null' \
-  'printf "%s\n" "${MOCK_RPM_FILE_LIST:-}"' >"$temporary/cpio"
-chmod +x "$temporary/rpm2cpio" "$temporary/cpio"
+  'case "$*" in' \
+  '  *-it*) printf "%s\n" "${MOCK_RPM_FILE_LIST:-}" ;;' \
+  '  *metainfo.xml*) cat "${MOCK_RPM_METADATA:?}" ;;' \
+  '  *NextcloudNative.desktop*) cat "${MOCK_RPM_DESKTOP:?}" ;;' \
+  '  *nextcloudnative.png*) cat "${MOCK_RPM_ICON:?}" ;;' \
+  '  *) exit 2 ;;' \
+  'esac' >"$temporary/cpio"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "%s" "${MOCK_RPM_VERSION:-1.0.2971}"' >"$temporary/rpm"
+chmod +x "$temporary/rpm2cpio" "$temporary/cpio" "$temporary/rpm"
 touch "$temporary/nextcloudnative.rpm"
+printf '%s\n' \
+  '[Desktop Entry]' \
+  'Name=Nextcloud Native' \
+  'Icon=dev.obiente.nextcloudnative' >"$temporary/application.desktop"
+cp "$project_root/website/public/icon-512.png" "$temporary/icon.png"
 
 valid_rpm_file_list=$'/opt/nextcloudnative/bin/NextcloudNative\n/usr/share/applications/nextcloudnative-NextcloudNative.desktop\n/usr/share/icons/hicolor/512x512/apps/dev.obiente.nextcloudnative.png\n/usr/share/metainfo/dev.obiente.nextcloudnative.metainfo.xml'
 PATH="$temporary:$PATH" \
 MOCK_RPM_FILE_LIST="$valid_rpm_file_list" \
+MOCK_RPM_METADATA="$rendered_metadata" \
+MOCK_RPM_DESKTOP="$temporary/application.desktop" \
+MOCK_RPM_ICON="$temporary/icon.png" \
   bash "$project_root/tools/verify-rpm-package.sh" \
   "$temporary/nextcloudnative.rpm" >/dev/null
 
 if PATH="$temporary:$PATH" \
   MOCK_RPM_FILE_LIST="$valid_rpm_file_list"$'\n/usr/lib/.build-id/aa/bb' \
+  MOCK_RPM_METADATA="$rendered_metadata" \
+  MOCK_RPM_DESKTOP="$temporary/application.desktop" \
+  MOCK_RPM_ICON="$temporary/icon.png" \
   bash "$project_root/tools/verify-rpm-package.sh" \
   "$temporary/nextcloudnative.rpm" >"$temporary/verification-error" 2>&1; then
   printf 'RPM verifier accepted a global build-ID link.\n' >&2
@@ -98,6 +139,9 @@ grep -Fq '/usr/lib/.build-id/aa/bb' "$temporary/verification-error"
 
 if PATH="$temporary:$PATH" \
   MOCK_RPM_FILE_LIST='/opt/nextcloudnative/bin/NextcloudNative' \
+  MOCK_RPM_METADATA="$rendered_metadata" \
+  MOCK_RPM_DESKTOP="$temporary/application.desktop" \
+  MOCK_RPM_ICON="$temporary/icon.png" \
   bash "$project_root/tools/verify-rpm-package.sh" \
   "$temporary/nextcloudnative.rpm" >"$temporary/verification-error" 2>&1; then
   printf 'RPM verifier accepted missing desktop integration assets.\n' >&2
@@ -107,5 +151,16 @@ grep -Fq '/usr/share/applications/nextcloudnative-NextcloudNative.desktop' \
   "$temporary/verification-error"
 grep -Fq '/usr/share/icons/hicolor/512x512/apps/dev.obiente.nextcloudnative.png' \
   "$temporary/verification-error"
+
+if PATH="$temporary:$PATH" \
+  MOCK_RPM_FILE_LIST="$valid_rpm_file_list" \
+  MOCK_RPM_METADATA="$metadata" \
+  MOCK_RPM_DESKTOP="$temporary/application.desktop" \
+  MOCK_RPM_ICON="$temporary/icon.png" \
+  bash "$project_root/tools/verify-rpm-package.sh" \
+  "$temporary/nextcloudnative.rpm" >"$temporary/verification-error" 2>&1; then
+  printf 'RPM verifier accepted metadata without the packaged release version.\n' >&2
+  exit 1
+fi
 
 printf 'Linux package metadata contract passed.\n'

--- a/tools/test-linux-package-metadata.sh
+++ b/tools/test-linux-package-metadata.sh
@@ -86,6 +86,7 @@ assert release.attrib == {
     "type": "development",
 }
 assert "nightly-20260801-1830-run406-03ebaf9d" in " ".join(release.itertext())
+assert "verified" not in " ".join(release.itertext()).lower()
 PY
 
 printf '%s\n' \

--- a/tools/verify-rpm-package.sh
+++ b/tools/verify-rpm-package.sh
@@ -7,7 +7,7 @@ if [[ "$#" -ne 1 || ! -f "$package" || "$package" != *.rpm ]]; then
     printf 'Expected exactly one existing RPM package.\n' >&2
     exit 2
 fi
-for required_command in rpm2cpio cpio; do
+for required_command in rpm rpm2cpio cpio python3; do
     if ! command -v "$required_command" >/dev/null 2>&1; then
         printf '%s is required to verify the RPM package.\n' "$required_command" >&2
         exit 2
@@ -44,5 +44,54 @@ if [[ "${#missing_desktop_assets[@]}" -gt 0 ]]; then
     exit 1
 fi
 
-printf 'Verified RPM payload desktop integration and global build-ID safety: %s\n' \
+temporary="$(mktemp -d)"
+trap 'rm -r -- "$temporary"' EXIT
+metadata_path=/usr/share/metainfo/dev.obiente.nextcloudnative.metainfo.xml
+desktop_path=/usr/share/applications/nextcloudnative-NextcloudNative.desktop
+icon_path=/usr/share/icons/hicolor/512x512/apps/dev.obiente.nextcloudnative.png
+rpm2cpio "$package" |
+    cpio -i --quiet --to-stdout ".${metadata_path}" >"$temporary/metainfo.xml"
+rpm2cpio "$package" |
+    cpio -i --quiet --to-stdout ".${desktop_path}" >"$temporary/application.desktop"
+rpm2cpio "$package" |
+    cpio -i --quiet --to-stdout ".${icon_path}" >"$temporary/icon.png"
+package_version="$(rpm -qp --queryformat '%{VERSION}' "$package")"
+
+python3 - \
+    "$temporary/metainfo.xml" \
+    "$temporary/application.desktop" \
+    "$temporary/icon.png" \
+    "$package_version" <<'PY'
+import struct
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+metadata_path, desktop_path, icon_path, package_version = sys.argv[1:]
+root = ET.parse(metadata_path).getroot()
+assert root.tag == "component"
+assert root.attrib.get("type") == "desktop-application"
+assert root.findtext("id") == "dev.obiente.nextcloudnative"
+assert root.findtext("pkgname") == "nextcloudnative"
+assert root.findtext("name") == "Nextcloud Native"
+assert root.findtext("launchable") == "nextcloudnative-NextcloudNative.desktop"
+assert root.find("icon[@type='stock']").text == "dev.obiente.nextcloudnative"
+assert root.find("icon[@type='remote']").text == "https://nc-native.obiente.dev/icon-512.png"
+assert any(
+    release.attrib.get("version") == package_version
+    for release in root.findall("./releases/release")
+)
+assert len(root.findall("./screenshots/screenshot")) >= 3
+
+desktop_lines = set(Path(desktop_path).read_text(encoding="UTF-8").splitlines())
+assert "Name=Nextcloud Native" in desktop_lines
+assert "Icon=dev.obiente.nextcloudnative" in desktop_lines
+
+with Path(icon_path).open("rb") as icon:
+    assert icon.read(16) == b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+    width, height = struct.unpack(">II", icon.read(8))
+assert width == 512 and height == 512
+PY
+
+printf 'Verified RPM payload metadata, artwork, release identity, and global build-ID safety: %s\n' \
     "$package"

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.Base64
 
 val desktopArchitecture = System.getProperty("os.arch").lowercase()
@@ -6,10 +8,15 @@ val ncDesktopPackageVersion = providers.gradleProperty("ncDesktopPackageVersion"
 val ncMacosPackageVersion = providers.gradleProperty("ncMacosPackageVersion").get()
 val ncVersionName = providers.gradleProperty("ncVersionName").get()
 val ncVersionCode = providers.gradleProperty("ncVersionCode").get()
+val ncAppStreamReleaseDate = providers.gradleProperty("ncAppStreamReleaseDate")
+    .orElse(LocalDate.now(ZoneOffset.UTC).toString())
+    .get()
 val ncDesktopReleaseBuild = providers.gradleProperty("ncDesktopReleaseBuild").orElse("false").get()
 val ncDirectDesktopPackageUpdates = providers.gradleProperty("ncDirectDesktopPackageUpdates").orElse("false").get()
 val linuxAppStreamMetadata = rootProject.layout.projectDirectory
     .file("release/linux/dev.obiente.nextcloudnative.metainfo.xml")
+val generatedLinuxAppStreamMetadata = layout.buildDirectory
+    .file("generated/linux-appstream/dev.obiente.nextcloudnative.metainfo.xml")
 val linuxJpackageTemplates = rootProject.layout.projectDirectory.dir("release/linux/jpackage")
 val generatedJpackageResources = layout.buildDirectory.dir("generated/jpackage-resources")
 val debPackageDirectory = layout.buildDirectory.dir("compose/binaries/main/deb")
@@ -18,8 +25,27 @@ val msiPackageDirectory = layout.buildDirectory.dir("compose/binaries/main/msi")
 val debPackageSucceededMarker = layout.buildDirectory.file("compose/tmp/packageDeb.succeeded")
 val rpmPackageSucceededMarker = layout.buildDirectory.file("compose/tmp/packageRpm.succeeded")
 
-val prepareLinuxJpackageResources by tasks.registering {
+val prepareLinuxAppStreamMetadata by tasks.registering(Exec::class) {
     inputs.file(linuxAppStreamMetadata)
+    inputs.file(rootProject.file("tools/render-linux-appstream-metadata.py"))
+    inputs.property("packageVersion", ncDesktopPackageVersion)
+    inputs.property("releaseName", ncVersionName)
+    inputs.property("releaseDate", ncAppStreamReleaseDate)
+    outputs.file(generatedLinuxAppStreamMetadata)
+    commandLine(
+        "python3",
+        rootProject.file("tools/render-linux-appstream-metadata.py"),
+        linuxAppStreamMetadata.asFile,
+        generatedLinuxAppStreamMetadata.get().asFile,
+        ncDesktopPackageVersion,
+        ncVersionName,
+        ncAppStreamReleaseDate,
+    )
+}
+
+val prepareLinuxJpackageResources by tasks.registering {
+    dependsOn(prepareLinuxAppStreamMetadata)
+    inputs.file(generatedLinuxAppStreamMetadata)
     inputs.dir(linuxJpackageTemplates)
     outputs.dir(generatedJpackageResources)
     doLast {
@@ -27,7 +53,7 @@ val prepareLinuxJpackageResources by tasks.registering {
         output.deleteRecursively()
         val linuxOutput = output.resolve("linux").apply { mkdirs() }
         val metadataBase64 = Base64.getEncoder()
-            .encodeToString(linuxAppStreamMetadata.asFile.readBytes())
+            .encodeToString(generatedLinuxAppStreamMetadata.get().asFile.readBytes())
         linuxJpackageTemplates.asFile.listFiles().orEmpty().forEach { template ->
             val content = template.readText().replace("APPSTREAM_XML_BASE64", metadataBase64)
             linuxOutput.resolve(template.name).writeText(content)
@@ -189,14 +215,15 @@ compose.desktop {
 }
 
 val enrichDebAppStream by tasks.registering(Exec::class) {
-    inputs.file(linuxAppStreamMetadata)
+    dependsOn(prepareLinuxAppStreamMetadata)
+    inputs.file(generatedLinuxAppStreamMetadata)
     doNotTrackState("Post-processes the packageDeb artifact in place.")
     onlyIf { debPackageSucceededMarker.get().asFile.isFile }
     commandLine(
         "bash",
         rootProject.file("tools/enrich-deb-appstream.sh"),
         debPackageDirectory.get().asFile,
-        linuxAppStreamMetadata.asFile,
+        generatedLinuxAppStreamMetadata.get().asFile,
         rootProject.file("LICENSE"),
         project.file("src/desktopMain/resources/nextcloud-native.png"),
     )

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -213,7 +213,7 @@
         "ui/src/desktopMain/resources/marketing/raw-render-fixture.png",
         "ui/src/desktopMain/resources/marketing/raw-render-fixture.svg"
     ],
-    "captureSourceSha256": "69d473381018745f781ee5369d9acee178342d4fb5874378461643302898528b",
+    "captureSourceSha256": "3361addae1ae117e709380a9108316e399af46e70190390ae3cb542e680b0279",
     "avatarSha256": "a20433eeda834a418f92d76853633b4fc9115ad3006c5622ce2611432dc1f14d",
     "captures": [
         {


### PR DESCRIPTION
## Summary

- generate AppStream release details that match each DEB and RPM package version
- verify the actual RPM metadata, desktop entry, icon artwork, screenshots, and release identity before publication
- keep development-build provenance neutral unless a trusted release workflow supplies evidence separately

## Root cause

The Linux packaging workflow verified only that expected payload paths existed. The published RPM therefore passed even though its AppStream release list contained only `0.1.0-alpha.1` while the package version was `1.0.2971`.

GNOME Software can consume the in-package metadata after installation. A rich page before installation also requires AppStream catalog data from the RPM repository; that dependent work is in #277.

## Validation

- `bash tools/check-repository.sh`
- `npm run verify:captures:fresh`
- `bash tools/test-linux-package-metadata.sh`
- `bash tools/test-nightly-release-workflow.sh`
- full RPM build and post-repackage payload verification with a generated current-version release entry
- the strengthened verifier rejects the previously published `1.0.2971` RPM

Closes #267.
