### PR TITLE
fix(desktop): theme the native Windows frame

### DIFF
--- a/changes/unreleased/281-native-windows-frame-theme.md
+++ b/changes/unreleased/281-native-windows-frame-theme.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 281
+pull: none
+platforms: windows
+user-facing: yes
+
+The native Windows title bar now follows the app's dark or light theme while retaining system window controls.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrame.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrame.kt
@@ -1,0 +1,52 @@
+package dev.obiente.nextcloudnative.app
+
+import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.platform.win32.WinDef.HWND
+import com.sun.jna.ptr.IntByReference
+import com.sun.jna.win32.StdCallLibrary
+import java.awt.Window
+
+/** Keeps the operating-system window frame aligned with the app theme without replacing it. */
+internal fun applyDesktopNativeWindowFrame(window: Window, darkTheme: Boolean) {
+    if (!isWindowsDesktop() || !window.isDisplayable) return
+    runCatching {
+        val windowHandle = HWND(Native.getWindowPointer(window))
+        applyWindowsNativeWindowTheme(
+            api = WindowsDesktopWindowApi.instance,
+            windowHandle = windowHandle,
+            darkTheme = darkTheme,
+        )
+    }
+}
+
+internal fun applyWindowsNativeWindowTheme(
+    api: WindowsDesktopWindowApi,
+    windowHandle: HWND,
+    darkTheme: Boolean,
+): Int {
+    val enabled = IntByReference(if (darkTheme) 1 else 0)
+    return api.DwmSetWindowAttribute(
+        windowHandle,
+        DWMWA_USE_IMMERSIVE_DARK_MODE,
+        enabled.pointer,
+        Int.SIZE_BYTES,
+    )
+}
+
+internal interface WindowsDesktopWindowApi : StdCallLibrary {
+    fun DwmSetWindowAttribute(
+        window: HWND,
+        attribute: Int,
+        value: Pointer,
+        valueSize: Int,
+    ): Int
+
+    companion object {
+        val instance: WindowsDesktopWindowApi by lazy {
+            Native.load("dwmapi", WindowsDesktopWindowApi::class.java)
+        }
+    }
+}
+
+internal const val DWMWA_USE_IMMERSIVE_DARK_MODE = 20

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrame.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrame.kt
@@ -26,9 +26,16 @@ internal fun applyWindowsNativeWindowTheme(
     darkTheme: Boolean,
 ): Int {
     val enabled = IntByReference(if (darkTheme) 1 else 0)
-    return api.DwmSetWindowAttribute(
+    val currentResult = api.DwmSetWindowAttribute(
         windowHandle,
         DWMWA_USE_IMMERSIVE_DARK_MODE,
+        enabled.pointer,
+        Int.SIZE_BYTES,
+    )
+    if (currentResult >= 0) return currentResult
+    return api.DwmSetWindowAttribute(
+        windowHandle,
+        DWMWA_USE_IMMERSIVE_DARK_MODE_LEGACY,
         enabled.pointer,
         Int.SIZE_BYTES,
     )
@@ -50,3 +57,4 @@ internal interface WindowsDesktopWindowApi : StdCallLibrary {
 }
 
 internal const val DWMWA_USE_IMMERSIVE_DARK_MODE = 20
+internal const val DWMWA_USE_IMMERSIVE_DARK_MODE_LEGACY = 19

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
@@ -27,6 +27,7 @@ import dev.obiente.nextcloudnative.app.DesktopFileSyncTrayPopup
 import dev.obiente.nextcloudnative.app.FileSyncCenterActionResult
 import dev.obiente.nextcloudnative.app.NextcloudNativeApp
 import dev.obiente.nextcloudnative.app.ThemePreference
+import dev.obiente.nextcloudnative.app.applyDesktopNativeWindowFrame
 import dev.obiente.nextcloudnative.app.tooltip
 import dev.obiente.nextcloudnative.app.unregisterWindowsCloudFilesRootForUninstall
 import dev.obiente.nextcloudnative.app.design.NextcloudNativeTheme
@@ -185,6 +186,7 @@ fun main(arguments: Array<String>) {
         state = rememberWindowState(width = 1_280.dp, height = 820.dp),
     ) {
         SideEffect {
+            applyDesktopNativeWindowFrame(window, darkTheme)
             window.background = java.awt.Color(background.toArgb(), true)
             window.minimumSize = java.awt.Dimension(960, 640)
         }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrameTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrameTest.kt
@@ -21,9 +21,25 @@ class DesktopNativeWindowFrameTest {
         assertEquals(0, api.value)
     }
 
-    private class RecordingWindowsDesktopWindowApi : WindowsDesktopWindowApi {
+    @Test
+    fun `Windows native frame retries the legacy dark mode attribute`() {
+        val api = RecordingWindowsDesktopWindowApi(rejectCurrentAttribute = true)
+        val handle = HWND(Pointer.createConstant(42L))
+
+        assertEquals(0, applyWindowsNativeWindowTheme(api, handle, darkTheme = true))
+        assertEquals(
+            listOf(DWMWA_USE_IMMERSIVE_DARK_MODE, DWMWA_USE_IMMERSIVE_DARK_MODE_LEGACY),
+            api.attributes,
+        )
+        assertEquals(1, api.value)
+    }
+
+    private class RecordingWindowsDesktopWindowApi(
+        private val rejectCurrentAttribute: Boolean = false,
+    ) : WindowsDesktopWindowApi {
         var window: HWND? = null
         var attribute: Int? = null
+        val attributes = mutableListOf<Int>()
         var value: Int? = null
         var valueSize: Int? = null
 
@@ -35,8 +51,10 @@ class DesktopNativeWindowFrameTest {
         ): Int {
             this.window = window
             this.attribute = attribute
+            attributes += attribute
             this.value = value.getInt(0L)
             this.valueSize = valueSize
+            if (rejectCurrentAttribute && attribute == DWMWA_USE_IMMERSIVE_DARK_MODE) return -1
             return 0
         }
     }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrameTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopNativeWindowFrameTest.kt
@@ -1,0 +1,43 @@
+package dev.obiente.nextcloudnative.app
+
+import com.sun.jna.Pointer
+import com.sun.jna.platform.win32.WinDef.HWND
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopNativeWindowFrameTest {
+    @Test
+    fun `Windows native frame follows the active app theme`() {
+        val api = RecordingWindowsDesktopWindowApi()
+        val handle = HWND(Pointer.createConstant(42L))
+
+        assertEquals(0, applyWindowsNativeWindowTheme(api, handle, darkTheme = true))
+        assertEquals(DWMWA_USE_IMMERSIVE_DARK_MODE, api.attribute)
+        assertEquals(1, api.value)
+        assertEquals(Int.SIZE_BYTES, api.valueSize)
+        assertEquals(handle, api.window)
+
+        applyWindowsNativeWindowTheme(api, handle, darkTheme = false)
+        assertEquals(0, api.value)
+    }
+
+    private class RecordingWindowsDesktopWindowApi : WindowsDesktopWindowApi {
+        var window: HWND? = null
+        var attribute: Int? = null
+        var value: Int? = null
+        var valueSize: Int? = null
+
+        override fun DwmSetWindowAttribute(
+            window: HWND,
+            attribute: Int,
+            value: Pointer,
+            valueSize: Int,
+        ): Int {
+            this.window = window
+            this.attribute = attribute
+            this.value = value.getInt(0L)
+            this.valueSize = valueSize
+            return 0
+        }
+    }
+}

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -213,7 +213,7 @@
         "ui/src/desktopMain/resources/marketing/raw-render-fixture.png",
         "ui/src/desktopMain/resources/marketing/raw-render-fixture.svg"
     ],
-    "captureSourceSha256": "69d473381018745f781ee5369d9acee178342d4fb5874378461643302898528b",
+    "captureSourceSha256": "148d86f8e9cfd8ba75d0eb4dbf943f461e2125e8a33320608df6ed92ce1f23f2",
     "avatarSha256": "a20433eeda834a418f92d76853633b4fc9115ad3006c5622ce2611432dc1f14d",
     "captures": [
         {


### PR DESCRIPTION
## Summary

- keep the operating-system-owned desktop title bar and window controls
- opt the Windows frame into the active app dark or light theme through DWM
- contain unavailable or unsupported frame styling so it cannot block startup
- cover the native attribute binding with a focused desktop test

## Validation

- `./gradlew --no-daemon :ui:desktopTest --tests "dev.obiente.nextcloudnative.app.DesktopNativeWindowFrameTest"`
- `./gradlew --no-daemon :ui:createDistributable`
- `node tools/changelog-fragments.mjs validate`

Closes #281