### PR TITLE
fix(files): bound virtual file preference keys

### DIFF
--- a/changes/unreleased/11-linux-filesync-preference-key.md
+++ b/changes/unreleased/11-linux-filesync-preference-key.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 11
+pull: none
+platforms: linux, windows
+user-facing: yes
+
+Connecting native virtual-file integration no longer fails because the account-scoped activation setting exceeds the platform preference key limit.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -178,9 +178,11 @@ internal fun unregisterWindowsCloudFilesRootForUninstall(
     }
 }
 
-private fun virtualFileProviderPreferenceKey(accountId: String): String {
-    require(accountId.isNotBlank() && accountId.length <= 128)
-    return "virtual-file-provider-active.$accountId"
+internal fun virtualFileProviderPreferenceKey(accountId: String): String {
+    require(accountId.length == 64 && accountId.all { it in '0'..'9' || it in 'a'..'f' })
+    return "vfp-active.$accountId".also { key ->
+        check(key.length <= Preferences.MAX_KEY_LENGTH)
+    }
 }
 
 internal fun documentTemplatesRelativePath(editorId: String, creatorId: String): String {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualFileProviderPreferencesTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualFileProviderPreferencesTest.kt
@@ -1,0 +1,22 @@
+package dev.obiente.nextcloudnative.app
+
+import java.util.prefs.Preferences
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class DesktopVirtualFileProviderPreferencesTest {
+    @Test
+    fun `provider activation key fits Java Preferences and remains account scoped`() {
+        val firstAccountId = "a".repeat(64)
+        val secondAccountId = "b".repeat(64)
+
+        val firstKey = virtualFileProviderPreferenceKey(firstAccountId)
+        val secondKey = virtualFileProviderPreferenceKey(secondAccountId)
+
+        assertEquals("vfp-active.$firstAccountId", firstKey)
+        assertTrue(firstKey.length <= Preferences.MAX_KEY_LENGTH)
+        assertNotEquals(firstKey, secondKey)
+    }
+}


### PR DESCRIPTION
## Summary

Keep the account-scoped virtual-file activation setting within Java Preferences' key limit while retaining the full account digest and per-account isolation.

## Root cause

The setting combined a 29-character prefix with a 64-character account digest. The resulting 93-character key exceeded Java Preferences' 80-character maximum and caused Linux filesync integration to fail during activation.

## Validation

- targeted desktop test asserts the key remains within `Preferences.MAX_KEY_LENGTH`
- targeted desktop test verifies separate accounts retain distinct keys
- desktop compilation and tests

Related to #11.
