### PR TITLE
feat(windows): brand Cloud Files in File Explorer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Detect build scopes
         id: changes
+        continue-on-error: true
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
@@ -91,6 +92,7 @@ jobs:
       - name: Install Linux repository tooling
         if: >-
           github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
           steps.changes.outputs.linux_repositories == 'true'
         run: |
           sudo apt-get update
@@ -99,6 +101,7 @@ jobs:
       - name: Test signed Linux package repositories
         if: >-
           github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
           steps.changes.outputs.linux_repositories == 'true'
         run: bash tools/test-linux-package-repositories.sh
 
@@ -132,6 +135,7 @@ jobs:
       - name: Set up JDK 21
         if: >-
           github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
           steps.changes.outputs.contract == 'true' ||
           steps.changes.outputs.desktop == 'true' ||
           steps.changes.outputs.android == 'true'
@@ -143,6 +147,7 @@ jobs:
       - name: Set up Gradle build cache
         if: >-
           github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
           steps.changes.outputs.contract == 'true' ||
           steps.changes.outputs.desktop == 'true' ||
           steps.changes.outputs.android == 'true'
@@ -153,13 +158,17 @@ jobs:
       - name: Install Linux virtual filesystem runtime
         if: >-
           github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
           steps.changes.outputs.desktop == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install --yes libfuse2t64
 
       - name: Cache Cargo dependencies and build output
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.rust == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.rust == 'true'
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: |
@@ -171,27 +180,37 @@ jobs:
             ${{ runner.os }}-cargo-v1-
 
       - name: Set up Android SDK
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.android == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.android == 'true'
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
 
       - name: Install Android platform
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.android == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.android == 'true'
         run: sdkmanager "platforms;android-36" "build-tools;35.0.0"
 
       - name: Test semantic compiler
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.rust == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.rust == 'true'
         run: cargo test --locked
 
       - name: Test and build selected Gradle scopes
         if: >-
           github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
           steps.changes.outputs.contract == 'true' ||
           steps.changes.outputs.desktop == 'true' ||
           steps.changes.outputs.android == 'true'
         env:
-          RUN_CONTRACT: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outputs.contract == 'true' }}
-          RUN_DESKTOP: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outputs.desktop == 'true' }}
-          RUN_ANDROID: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outputs.android == 'true' }}
+          RUN_CONTRACT: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outcome != 'success' || steps.changes.outputs.contract == 'true' }}
+          RUN_DESKTOP: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outcome != 'success' || steps.changes.outputs.desktop == 'true' }}
+          RUN_ANDROID: ${{ github.event_name == 'workflow_dispatch' || steps.changes.outcome != 'success' || steps.changes.outputs.android == 'true' }}
         run: |
           set -euo pipefail
           gradle_tasks=()
@@ -212,7 +231,10 @@ jobs:
           ./gradlew --no-daemon "${gradle_tasks[@]}"
 
       - name: Upload Linux desktop app
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.desktop == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.desktop == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nextcloud-native-linux
@@ -221,7 +243,10 @@ jobs:
           retention-days: 7
 
       - name: Upload Android debug APK
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.android == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.android == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nextcloud-native-android-debug
@@ -232,6 +257,7 @@ jobs:
       - name: Report skipped app build
         if: >-
           github.event_name != 'workflow_dispatch' &&
+          steps.changes.outcome == 'success' &&
           steps.changes.outputs.rust != 'true' &&
           steps.changes.outputs.contract != 'true' &&
           steps.changes.outputs.desktop != 'true' &&
@@ -248,6 +274,7 @@ jobs:
 
       - name: Detect Windows desktop changes
         id: changes
+        continue-on-error: true
         uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
@@ -274,32 +301,47 @@ jobs:
               - "gradlew.bat"
 
       - name: Set up Rust
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.windows == 'true'
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: x86_64-pc-windows-msvc
 
       - name: Set up JDK 21
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.windows == 'true'
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Set up Gradle build cache
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.windows == 'true'
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Test Windows desktop and build MSI
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.windows == 'true'
         shell: pwsh
         run: |
           .\gradlew.bat --no-daemon :ui:desktopTest :ui:packageMsi
 
       - name: Verify Windows MSI metadata
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.windows == 'true'
         shell: pwsh
         run: |
           tools/verify-windows-package.ps1 `
@@ -307,7 +349,10 @@ jobs:
             -ExpectedVersion "0.1.0"
 
       - name: Exercise WinGet manifest generation
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.windows == 'true'
         shell: pwsh
         run: |
           tools/create-winget-manifests.ps1 `
@@ -323,7 +368,10 @@ jobs:
           }
 
       - name: Upload Windows MSI
-        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.changes.outcome != 'success' ||
+          steps.changes.outputs.windows == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nextcloud-native-windows
@@ -334,6 +382,9 @@ jobs:
           retention-days: 7
 
       - name: Report skipped Windows build
-        if: github.event_name != 'workflow_dispatch' && steps.changes.outputs.windows != 'true'
+        if: >-
+          github.event_name != 'workflow_dispatch' &&
+          steps.changes.outcome == 'success' &&
+          steps.changes.outputs.windows != 'true'
         shell: pwsh
         run: '"No Windows desktop or build-system changes; native Windows validation was skipped." >> $env:GITHUB_STEP_SUMMARY'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,9 @@ jobs:
           filters: |
             windows:
               - ".github/workflows/ci.yml"
+              - "Cargo.toml"
+              - "Cargo.lock"
+              - "src/bin/nextcloud-native-shell-registrar.rs"
               - "contractAcquisition/**"
               - "release/windows/**"
               - "tools/create-winget-manifests.ps1"
@@ -269,6 +272,12 @@ jobs:
               - "gradle/**"
               - "gradlew"
               - "gradlew.bat"
+
+      - name: Set up Rust
+        if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          targets: x86_64-pc-windows-msvc
 
       - name: Set up JDK 21
         if: github.event_name == 'workflow_dispatch' || steps.changes.outputs.windows == 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -280,6 +280,12 @@ jobs:
           java-version: "21"
           cache: gradle
 
+      - name: Set up Rust for Windows packaging
+        if: matrix.platform == 'windows'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
       - name: Build native desktop package
         shell: bash
         env:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -176,6 +176,12 @@ jobs:
           java-version: "21"
           cache: gradle
 
+      - name: Set up Rust for Windows packaging
+        if: matrix.platform == 'windows'
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
       - name: Build native desktop package
         shell: bash
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,8 @@ dependencies = [
  "serde_json",
  "thiserror",
  "url",
+ "windows",
+ "windows-future",
 ]
 
 [[package]]
@@ -344,6 +346,116 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,17 @@ url = "2.5"
 
 [dev-dependencies]
 pretty_assertions = "1.4"
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62.2", features = [
+    "Security_Cryptography",
+    "Storage",
+    "Storage_Provider",
+    "Storage_Search",
+    "Storage_Streams",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_System_WinRT",
+] }
+windows-future = { version = "0.3.2", features = ["std"] }

--- a/changes/unreleased/290-windows-cloud-files-shell.md
+++ b/changes/unreleased/290-windows-cloud-files-shell.md
@@ -1,0 +1,7 @@
+category: feature
+issue: 290
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows Cloud Files roots now appear in File Explorer with Nextcloud Native branding. The MSI includes its icon and a supported storage-provider registrar while retaining the existing Cloud Files path as a safe fallback.

--- a/changes/unreleased/294-ci-scope-fallback.md
+++ b/changes/unreleased/294-ci-scope-fallback.md
@@ -1,0 +1,7 @@
+category: internal
+issue: 294
+pull: none
+platforms: all
+user-facing: no
+
+Build validation now falls back to every relevant scope when pull request diff metadata is temporarily unavailable.

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -1,0 +1,362 @@
+#![cfg_attr(windows, windows_subsystem = "windows")]
+
+#[cfg(windows)]
+const PROVIDER_ID: &str = "Obiente.NextcloudNative";
+#[cfg(any(windows, test))]
+const ACCOUNT_ID_LENGTH: usize = 64;
+#[cfg(any(windows, test))]
+const MAX_SYNC_ROOT_IDENTITY_BYTES: usize = 4_096;
+
+#[cfg(any(windows, test))]
+fn valid_account_id(value: &str) -> bool {
+    value.len() == ACCOUNT_ID_LENGTH
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(any(windows, test))]
+fn decode_identity_hex(value: &str) -> Result<Vec<u8>, &'static str> {
+    if value.is_empty()
+        || value.len() > MAX_SYNC_ROOT_IDENTITY_BYTES * 2
+        || !value.len().is_multiple_of(2)
+    {
+        return Err("invalid identity length");
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = hex_nibble(pair[0]).ok_or("invalid identity encoding")?;
+            let low = hex_nibble(pair[1]).ok_or("invalid identity encoding")?;
+            Ok((high << 4) | low)
+        })
+        .collect()
+}
+
+#[cfg(any(windows, test))]
+fn hex_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn lowercase_hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(DIGITS[(byte >> 4) as usize] as char);
+        encoded.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+#[cfg(any(windows, test))]
+fn sid_string(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 8 {
+        return None;
+    }
+    let subauthority_count = bytes[1] as usize;
+    if bytes.len() != 8 + subauthority_count * 4 {
+        return None;
+    }
+    let authority = bytes[2..8]
+        .iter()
+        .fold(0u64, |value, byte| (value << 8) | u64::from(*byte));
+    let mut sid = format!("S-{}-{authority}", bytes[0]);
+    for subauthority in bytes[8..].chunks_exact(4) {
+        let value = u32::from_le_bytes(subauthority.try_into().ok()?);
+        sid.push('-');
+        sid.push_str(&value.to_string());
+    }
+    Some(sid)
+}
+
+#[cfg(windows)]
+mod platform {
+    use super::{PROVIDER_ID, decode_identity_hex, sid_string, valid_account_id};
+    use std::ffi::{OsStr, OsString};
+    use std::mem::size_of;
+    use std::path::{Path, PathBuf};
+    use windows::Security::Cryptography::CryptographicBuffer;
+    use windows::Storage::Provider::{
+        StorageProviderHardlinkPolicy, StorageProviderHydrationPolicy,
+        StorageProviderHydrationPolicyModifier, StorageProviderInSyncPolicy,
+        StorageProviderPopulationPolicy, StorageProviderSyncRootInfo,
+        StorageProviderSyncRootManager,
+    };
+    use windows::Storage::StorageFolder;
+    use windows::Win32::Foundation::{CloseHandle, E_FAIL, HANDLE};
+    use windows::Win32::Security::{
+        GetLengthSid, GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+    use windows::Win32::System::WinRT::{RO_INIT_MULTITHREADED, RoInitialize, RoUninitialize};
+    use windows::core::{Error as WindowsError, GUID, HSTRING, Result as WindowsResult};
+
+    const PROVIDER_GUID: GUID = GUID::from_u128(0x6d456713_7d9a_4a39_90ce_127998de42d7);
+
+    struct OwnedHandle(HANDLE);
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            // SAFETY: OpenProcessToken returned this owned handle and it is closed exactly once.
+            unsafe {
+                let _ = CloseHandle(self.0);
+            }
+        }
+    }
+
+    struct WinRtApartment;
+
+    impl WinRtApartment {
+        fn initialize() -> WindowsResult<Self> {
+            // SAFETY: this process initializes and uninitializes WinRT on the same main thread.
+            unsafe { RoInitialize(RO_INIT_MULTITHREADED)? };
+            Ok(Self)
+        }
+    }
+
+    impl Drop for WinRtApartment {
+        fn drop(&mut self) {
+            // SAFETY: paired with the successful RoInitialize call on this thread.
+            unsafe { RoUninitialize() };
+        }
+    }
+
+    fn registration_error(message: &'static str) -> WindowsError {
+        WindowsError::new(E_FAIL, message)
+    }
+
+    fn current_user_sid() -> WindowsResult<String> {
+        let mut raw_token = HANDLE::default();
+        // SAFETY: raw_token is a valid out pointer and TOKEN_QUERY is the only requested access.
+        unsafe {
+            OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut raw_token)?;
+        }
+        let token = OwnedHandle(raw_token);
+        let mut required_bytes = 0u32;
+        // The first call intentionally has no output buffer and reports its required length.
+        let _ = unsafe { GetTokenInformation(token.0, TokenUser, None, 0, &mut required_bytes) };
+        if required_bytes < size_of::<TOKEN_USER>() as u32 {
+            return Err(registration_error(
+                "Windows did not return a valid user identity.",
+            ));
+        }
+        let word_bytes = size_of::<usize>();
+        let mut storage = vec![0usize; (required_bytes as usize).div_ceil(word_bytes)];
+        // SAFETY: storage is aligned for TOKEN_USER and has at least required_bytes capacity.
+        unsafe {
+            GetTokenInformation(
+                token.0,
+                TokenUser,
+                Some(storage.as_mut_ptr().cast()),
+                required_bytes,
+                &mut required_bytes,
+            )?;
+        }
+        // SAFETY: GetTokenInformation populated storage with a TOKEN_USER structure.
+        let token_user = unsafe { &*storage.as_ptr().cast::<TOKEN_USER>() };
+        let sid_length = unsafe { GetLengthSid(token_user.User.Sid) } as usize;
+        if sid_length == 0 {
+            return Err(registration_error(
+                "Windows did not return a valid user identity.",
+            ));
+        }
+        // SAFETY: TOKEN_USER owns a valid SID for the lifetime of storage.
+        let sid =
+            unsafe { std::slice::from_raw_parts(token_user.User.Sid.0.cast::<u8>(), sid_length) };
+        sid_string(sid).ok_or_else(|| registration_error("Windows returned an invalid user SID."))
+    }
+
+    fn sync_root_id(account_id: &str) -> WindowsResult<HSTRING> {
+        let id = format!("{PROVIDER_ID}!{}!{account_id}", current_user_sid()?);
+        if id.len() > 255 {
+            return Err(registration_error(
+                "The Windows sync root identity is too long.",
+            ));
+        }
+        Ok(HSTRING::from(id))
+    }
+
+    fn validate_registration_paths(root: &Path, icon: &Path) -> Result<(), &'static str> {
+        if !root.is_absolute() || !root.is_dir() {
+            return Err("invalid sync root");
+        }
+        if !icon.is_absolute() || !icon.is_file() {
+            return Err("invalid icon resource");
+        }
+        Ok(())
+    }
+
+    fn register(
+        root: PathBuf,
+        account_id: String,
+        icon: PathBuf,
+        identity_hex: String,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if !valid_account_id(&account_id) {
+            return Err("invalid account identity".into());
+        }
+        validate_registration_paths(&root, &icon)?;
+        let identity = decode_identity_hex(&identity_hex)?;
+        let root_path = HSTRING::from(root.as_path());
+        let mut icon_resource_value = OsString::from("\"");
+        icon_resource_value.push(icon.as_os_str());
+        icon_resource_value.push(OsStr::new("\",0"));
+        let icon_resource = HSTRING::from(&icon_resource_value);
+        let display_name = HSTRING::from("Nextcloud Native");
+        let context = CryptographicBuffer::CreateFromByteArray(&identity)?;
+
+        let id = sync_root_id(&account_id)?;
+        if let Ok(existing) = StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
+            if existing.Path()?.Path()? == root_path
+                && existing.DisplayNameResource()? == display_name
+                && existing.IconResource()? == icon_resource
+                && CryptographicBuffer::Compare(&existing.Context()?, &context)?
+            {
+                return Ok(());
+            }
+            StorageProviderSyncRootManager::Unregister(&id)?;
+        }
+
+        let info = StorageProviderSyncRootInfo::new()?;
+        info.SetId(&id)?;
+        info.SetPath(&StorageFolder::GetFolderFromPathAsync(&root_path)?.join()?)?;
+        info.SetDisplayNameResource(&display_name)?;
+        info.SetIconResource(&icon_resource)?;
+        info.SetHydrationPolicy(StorageProviderHydrationPolicy::Progressive)?;
+        info.SetHydrationPolicyModifier(
+            StorageProviderHydrationPolicyModifier::AutoDehydrationAllowed,
+        )?;
+        info.SetPopulationPolicy(StorageProviderPopulationPolicy::Full)?;
+        info.SetInSyncPolicy(
+            StorageProviderInSyncPolicy::FileCreationTime
+                | StorageProviderInSyncPolicy::FileLastWriteTime
+                | StorageProviderInSyncPolicy::DirectoryCreationTime
+                | StorageProviderInSyncPolicy::DirectoryLastWriteTime,
+        )?;
+        info.SetHardlinkPolicy(StorageProviderHardlinkPolicy::None)?;
+        info.SetShowSiblingsAsGroup(false)?;
+        info.SetVersion(&HSTRING::from(env!("CARGO_PKG_VERSION")))?;
+        info.SetProviderId(PROVIDER_GUID)?;
+        info.SetAllowPinning(true)?;
+        info.SetContext(&context)?;
+        StorageProviderSyncRootManager::Register(&info)?;
+        Ok(())
+    }
+
+    fn unregister(account_id: String) -> Result<(), Box<dyn std::error::Error>> {
+        if !valid_account_id(&account_id) {
+            return Err("invalid account identity".into());
+        }
+        StorageProviderSyncRootManager::Unregister(&sync_root_id(&account_id)?)?;
+        Ok(())
+    }
+
+    pub fn run(arguments: Vec<OsString>) -> Result<(), Box<dyn std::error::Error>> {
+        let _apartment = WinRtApartment::initialize()?;
+        let mut values = arguments.into_iter();
+        let command = values.next().and_then(|value| value.into_string().ok());
+        match command.as_deref() {
+            Some("self-test") if values.next().is_none() => {
+                if StorageProviderSyncRootManager::IsSupported()? {
+                    Ok(())
+                } else {
+                    Err("Windows storage-provider registration is unavailable".into())
+                }
+            }
+            Some("register") => {
+                let root = values
+                    .next()
+                    .map(PathBuf::from)
+                    .ok_or("missing sync root")?;
+                let account_id = values
+                    .next()
+                    .and_then(|value| value.into_string().ok())
+                    .ok_or("invalid account identity")?;
+                let icon = values
+                    .next()
+                    .map(PathBuf::from)
+                    .ok_or("missing icon resource")?;
+                let identity_hex = values
+                    .next()
+                    .and_then(|value| value.into_string().ok())
+                    .ok_or("invalid sync root identity")?;
+                if values.next().is_some() {
+                    return Err("unexpected arguments".into());
+                }
+                register(root, account_id, icon, identity_hex)
+            }
+            Some("unregister") => {
+                let account_id = values
+                    .next()
+                    .and_then(|value| value.into_string().ok())
+                    .ok_or("invalid account identity")?;
+                if values.next().is_some() {
+                    return Err("unexpected arguments".into());
+                }
+                unregister(account_id)
+            }
+            _ => Err("unsupported command".into()),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn main() {
+    let arguments = std::env::args_os().skip(1).collect();
+    if platform::run(arguments).is_err() {
+        eprintln!("Windows shell registration failed.");
+        std::process::exit(1);
+    }
+}
+
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("This helper is only available on Windows.");
+    std::process::exit(2);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_lowercase_sha256_account_ids() {
+        assert!(valid_account_id(&"a5".repeat(32)));
+        assert!(!valid_account_id(&"A5".repeat(32)));
+        assert!(!valid_account_id(&"a5".repeat(31)));
+        assert!(!valid_account_id(&format!("{}g", "a".repeat(63))));
+    }
+
+    #[test]
+    fn decodes_bounded_lowercase_identity_hex() {
+        assert_eq!(decode_identity_hex("004eff").unwrap(), vec![0, 78, 255]);
+        assert!(decode_identity_hex("").is_err());
+        assert!(decode_identity_hex("0").is_err());
+        assert!(decode_identity_hex("AA").is_err());
+        assert!(decode_identity_hex("gg").is_err());
+        assert!(decode_identity_hex(&"00".repeat(MAX_SYNC_ROOT_IDENTITY_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn lowercase_hex_round_trips_binary_identity() {
+        let identity = [0, 1, 15, 16, 127, 128, 255];
+        let encoded = lowercase_hex(&identity);
+        assert_eq!(decode_identity_hex(&encoded).unwrap(), identity);
+    }
+
+    #[test]
+    fn renders_a_windows_sid_in_the_supported_registration_format() {
+        let administrators_sid = [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0];
+        assert_eq!(
+            sid_string(&administrators_sid).as_deref(),
+            Some("S-1-5-32-544")
+        );
+        assert_eq!(sid_string(&administrators_sid[..15]), None);
+    }
+}

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -6,6 +6,22 @@ const PROVIDER_ID: &str = "Obiente.NextcloudNative";
 const ACCOUNT_ID_LENGTH: usize = 64;
 #[cfg(any(windows, test))]
 const MAX_SYNC_ROOT_IDENTITY_BYTES: usize = 4_096;
+#[cfg(any(windows, test))]
+const MAX_DISPLAY_NAME_CHARACTERS: usize = 128;
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct OwnedPathConflict;
+
+#[cfg(windows)]
+impl std::fmt::Display for OwnedPathConflict {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an owned Cloud Files registration already uses this path")
+    }
+}
+
+#[cfg(windows)]
+impl std::error::Error for OwnedPathConflict {}
 
 #[cfg(any(windows, test))]
 fn valid_account_id(value: &str) -> bool {
@@ -13,6 +29,12 @@ fn valid_account_id(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(any(windows, test))]
+fn valid_display_name(value: &str) -> bool {
+    let count = value.encode_utf16().count();
+    (1..=MAX_DISPLAY_NAME_CHARACTERS).contains(&count) && !value.chars().any(char::is_control)
 }
 
 #[cfg(any(windows, test))]
@@ -77,7 +99,10 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 
 #[cfg(windows)]
 mod platform {
-    use super::{PROVIDER_ID, decode_identity_hex, sid_string, valid_account_id};
+    use super::{
+        OwnedPathConflict, PROVIDER_ID, decode_identity_hex, sid_string, valid_account_id,
+        valid_display_name,
+    };
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
     use std::path::{Path, PathBuf};
@@ -195,11 +220,15 @@ mod platform {
     fn register(
         root: PathBuf,
         account_id: String,
+        display_name: String,
         icon: PathBuf,
         identity_hex: String,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if !valid_account_id(&account_id) {
             return Err("invalid account identity".into());
+        }
+        if !valid_display_name(&display_name) {
+            return Err("invalid display name".into());
         }
         validate_registration_paths(&root, &icon)?;
         let identity = decode_identity_hex(&identity_hex)?;
@@ -208,19 +237,29 @@ mod platform {
         icon_resource_value.push(icon.as_os_str());
         icon_resource_value.push(OsStr::new("\",0"));
         let icon_resource = HSTRING::from(&icon_resource_value);
-        let display_name = HSTRING::from("Nextcloud Native");
+        let display_name = HSTRING::from(display_name);
         let context = CryptographicBuffer::CreateFromByteArray(&identity)?;
 
         let id = sync_root_id(&account_id)?;
         if let Ok(existing) = StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
-            if existing.Path()?.Path()? == root_path
-                && existing.DisplayNameResource()? == display_name
+            if existing.Path()?.Path()? != root_path {
+                return Err("the account is registered at a different sync root path".into());
+            }
+            if existing.DisplayNameResource()? == display_name
                 && existing.IconResource()? == icon_resource
                 && CryptographicBuffer::Compare(&existing.Context()?, &context)?
             {
                 return Ok(());
             }
             StorageProviderSyncRootManager::Unregister(&id)?;
+        }
+        for existing in StorageProviderSyncRootManager::GetCurrentSyncRoots()? {
+            if existing.Id()? != id
+                && existing.ProviderId()? == PROVIDER_GUID
+                && existing.Path()?.Path()? == root_path
+            {
+                return Err(Box::new(OwnedPathConflict));
+            }
         }
 
         let info = StorageProviderSyncRootInfo::new()?;
@@ -249,11 +288,19 @@ mod platform {
         Ok(())
     }
 
-    fn unregister(account_id: String) -> Result<(), Box<dyn std::error::Error>> {
+    fn unregister(root: PathBuf, account_id: String) -> Result<(), Box<dyn std::error::Error>> {
+        if !root.is_absolute() {
+            return Err("invalid sync root".into());
+        }
         if !valid_account_id(&account_id) {
             return Err("invalid account identity".into());
         }
-        StorageProviderSyncRootManager::Unregister(&sync_root_id(&account_id)?)?;
+        let id = sync_root_id(&account_id)?;
+        let existing = StorageProviderSyncRootManager::GetSyncRootInformationForId(&id)?;
+        if existing.Path()?.Path()? != HSTRING::from(root.as_path()) {
+            return Err("the registered sync root path does not match".into());
+        }
+        StorageProviderSyncRootManager::Unregister(&id)?;
         Ok(())
     }
 
@@ -278,6 +325,10 @@ mod platform {
                     .next()
                     .and_then(|value| value.into_string().ok())
                     .ok_or("invalid account identity")?;
+                let display_name = values
+                    .next()
+                    .and_then(|value| value.into_string().ok())
+                    .ok_or("invalid display name")?;
                 let icon = values
                     .next()
                     .map(PathBuf::from)
@@ -289,9 +340,13 @@ mod platform {
                 if values.next().is_some() {
                     return Err("unexpected arguments".into());
                 }
-                register(root, account_id, icon, identity_hex)
+                register(root, account_id, display_name, icon, identity_hex)
             }
             Some("unregister") => {
+                let root = values
+                    .next()
+                    .map(PathBuf::from)
+                    .ok_or("missing sync root")?;
                 let account_id = values
                     .next()
                     .and_then(|value| value.into_string().ok())
@@ -299,7 +354,7 @@ mod platform {
                 if values.next().is_some() {
                     return Err("unexpected arguments".into());
                 }
-                unregister(account_id)
+                unregister(root, account_id)
             }
             _ => Err("unsupported command".into()),
         }
@@ -309,9 +364,13 @@ mod platform {
 #[cfg(windows)]
 fn main() {
     let arguments = std::env::args_os().skip(1).collect();
-    if platform::run(arguments).is_err() {
+    if let Err(failure) = platform::run(arguments) {
         eprintln!("Windows shell registration failed.");
-        std::process::exit(1);
+        std::process::exit(if failure.is::<OwnedPathConflict>() {
+            3
+        } else {
+            1
+        });
     }
 }
 
@@ -331,6 +390,16 @@ mod tests {
         assert!(!valid_account_id(&"A5".repeat(32)));
         assert!(!valid_account_id(&"a5".repeat(31)));
         assert!(!valid_account_id(&format!("{}g", "a".repeat(63))));
+    }
+
+    #[test]
+    fn accepts_only_bounded_non_control_display_names() {
+        assert!(valid_display_name("Nextcloud Native - ada@cloud.example"));
+        assert!(!valid_display_name(""));
+        assert!(!valid_display_name("Nextcloud Native\nmalformed"));
+        assert!(!valid_display_name(
+            &"n".repeat(MAX_DISPLAY_NAME_CHARACTERS + 1)
+        ));
     }
 
     #[test]

--- a/tools/repackage-msi-with-uninstall-cleanup.ps1
+++ b/tools/repackage-msi-with-uninstall-cleanup.ps1
@@ -15,13 +15,27 @@ param(
     [string]$AppImage,
 
     [Parameter(Mandatory = $true)]
-    [string]$Jpackage
+    [string]$Jpackage,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ShellRegistrar,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ShellIcon
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-foreach ($path in @($PackageDirectory, $ArgumentsFile, $JpackageResourceDirectory, $AppImage, $Jpackage)) {
+foreach ($path in @(
+    $PackageDirectory,
+    $ArgumentsFile,
+    $JpackageResourceDirectory,
+    $AppImage,
+    $Jpackage,
+    $ShellRegistrar,
+    $ShellIcon
+)) {
     if (-not (Test-Path -LiteralPath $path)) {
         throw "Required MSI packaging input does not exist: $path"
     }
@@ -74,6 +88,15 @@ if ($name -ne "NextcloudNative" -or
     -not (Test-Path -LiteralPath (Join-Path $AppImage "NextcloudNative.exe") -PathType Leaf) -or
     -not (Test-Path -LiteralPath (Join-Path $AppImage "app/.jpackage.xml") -PathType Leaf)) {
     throw "The captured package metadata or application image is invalid."
+}
+
+$packagedShellRegistrar = Join-Path $AppImage "NextcloudNativeShellRegistrar.exe"
+$packagedShellIcon = Join-Path $AppImage "NextcloudNative.ico"
+Copy-Item -LiteralPath $ShellRegistrar -Destination $packagedShellRegistrar -Force
+Copy-Item -LiteralPath $ShellIcon -Destination $packagedShellIcon -Force
+if (-not (Test-Path -LiteralPath $packagedShellRegistrar -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $packagedShellIcon -PathType Leaf)) {
+    throw "The Windows shell registration helper or icon was not added to the application image."
 }
 
 if (Test-Path -LiteralPath $GeneratedResourceDirectory) {

--- a/tools/repackage-msi-with-uninstall-cleanup.ps1
+++ b/tools/repackage-msi-with-uninstall-cleanup.ps1
@@ -15,13 +15,7 @@ param(
     [string]$AppImage,
 
     [Parameter(Mandatory = $true)]
-    [string]$Jpackage,
-
-    [Parameter(Mandatory = $true)]
-    [string]$ShellRegistrar,
-
-    [Parameter(Mandatory = $true)]
-    [string]$ShellIcon
+    [string]$Jpackage
 )
 
 $ErrorActionPreference = "Stop"
@@ -32,9 +26,7 @@ foreach ($path in @(
     $ArgumentsFile,
     $JpackageResourceDirectory,
     $AppImage,
-    $Jpackage,
-    $ShellRegistrar,
-    $ShellIcon
+    $Jpackage
 )) {
     if (-not (Test-Path -LiteralPath $path)) {
         throw "Required MSI packaging input does not exist: $path"
@@ -92,11 +84,9 @@ if ($name -ne "NextcloudNative" -or
 
 $packagedShellRegistrar = Join-Path $AppImage "NextcloudNativeShellRegistrar.exe"
 $packagedShellIcon = Join-Path $AppImage "NextcloudNative.ico"
-Copy-Item -LiteralPath $ShellRegistrar -Destination $packagedShellRegistrar -Force
-Copy-Item -LiteralPath $ShellIcon -Destination $packagedShellIcon -Force
 if (-not (Test-Path -LiteralPath $packagedShellRegistrar -PathType Leaf) -or
     -not (Test-Path -LiteralPath $packagedShellIcon -PathType Leaf)) {
-    throw "The Windows shell registration helper or icon was not added to the application image."
+    throw "The completed Windows application image is missing its shell registration helper or icon."
 }
 
 if (Test-Path -LiteralPath $GeneratedResourceDirectory) {

--- a/tools/test-marketing-capture-workflow.sh
+++ b/tools/test-marketing-capture-workflow.sh
@@ -65,6 +65,15 @@ for stale_gate in \
     fi
 done
 
+scope_detector_count="$(grep -Ec '^      - name: Detect (build scopes|Windows desktop changes)$' "$ci")"
+continued_detector_count="$(grep -Fc 'continue-on-error: true' "$ci")"
+if [[ "$scope_detector_count" -ne 2 || "$continued_detector_count" -ne 2 ]]; then
+    printf 'Build scope detection must degrade safely for both build jobs.\n' >&2
+    exit 1
+fi
+require_text "$ci" "steps.changes.outcome != 'success'"
+require_text "$ci" "steps.changes.outcome == 'success'"
+
 if grep -Fq 'pull_request_target:' "$prepare_workflow" "$commit_workflow"; then
     printf 'Capture automation must not execute pull request code with pull_request_target.\n' >&2
     exit 1

--- a/tools/test-nightly-release-workflow.sh
+++ b/tools/test-nightly-release-workflow.sh
@@ -8,6 +8,7 @@ nightly_notes="$project_root/tools/nightly-release-notes.mjs"
 promotion="$project_root/tools/promote-app-update-channel.sh"
 msi_repackager="$project_root/tools/repackage-msi-with-uninstall-cleanup.ps1"
 msi_verifier="$project_root/tools/verify-windows-package.ps1"
+ui_build="$project_root/ui/build.gradle.kts"
 temporary_directory="$(mktemp -d)"
 trap 'rm -r -- "$temporary_directory"' EXIT
 
@@ -162,6 +163,9 @@ require_text "$msi_repackager" 'NextcloudNativeShellRegistrar.exe'
 require_text "$msi_repackager" 'NextcloudNative.ico'
 require_text "$msi_verifier" 'NextcloudNativeShellRegistrar.exe'
 require_text "$msi_verifier" 'NextcloudNative.ico'
+require_text "$ui_build" 'val stageWindowsShellAssets by tasks.registering'
+require_text "$ui_build" 'finalizedBy(stageWindowsShellAssets)'
+require_text "$ui_build" 'dependsOn("createDistributable", stageWindowsShellAssets)'
 if grep -Fq 'Join-Path $AppImage "lib/app/.jpackage.xml"' "$msi_repackager"; then
     echo "Windows MSI repackaging must use the Windows jpackage metadata layout." >&2
     exit 1

--- a/tools/test-nightly-release-workflow.sh
+++ b/tools/test-nightly-release-workflow.sh
@@ -7,6 +7,7 @@ prerelease="$project_root/.github/workflows/prerelease.yml"
 nightly_notes="$project_root/tools/nightly-release-notes.mjs"
 promotion="$project_root/tools/promote-app-update-channel.sh"
 msi_repackager="$project_root/tools/repackage-msi-with-uninstall-cleanup.ps1"
+msi_verifier="$project_root/tools/verify-windows-package.ps1"
 temporary_directory="$(mktemp -d)"
 trap 'rm -r -- "$temporary_directory"' EXIT
 
@@ -37,6 +38,8 @@ require_text "$nightly" 'runner: windows-latest'
 require_text "$nightly" 'runner: macos-15-intel'
 require_text "$nightly" 'tasks: ":ui:packageDeb :ui:packageRpm"'
 require_text "$nightly" 'tasks: ":ui:packageMsi"'
+require_text "$nightly" 'name: Set up Rust for Windows packaging'
+require_text "$nightly" 'targets: x86_64-pc-windows-msvc'
 require_text "$nightly" 'name: Verify unsigned Windows MSI'
 require_text "$nightly" 'tools/verify-windows-package.ps1'
 require_text "$nightly" 'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1'
@@ -114,6 +117,8 @@ require_text "$prerelease" '-PncDesktopPackageVersion="${RELEASE_DESKTOP_VERSION
 require_text "$prerelease" '-PncMacosPackageVersion="${RELEASE_DESKTOP_VERSION}"'
 require_text "$prerelease" '-PncDirectDesktopPackageUpdates="${{ matrix.direct_updates }}"'
 require_text "$prerelease" 'name: Verify unsigned Windows MSI'
+require_text "$prerelease" 'name: Set up Rust for Windows packaging'
+require_text "$prerelease" 'targets: x86_64-pc-windows-msvc'
 require_text "$prerelease" 'tools/verify-windows-package.ps1'
 require_text "$prerelease" 'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1'
 require_text "$prerelease" 'subject-path: ui/build/compose/binaries/main/msi/*.msi'
@@ -153,6 +158,10 @@ require_text "$msi_repackager" 'Join-Path $AppImage "app/.jpackage.xml"'
 require_text "$msi_repackager" 'Id="LaunchNextcloudNative"'
 require_text "$msi_repackager" 'NOT REMOVE AND UILevel &gt;= 3 AND NOT NEXTCLOUD_NATIVE_UPDATER_HANDOFF'
 require_text "$msi_repackager" 'Return="asyncNoWait"'
+require_text "$msi_repackager" 'NextcloudNativeShellRegistrar.exe'
+require_text "$msi_repackager" 'NextcloudNative.ico'
+require_text "$msi_verifier" 'NextcloudNativeShellRegistrar.exe'
+require_text "$msi_verifier" 'NextcloudNative.ico'
 if grep -Fq 'Join-Path $AppImage "lib/app/.jpackage.xml"' "$msi_repackager"; then
     echo "Windows MSI repackaging must use the Windows jpackage metadata layout." >&2
     exit 1

--- a/tools/verify-windows-package.ps1
+++ b/tools/verify-windows-package.ps1
@@ -59,6 +59,39 @@ function Read-MsiProperty {
     }
 }
 
+function Read-MsiFileNames {
+    $view = $database.GetType().InvokeMember(
+        "OpenView",
+        "InvokeMethod",
+        $null,
+        $database,
+        @("SELECT ``FileName`` FROM ``File``")
+    )
+    try {
+        $view.GetType().InvokeMember("Execute", "InvokeMethod", $null, $view, $null) | Out-Null
+        $names = [System.Collections.Generic.List[string]]::new()
+        while ($true) {
+            $record = $view.GetType().InvokeMember("Fetch", "InvokeMethod", $null, $view, $null)
+            if ($null -eq $record) {
+                break
+            }
+            $encodedName = $record.GetType().InvokeMember(
+                "StringData",
+                "GetProperty",
+                $null,
+                $record,
+                @(1)
+            )
+            foreach ($name in ($encodedName -split "\|")) {
+                $names.Add($name)
+            }
+        }
+        return $names
+    } finally {
+        $view.GetType().InvokeMember("Close", "InvokeMethod", $null, $view, $null) | Out-Null
+    }
+}
+
 $productName = Read-MsiProperty -Name "ProductName"
 $productVersion = Read-MsiProperty -Name "ProductVersion"
 $manufacturer = Read-MsiProperty -Name "Manufacturer"
@@ -76,6 +109,13 @@ if ($manufacturer -ne "Obiente") {
 $expectedUpgradeCode = "{81237D85-C511-47A7-B8DC-C87A5F5C5823}"
 if ($upgradeCode.ToUpperInvariant() -ne $expectedUpgradeCode) {
     throw "Unexpected Windows upgrade identity."
+}
+
+$packagedFiles = @(Read-MsiFileNames)
+foreach ($requiredFile in @("NextcloudNativeShellRegistrar.exe", "NextcloudNative.ico")) {
+    if ($requiredFile -notin $packagedFiles) {
+        throw "The Windows MSI does not contain $requiredFile."
+    }
 }
 
 $signature = Get-AuthenticodeSignature -LiteralPath $package.FullName

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -26,6 +26,32 @@ val rpmPackageDirectory = layout.buildDirectory.dir("compose/binaries/main/rpm")
 val msiPackageDirectory = layout.buildDirectory.dir("compose/binaries/main/msi")
 val debPackageSucceededMarker = layout.buildDirectory.file("compose/tmp/packageDeb.succeeded")
 val rpmPackageSucceededMarker = layout.buildDirectory.file("compose/tmp/packageRpm.succeeded")
+val windowsShellRegistrar = rootProject.layout.projectDirectory.file(
+    "target/x86_64-pc-windows-msvc/release/nextcloud-native-shell-registrar.exe",
+)
+val windowsShellIcon = project.layout.projectDirectory.file("src/desktopMain/resources/nextcloud-native.ico")
+
+val buildWindowsShellRegistrar by tasks.registering(Exec::class) {
+    group = "build"
+    description = "Builds the supported Windows Explorer sync-root registration helper."
+    inputs.file(rootProject.file("Cargo.toml"))
+    inputs.file(rootProject.file("Cargo.lock"))
+    inputs.file(rootProject.file("src/bin/nextcloud-native-shell-registrar.rs"))
+    outputs.file(windowsShellRegistrar)
+    onlyIf { System.getProperty("os.name").startsWith("Windows", ignoreCase = true) }
+    workingDir(rootProject.projectDir)
+    environment("RUSTFLAGS", "-Ctarget-feature=+crt-static")
+    commandLine(
+        "cargo",
+        "build",
+        "--locked",
+        "--release",
+        "--target",
+        "x86_64-pc-windows-msvc",
+        "--bin",
+        "nextcloud-native-shell-registrar",
+    )
+}
 
 val prepareLinuxAppStreamMetadata by tasks.registering(Exec::class) {
     inputs.file(linuxAppStreamMetadata)
@@ -257,7 +283,10 @@ val repackageRpmWithMetadata by tasks.registering(Exec::class) {
 }
 
 val repackageMsiWithUninstallCleanup by tasks.registering(Exec::class) {
+    dependsOn(buildWindowsShellRegistrar)
     inputs.file(rootProject.file("tools/repackage-msi-with-uninstall-cleanup.ps1"))
+    inputs.file(windowsShellRegistrar)
+    inputs.file(windowsShellIcon)
     doNotTrackState("Rebuilds the packageMsi artifact with an uninstall cleanup action.")
     onlyIf {
         System.getProperty("os.name").startsWith("Windows", ignoreCase = true) &&
@@ -280,6 +309,10 @@ val repackageMsiWithUninstallCleanup by tasks.registering(Exec::class) {
         layout.buildDirectory.dir("compose/binaries/main/app/NextcloudNative").get().asFile,
         "-Jpackage",
         File(System.getProperty("java.home"), "bin/jpackage.exe"),
+        "-ShellRegistrar",
+        windowsShellRegistrar.asFile,
+        "-ShellIcon",
+        windowsShellIcon.asFile,
     )
 }
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -53,6 +53,30 @@ val buildWindowsShellRegistrar by tasks.registering(Exec::class) {
     )
 }
 
+val stageWindowsShellAssets by tasks.registering {
+    group = "distribution"
+    description = "Adds the supported Windows Explorer integration to the desktop application image."
+    dependsOn(buildWindowsShellRegistrar)
+    inputs.file(windowsShellRegistrar)
+    inputs.file(windowsShellIcon)
+    val appImage = layout.buildDirectory.dir("compose/binaries/main/app/NextcloudNative")
+    val packagedRegistrar = appImage.map { it.file("NextcloudNativeShellRegistrar.exe") }
+    val packagedIcon = appImage.map { it.file("NextcloudNative.ico") }
+    outputs.files(packagedRegistrar, packagedIcon)
+    onlyIf { System.getProperty("os.name").startsWith("Windows", ignoreCase = true) }
+    doLast {
+        val image = appImage.get().asFile
+        check(image.resolve("NextcloudNative.exe").isFile) {
+            "The Windows application image is unavailable for shell asset staging."
+        }
+        windowsShellRegistrar.asFile.copyTo(packagedRegistrar.get().asFile, overwrite = true)
+        windowsShellIcon.asFile.copyTo(packagedIcon.get().asFile, overwrite = true)
+        check(packagedRegistrar.get().asFile.isFile && packagedIcon.get().asFile.isFile) {
+            "The Windows shell registration helper or icon was not added to the application image."
+        }
+    }
+}
+
 val prepareLinuxAppStreamMetadata by tasks.registering(Exec::class) {
     inputs.file(linuxAppStreamMetadata)
     inputs.file(rootProject.file("tools/render-linux-appstream-metadata.py"))
@@ -283,10 +307,8 @@ val repackageRpmWithMetadata by tasks.registering(Exec::class) {
 }
 
 val repackageMsiWithUninstallCleanup by tasks.registering(Exec::class) {
-    dependsOn(buildWindowsShellRegistrar)
+    dependsOn(stageWindowsShellAssets)
     inputs.file(rootProject.file("tools/repackage-msi-with-uninstall-cleanup.ps1"))
-    inputs.file(windowsShellRegistrar)
-    inputs.file(windowsShellIcon)
     doNotTrackState("Rebuilds the packageMsi artifact with an uninstall cleanup action.")
     onlyIf {
         System.getProperty("os.name").startsWith("Windows", ignoreCase = true) &&
@@ -309,10 +331,6 @@ val repackageMsiWithUninstallCleanup by tasks.registering(Exec::class) {
         layout.buildDirectory.dir("compose/binaries/main/app/NextcloudNative").get().asFile,
         "-Jpackage",
         File(System.getProperty("java.home"), "bin/jpackage.exe"),
-        "-ShellRegistrar",
-        windowsShellRegistrar.asFile,
-        "-ShellIcon",
-        windowsShellIcon.asFile,
     )
 }
 
@@ -332,8 +350,12 @@ tasks.matching { task -> task.name in setOf("packageDeb", "packageRpm") }.config
 }
 
 tasks.matching { task -> task.name == "packageMsi" }.configureEach {
-    dependsOn("createDistributable")
+    dependsOn("createDistributable", stageWindowsShellAssets)
     finalizedBy(repackageMsiWithUninstallCleanup)
+}
+
+tasks.matching { task -> task.name == "createDistributable" }.configureEach {
+    finalizedBy(stageWindowsShellAssets)
 }
 
 val desktopCaptureCompilation = kotlin.targets

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -18,7 +18,9 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 
 /** 64-bit Windows CldApi.dll binding kept behind [WindowsCloudFilesApi] for deterministic tests. */
-internal class JnaWindowsCloudFilesApi : WindowsCloudFilesApi {
+internal class JnaWindowsCloudFilesApi(
+    private val shellRegistrar: WindowsCloudShellRegistrar = PackagedWindowsCloudShellRegistrar(),
+) : WindowsCloudFilesApi {
     private val cldApi: CldApi
     private val kernelFiles: KernelFileApi
     private val callbacksByConnection = ConcurrentHashMap<Long, CallbackLifetime>()
@@ -33,46 +35,72 @@ internal class JnaWindowsCloudFilesApi : WindowsCloudFilesApi {
     }
 
     override fun registerSyncRoot(root: Path, syncRootIdentity: ByteArray) {
-        val identity = syncRootIdentity.nativeMemory()
-        val registration = CfSyncRegistration().apply {
-            structSize = size()
-            providerName = WString("Nextcloud Native")
-            providerVersion = WString("0.1.0")
-            syncRootIdentityPointer = identity
-            syncRootIdentityLength = syncRootIdentity.size
-            fileIdentity = identity
-            fileIdentityLength = syncRootIdentity.size
-            providerId = Guid.GUID("{6D456713-7D9A-4A39-90CE-127998DE42D7}")
-            write()
-        }
-        val policies = CfSyncPolicies().apply {
-            structSize = size()
-            hydration = CfPolicy(CF_HYDRATION_POLICY_PROGRESSIVE, CF_HYDRATION_POLICY_MODIFIER_AUTO_DEHYDRATION_ALLOWED)
-            population = CfPolicy(CF_POPULATION_POLICY_FULL, 0)
-            inSync = CF_INSYNC_POLICY_TRACK_FILE_CREATION_TIME or
-                CF_INSYNC_POLICY_TRACK_FILE_LAST_WRITE_TIME or
-                CF_INSYNC_POLICY_TRACK_DIRECTORY_CREATION_TIME or
-                CF_INSYNC_POLICY_TRACK_DIRECTORY_LAST_WRITE_TIME
-            hardLink = CF_HARDLINK_POLICY_NONE
-            placeholderManagement = CF_PLACEHOLDER_MANAGEMENT_POLICY_DEFAULT
-            write()
-        }
-        checkHResult(
-            cldApi.CfRegisterSyncRoot(
-                WString(root.toAbsolutePath().toString()),
-                registration,
-                policies,
-                CF_REGISTER_FLAG_UPDATE or CF_REGISTER_FLAG_MARK_IN_SYNC_ON_ROOT,
-            ),
-            "register the Windows Cloud Files root",
+        val rootIdentity = WindowsCloudFileIdentityCodec.decode(syncRootIdentity)
+        require(rootIdentity.directory && rootIdentity.path.isEmpty() && rootIdentity.remoteRevision == "root")
+        migrateWindowsSyncRootRegistration(
+            shellAvailable = shellRegistrar.available,
+            unregisterCloudFilesRoot = { unregisterCloudFilesRoot(root) },
+            registerBrandedShellRoot = {
+                shellRegistrar.register(root, rootIdentity.accountId, syncRootIdentity)
+            },
+            registerCloudFilesRoot = { registerCloudFilesRoot(root, syncRootIdentity) },
         )
-        identity.clear()
+    }
+
+    private fun registerCloudFilesRoot(root: Path, syncRootIdentity: ByteArray) {
+        val identity = syncRootIdentity.nativeMemory()
+        try {
+            val registration = CfSyncRegistration().apply {
+                structSize = size()
+                providerName = WString("Nextcloud Native")
+                providerVersion = WString("0.1.0")
+                syncRootIdentityPointer = identity
+                syncRootIdentityLength = syncRootIdentity.size
+                fileIdentity = identity
+                fileIdentityLength = syncRootIdentity.size
+                providerId = Guid.GUID("{6D456713-7D9A-4A39-90CE-127998DE42D7}")
+                write()
+            }
+            val policies = CfSyncPolicies().apply {
+                structSize = size()
+                hydration = CfPolicy(
+                    CF_HYDRATION_POLICY_PROGRESSIVE,
+                    CF_HYDRATION_POLICY_MODIFIER_AUTO_DEHYDRATION_ALLOWED,
+                )
+                population = CfPolicy(CF_POPULATION_POLICY_FULL, 0)
+                inSync = CF_INSYNC_POLICY_TRACK_FILE_CREATION_TIME or
+                    CF_INSYNC_POLICY_TRACK_FILE_LAST_WRITE_TIME or
+                    CF_INSYNC_POLICY_TRACK_DIRECTORY_CREATION_TIME or
+                    CF_INSYNC_POLICY_TRACK_DIRECTORY_LAST_WRITE_TIME
+                hardLink = CF_HARDLINK_POLICY_NONE
+                placeholderManagement = CF_PLACEHOLDER_MANAGEMENT_POLICY_DEFAULT
+                write()
+            }
+            checkHResult(
+                cldApi.CfRegisterSyncRoot(
+                    WString(root.toAbsolutePath().toString()),
+                    registration,
+                    policies,
+                    CF_REGISTER_FLAG_UPDATE or CF_REGISTER_FLAG_MARK_IN_SYNC_ON_ROOT,
+                ),
+                "register the Windows Cloud Files root",
+            )
+        } finally {
+            identity.clear()
+        }
     }
 
     override fun unregisterSyncRoot(root: Path) {
+        val accountId = windowsCloudShellAccountId(root)
+        if (accountId != null && shellRegistrar.available && shellRegistrar.unregister(accountId)) return
         val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
         if (result in SYNC_ROOT_ALREADY_UNREGISTERED_RESULTS) return
         checkHResult(result, "unregister the Windows Cloud Files root")
+    }
+
+    private fun unregisterCloudFilesRoot(root: Path): Boolean {
+        val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
+        return result >= 0 || result in SYNC_ROOT_ALREADY_UNREGISTERED_RESULTS
     }
 
     override fun connect(root: Path, callbacks: WindowsCloudFilesCallbacks): Long {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -34,25 +34,25 @@ internal class JnaWindowsCloudFilesApi(
         kernelFiles = Native.load("kernel32", KernelFileApi::class.java)
     }
 
-    override fun registerSyncRoot(root: Path, syncRootIdentity: ByteArray) {
+    override fun registerSyncRoot(root: Path, displayName: String, syncRootIdentity: ByteArray) {
         val rootIdentity = WindowsCloudFileIdentityCodec.decode(syncRootIdentity)
         require(rootIdentity.directory && rootIdentity.path.isEmpty() && rootIdentity.remoteRevision == "root")
         migrateWindowsSyncRootRegistration(
             shellAvailable = shellRegistrar.available,
             unregisterCloudFilesRoot = { unregisterCloudFilesRoot(root) },
             registerBrandedShellRoot = {
-                shellRegistrar.register(root, rootIdentity.accountId, syncRootIdentity)
+                shellRegistrar.register(root, rootIdentity.accountId, displayName, syncRootIdentity)
             },
-            registerCloudFilesRoot = { registerCloudFilesRoot(root, syncRootIdentity) },
+            registerCloudFilesRoot = { registerCloudFilesRoot(root, displayName, syncRootIdentity) },
         )
     }
 
-    private fun registerCloudFilesRoot(root: Path, syncRootIdentity: ByteArray) {
+    private fun registerCloudFilesRoot(root: Path, displayName: String, syncRootIdentity: ByteArray) {
         val identity = syncRootIdentity.nativeMemory()
         try {
             val registration = CfSyncRegistration().apply {
                 structSize = size()
-                providerName = WString("Nextcloud Native")
+                providerName = WString(displayName)
                 providerVersion = WString("0.1.0")
                 syncRootIdentityPointer = identity
                 syncRootIdentityLength = syncRootIdentity.size
@@ -92,7 +92,7 @@ internal class JnaWindowsCloudFilesApi(
 
     override fun unregisterSyncRoot(root: Path) {
         val accountId = windowsCloudShellAccountId(root)
-        if (accountId != null && shellRegistrar.available && shellRegistrar.unregister(accountId)) return
+        if (accountId != null && shellRegistrar.available && shellRegistrar.unregister(root, accountId)) return
         val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
         if (result in SYNC_ROOT_ALREADY_UNREGISTERED_RESULTS) return
         checkHResult(result, "unregister the Windows Cloud Files root")

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -202,7 +202,7 @@ internal enum class WindowsCloudPlaceholderState {
 }
 
 internal interface WindowsCloudFilesApi : AutoCloseable {
-    fun registerSyncRoot(root: Path, syncRootIdentity: ByteArray)
+    fun registerSyncRoot(root: Path, displayName: String, syncRootIdentity: ByteArray)
     fun unregisterSyncRoot(root: Path)
     fun connect(root: Path, callbacks: WindowsCloudFilesCallbacks): Long
     fun disconnect(connectionKey: Long)
@@ -247,6 +247,7 @@ internal data class WindowsCloudFilesSummary(
 
 internal interface WindowsCloudFilesBackend {
     val accountId: String
+    val displayName: String
     fun resolve(path: String): WindowsCloudFileIdentity?
     fun list(path: String): List<WindowsCloudFileIdentity>
     fun open(identity: WindowsCloudFileIdentity): WindowsCloudFileReadHandle
@@ -263,6 +264,7 @@ internal class DesktopNextcloudWindowsCloudFilesBackend(
     private val tree: DesktopFileSyncRemoteTree = DesktopFileSyncRemoteTree(session, userId, ""),
 ) : WindowsCloudFilesBackend {
     override val accountId: String = desktopFileCacheAccountId(session)
+    override val displayName: String = windowsCloudShellDisplayName(session)
 
     override fun resolve(path: String): WindowsCloudFileIdentity? =
         tree.resolve(path.windowsCloudPath())?.toWindowsIdentity()
@@ -364,7 +366,7 @@ internal class WindowsCloudFilesProvider(
         Files.createDirectories(root)
         check(!Files.isSymbolicLink(root)) { "The Windows Cloud Files root cannot be a symlink." }
         val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
-        api.registerSyncRoot(root, WindowsCloudFileIdentityCodec.encode(rootIdentity))
+        api.registerSyncRoot(root, backend.displayName, WindowsCloudFileIdentityCodec.encode(rootIdentity))
         connection.set(api.connect(root, this))
         try {
             populateDirectory("", root)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
@@ -139,6 +139,8 @@ private fun requireWindowsShellDisplayName(displayName: String) {
 }
 
 internal fun windowsCloudShellDisplayName(session: NextcloudSession): String {
+    val accountId = desktopFileCacheAccountId(session)
+    requireWindowsShellAccountId(accountId)
     val login = session.loginName.windowsShellLabelPart(WINDOWS_SHELL_ACCOUNT_LABEL_PART_MAX_CHARACTERS)
     val host = runCatching { URI(session.serverUrl).host.orEmpty() }
         .getOrDefault("")
@@ -150,7 +152,7 @@ internal fun windowsCloudShellDisplayName(session: NextcloudSession): String {
         host.isNotEmpty() -> host
         else -> "account"
     }
-    return "Nextcloud Native - $accountLabel"
+    return "Nextcloud Native - $accountLabel [${accountId.take(WINDOWS_SHELL_ACCOUNT_TAG_CHARACTERS)}]"
 }
 
 private fun String.windowsShellLabelPart(maxCharacters: Int): String =
@@ -191,10 +193,38 @@ private fun runWindowsShellRegistrar(command: List<String>, timeoutSeconds: Long
         .redirectOutput(ProcessBuilder.Redirect.DISCARD)
         .redirectError(ProcessBuilder.Redirect.DISCARD)
         .start()
-    if (process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) return process.exitValue()
-    process.destroy()
-    if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
+    val completed = try {
+        process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+    } catch (_: InterruptedException) {
+        terminateWindowsShellRegistrar(process)
+        Thread.currentThread().interrupt()
+        return null
+    }
+    if (completed) return process.exitValue()
+    terminateWindowsShellRegistrar(process)
     return null
+}
+
+internal fun terminateWindowsShellRegistrar(process: Process) {
+    var interrupted = false
+    runCatching { process.destroy() }
+    val exitedDuringGrace = try {
+        process.waitFor(WINDOWS_SHELL_TERMINATION_GRACE_SECONDS, TimeUnit.SECONDS)
+    } catch (_: InterruptedException) {
+        interrupted = true
+        false
+    }
+    if (!exitedDuringGrace && process.isAlive) {
+        runCatching { process.destroyForcibly() }
+        while (process.isAlive) {
+            try {
+                process.waitFor()
+            } catch (_: InterruptedException) {
+                interrupted = true
+            }
+        }
+    }
+    if (interrupted) Thread.currentThread().interrupt()
 }
 
 private const val WINDOWS_CLOUD_ROOT_GENERATION_SUFFIX = "-v2"
@@ -202,5 +232,7 @@ internal const val WINDOWS_SHELL_REGISTRAR_NAME = "NextcloudNativeShellRegistrar
 internal const val WINDOWS_SHELL_ICON_NAME = "NextcloudNative.ico"
 internal const val WINDOWS_SHELL_OWNED_PATH_CONFLICT_EXIT_CODE = 3
 private const val WINDOWS_SHELL_DISPLAY_NAME_MAX_CHARACTERS = 128
-private const val WINDOWS_SHELL_ACCOUNT_LABEL_PART_MAX_CHARACTERS = 48
+private const val WINDOWS_SHELL_ACCOUNT_LABEL_PART_MAX_CHARACTERS = 44
+private const val WINDOWS_SHELL_ACCOUNT_TAG_CHARACTERS = 12
+private const val WINDOWS_SHELL_TERMINATION_GRACE_SECONDS = 2L
 private const val HEX_DIGITS = "0123456789abcdef"

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
@@ -1,14 +1,26 @@
 package dev.obiente.nextcloudnative.app
 
 import java.io.File
+import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
 internal interface WindowsCloudShellRegistrar {
     val available: Boolean
-    fun register(root: Path, accountId: String, syncRootIdentity: ByteArray): Boolean
-    fun unregister(accountId: String): Boolean
+    fun register(
+        root: Path,
+        accountId: String,
+        displayName: String,
+        syncRootIdentity: ByteArray,
+    ): WindowsShellRegistrationResult
+    fun unregister(root: Path, accountId: String): Boolean
+}
+
+internal enum class WindowsShellRegistrationResult {
+    Registered,
+    OwnedPathConflict,
+    Failed,
 }
 
 internal class PackagedWindowsCloudShellRegistrar(
@@ -25,34 +37,47 @@ internal class PackagedWindowsCloudShellRegistrar(
     override val available: Boolean
         get() = helper?.isFile == true && icon?.isFile == true
 
-    override fun register(root: Path, accountId: String, syncRootIdentity: ByteArray): Boolean {
+    override fun register(
+        root: Path,
+        accountId: String,
+        displayName: String,
+        syncRootIdentity: ByteArray,
+    ): WindowsShellRegistrationResult {
         requireWindowsShellAccountId(accountId)
+        requireWindowsShellDisplayName(displayName)
         require(syncRootIdentity.isNotEmpty() && syncRootIdentity.size <= MAX_SYNC_ROOT_IDENTITY_BYTES)
         val normalizedRoot = root.toAbsolutePath().normalize()
         require(Files.isDirectory(normalizedRoot) && !Files.isSymbolicLink(normalizedRoot))
-        val executable = helper?.takeIf(File::isFile) ?: return false
-        val iconResource = icon?.takeIf(File::isFile) ?: return false
-        return runCatching {
+        val executable = helper?.takeIf(File::isFile) ?: return WindowsShellRegistrationResult.Failed
+        val iconResource = icon?.takeIf(File::isFile) ?: return WindowsShellRegistrationResult.Failed
+        val exitCode = runCatching {
             processRunner(
                 listOf(
                     executable.absolutePath,
                     "register",
                     normalizedRoot.toString(),
                     accountId,
+                    displayName,
                     iconResource.absolutePath,
                     syncRootIdentity.lowercaseHex(),
                 ),
                 REGISTRATION_TIMEOUT_SECONDS,
-            ) == 0
-        }.getOrDefault(false)
+            )
+        }.getOrNull()
+        return when (exitCode) {
+            0 -> WindowsShellRegistrationResult.Registered
+            WINDOWS_SHELL_OWNED_PATH_CONFLICT_EXIT_CODE -> WindowsShellRegistrationResult.OwnedPathConflict
+            else -> WindowsShellRegistrationResult.Failed
+        }
     }
 
-    override fun unregister(accountId: String): Boolean {
+    override fun unregister(root: Path, accountId: String): Boolean {
         requireWindowsShellAccountId(accountId)
+        val normalizedRoot = root.toAbsolutePath().normalize()
         val executable = helper?.takeIf(File::isFile) ?: return false
         return runCatching {
             processRunner(
-                listOf(executable.absolutePath, "unregister", accountId),
+                listOf(executable.absolutePath, "unregister", normalizedRoot.toString(), accountId),
                 REGISTRATION_TIMEOUT_SECONDS,
             ) == 0
         }.getOrDefault(false)
@@ -72,13 +97,23 @@ internal enum class WindowsSyncRootRegistrationMode {
 internal fun migrateWindowsSyncRootRegistration(
     shellAvailable: Boolean,
     unregisterCloudFilesRoot: () -> Boolean,
-    registerBrandedShellRoot: () -> Boolean,
+    registerBrandedShellRoot: () -> WindowsShellRegistrationResult,
     registerCloudFilesRoot: () -> Unit,
 ): WindowsSyncRootRegistrationMode {
     if (shellAvailable) {
-        if (registerBrandedShellRoot()) return WindowsSyncRootRegistrationMode.BrandedShell
-        if (unregisterCloudFilesRoot() && registerBrandedShellRoot()) {
-            return WindowsSyncRootRegistrationMode.BrandedShell
+        when (registerBrandedShellRoot()) {
+            WindowsShellRegistrationResult.Registered -> {
+                return WindowsSyncRootRegistrationMode.BrandedShell
+            }
+            WindowsShellRegistrationResult.OwnedPathConflict -> {
+                if (
+                    unregisterCloudFilesRoot() &&
+                    registerBrandedShellRoot() == WindowsShellRegistrationResult.Registered
+                ) {
+                    return WindowsSyncRootRegistrationMode.BrandedShell
+                }
+            }
+            WindowsShellRegistrationResult.Failed -> Unit
         }
     }
     registerCloudFilesRoot()
@@ -93,6 +128,49 @@ internal fun windowsCloudShellAccountId(root: Path): String? {
 
 private fun requireWindowsShellAccountId(accountId: String) {
     require(isWindowsShellAccountId(accountId))
+}
+
+private fun requireWindowsShellDisplayName(displayName: String) {
+    require(
+        displayName.isNotBlank() &&
+            displayName.length <= WINDOWS_SHELL_DISPLAY_NAME_MAX_CHARACTERS &&
+            displayName.none(Char::isISOControl),
+    )
+}
+
+internal fun windowsCloudShellDisplayName(session: NextcloudSession): String {
+    val login = session.loginName.windowsShellLabelPart(WINDOWS_SHELL_ACCOUNT_LABEL_PART_MAX_CHARACTERS)
+    val host = runCatching { URI(session.serverUrl).host.orEmpty() }
+        .getOrDefault("")
+        .lowercase()
+        .windowsShellLabelPart(WINDOWS_SHELL_ACCOUNT_LABEL_PART_MAX_CHARACTERS)
+    val accountLabel = when {
+        login.isNotEmpty() && host.isNotEmpty() -> "$login@$host"
+        login.isNotEmpty() -> login
+        host.isNotEmpty() -> host
+        else -> "account"
+    }
+    return "Nextcloud Native - $accountLabel"
+}
+
+private fun String.windowsShellLabelPart(maxCharacters: Int): String =
+    trim()
+        .filterNot(Char::isISOControl)
+        .replace(Regex("\\s+"), " ")
+        .takeWholeCodePoints(maxCharacters)
+
+private fun String.takeWholeCodePoints(maxCharacters: Int): String {
+    if (length <= maxCharacters) return this
+    val end = if (
+        maxCharacters > 0 &&
+        this[maxCharacters - 1].isHighSurrogate() &&
+        this[maxCharacters].isLowSurrogate()
+    ) {
+        maxCharacters - 1
+    } else {
+        maxCharacters
+    }
+    return substring(0, end)
 }
 
 private fun isWindowsShellAccountId(accountId: String): Boolean =
@@ -122,4 +200,7 @@ private fun runWindowsShellRegistrar(command: List<String>, timeoutSeconds: Long
 private const val WINDOWS_CLOUD_ROOT_GENERATION_SUFFIX = "-v2"
 internal const val WINDOWS_SHELL_REGISTRAR_NAME = "NextcloudNativeShellRegistrar.exe"
 internal const val WINDOWS_SHELL_ICON_NAME = "NextcloudNative.ico"
+internal const val WINDOWS_SHELL_OWNED_PATH_CONFLICT_EXIT_CODE = 3
+private const val WINDOWS_SHELL_DISPLAY_NAME_MAX_CHARACTERS = 128
+private const val WINDOWS_SHELL_ACCOUNT_LABEL_PART_MAX_CHARACTERS = 48
 private const val HEX_DIGITS = "0123456789abcdef"

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
@@ -1,0 +1,125 @@
+package dev.obiente.nextcloudnative.app
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+internal interface WindowsCloudShellRegistrar {
+    val available: Boolean
+    fun register(root: Path, accountId: String, syncRootIdentity: ByteArray): Boolean
+    fun unregister(accountId: String): Boolean
+}
+
+internal class PackagedWindowsCloudShellRegistrar(
+    launcherPath: String? = packagedDesktopLauncherPath(),
+    private val processRunner: (List<String>, Long) -> Int? = ::runWindowsShellRegistrar,
+) : WindowsCloudShellRegistrar {
+    private val installationDirectory = launcherPath
+        ?.takeIf(String::isNotBlank)
+        ?.let(::File)
+        ?.parentFile
+    private val helper = installationDirectory?.resolve(WINDOWS_SHELL_REGISTRAR_NAME)
+    private val icon = installationDirectory?.resolve(WINDOWS_SHELL_ICON_NAME)
+
+    override val available: Boolean
+        get() = helper?.isFile == true && icon?.isFile == true
+
+    override fun register(root: Path, accountId: String, syncRootIdentity: ByteArray): Boolean {
+        requireWindowsShellAccountId(accountId)
+        require(syncRootIdentity.isNotEmpty() && syncRootIdentity.size <= MAX_SYNC_ROOT_IDENTITY_BYTES)
+        val normalizedRoot = root.toAbsolutePath().normalize()
+        require(Files.isDirectory(normalizedRoot) && !Files.isSymbolicLink(normalizedRoot))
+        val executable = helper?.takeIf(File::isFile) ?: return false
+        val iconResource = icon?.takeIf(File::isFile) ?: return false
+        return runCatching {
+            processRunner(
+                listOf(
+                    executable.absolutePath,
+                    "register",
+                    normalizedRoot.toString(),
+                    accountId,
+                    iconResource.absolutePath,
+                    syncRootIdentity.lowercaseHex(),
+                ),
+                REGISTRATION_TIMEOUT_SECONDS,
+            ) == 0
+        }.getOrDefault(false)
+    }
+
+    override fun unregister(accountId: String): Boolean {
+        requireWindowsShellAccountId(accountId)
+        val executable = helper?.takeIf(File::isFile) ?: return false
+        return runCatching {
+            processRunner(
+                listOf(executable.absolutePath, "unregister", accountId),
+                REGISTRATION_TIMEOUT_SECONDS,
+            ) == 0
+        }.getOrDefault(false)
+    }
+
+    private companion object {
+        const val MAX_SYNC_ROOT_IDENTITY_BYTES = 4_096
+        const val REGISTRATION_TIMEOUT_SECONDS = 30L
+    }
+}
+
+internal enum class WindowsSyncRootRegistrationMode {
+    BrandedShell,
+    CloudFilesOnly,
+}
+
+internal fun migrateWindowsSyncRootRegistration(
+    shellAvailable: Boolean,
+    unregisterCloudFilesRoot: () -> Boolean,
+    registerBrandedShellRoot: () -> Boolean,
+    registerCloudFilesRoot: () -> Unit,
+): WindowsSyncRootRegistrationMode {
+    if (shellAvailable) {
+        if (registerBrandedShellRoot()) return WindowsSyncRootRegistrationMode.BrandedShell
+        if (unregisterCloudFilesRoot() && registerBrandedShellRoot()) {
+            return WindowsSyncRootRegistrationMode.BrandedShell
+        }
+    }
+    registerCloudFilesRoot()
+    return WindowsSyncRootRegistrationMode.CloudFilesOnly
+}
+
+internal fun windowsCloudShellAccountId(root: Path): String? {
+    val name = root.fileName?.toString() ?: return null
+    val accountId = name.removeSuffix(WINDOWS_CLOUD_ROOT_GENERATION_SUFFIX)
+    return accountId.takeIf(::isWindowsShellAccountId)
+}
+
+private fun requireWindowsShellAccountId(accountId: String) {
+    require(isWindowsShellAccountId(accountId))
+}
+
+private fun isWindowsShellAccountId(accountId: String): Boolean =
+    accountId.length == 64 && accountId.all { it in '0'..'9' || it in 'a'..'f' }
+
+private fun ByteArray.lowercaseHex(): String {
+    val output = CharArray(size * 2)
+    forEachIndexed { index, byte ->
+        val value = byte.toInt() and 0xff
+        output[index * 2] = HEX_DIGITS[value ushr 4]
+        output[index * 2 + 1] = HEX_DIGITS[value and 0x0f]
+    }
+    return output.concatToString()
+}
+
+private fun runWindowsShellRegistrar(command: List<String>, timeoutSeconds: Long): Int? {
+    val process = ProcessBuilder(command)
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
+        .start()
+    if (process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) return process.exitValue()
+    process.destroy()
+    if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
+    return null
+}
+
+private const val WINDOWS_CLOUD_ROOT_GENERATION_SUFFIX = "-v2"
+internal const val WINDOWS_SHELL_REGISTRAR_NAME = "NextcloudNativeShellRegistrar.exe"
+internal const val WINDOWS_SHELL_ICON_NAME = "NextcloudNative.ico"
+private const val HEX_DIGITS = "0123456789abcdef"

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -691,6 +691,7 @@ class WindowsCloudFilesProviderTest {
         @Volatile var uploadFailuresRemaining: Int = 0,
     ) : WindowsCloudFilesBackend {
         override val accountId: String = "account-01"
+        override val displayName: String = "Nextcloud Native - account@example.test"
         private val uploadLatch = CountDownLatch(expectedUploads)
         private val firstUploadStarted = CountDownLatch(if (blockFirstUpload) 1 else 0)
         private val firstUploadRelease = CountDownLatch(if (blockFirstUpload) 1 else 0)
@@ -796,7 +797,7 @@ class WindowsCloudFilesProviderTest {
         var closed = false
         val lifecycleEvents = mutableListOf<String>()
 
-        override fun registerSyncRoot(root: Path, syncRootIdentity: ByteArray) {
+        override fun registerSyncRoot(root: Path, displayName: String, syncRootIdentity: ByteArray) {
             lifecycleEvents += "register"
         }
         override fun unregisterSyncRoot(root: Path) {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
@@ -1,11 +1,15 @@
 package dev.obiente.nextcloudnative.app
 
 import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 class WindowsCloudShellRegistrarTest {
@@ -159,16 +163,77 @@ class WindowsCloudShellRegistrarTest {
 
     @Test
     fun createsBoundedAccountSpecificDisplayNamesWithoutSecrets() {
-        val first = windowsCloudShellDisplayName(
-            NextcloudSession("https://cloud.example/nextcloud", "ada", "secret-one"),
-        )
-        val second = windowsCloudShellDisplayName(
-            NextcloudSession("https://cloud.example/nextcloud", "grace", "secret-two"),
-        )
+        val firstSession = NextcloudSession("https://cloud.example/nextcloud", "ada", "secret-one")
+        val secondSession = NextcloudSession("https://cloud.example/nextcloud", "grace", "secret-two")
+        val first = windowsCloudShellDisplayName(firstSession)
+        val second = windowsCloudShellDisplayName(secondSession)
 
-        assertEquals("Nextcloud Native - ada@cloud.example", first)
-        assertEquals("Nextcloud Native - grace@cloud.example", second)
+        assertEquals(
+            "Nextcloud Native - ada@cloud.example [${desktopFileCacheAccountId(firstSession).take(12)}]",
+            first,
+        )
+        assertEquals(
+            "Nextcloud Native - grace@cloud.example [${desktopFileCacheAccountId(secondSession).take(12)}]",
+            second,
+        )
         assertFalse(first.contains("secret"))
         assertTrue(first.length <= 128)
+    }
+
+    @Test
+    fun distinguishesServersThatShareAHostAndLogin() {
+        val first = windowsCloudShellDisplayName(
+            NextcloudSession("https://cloud.example:8443/one", "ada", "secret-one"),
+        )
+        val second = windowsCloudShellDisplayName(
+            NextcloudSession("https://cloud.example:9443/two", "ada", "secret-two"),
+        )
+
+        assertTrue(first.startsWith("Nextcloud Native - ada@cloud.example ["))
+        assertTrue(second.startsWith("Nextcloud Native - ada@cloud.example ["))
+        assertNotEquals(first, second)
+        assertFalse(first.contains("secret"))
+        assertFalse(second.contains("secret"))
+    }
+
+    @Test
+    fun waitsForForcedRegistrarTerminationBeforeReturning() {
+        val process = StubbornRegistrarProcess()
+
+        terminateWindowsShellRegistrar(process)
+
+        assertTrue(process.destroyCalled)
+        assertTrue(process.destroyForciblyCalled)
+        assertTrue(process.waitedForForcedExit)
+        assertFalse(process.isAlive)
+    }
+
+    private class StubbornRegistrarProcess : Process() {
+        var destroyCalled = false
+        var destroyForciblyCalled = false
+        var waitedForForcedExit = false
+        private var alive = true
+
+        override fun getOutputStream(): OutputStream = OutputStream.nullOutputStream()
+        override fun getInputStream(): InputStream = InputStream.nullInputStream()
+        override fun getErrorStream(): InputStream = InputStream.nullInputStream()
+        override fun waitFor(): Int {
+            waitedForForcedExit = true
+            alive = false
+            return 137
+        }
+        override fun waitFor(timeout: Long, unit: TimeUnit): Boolean = false
+        override fun exitValue(): Int {
+            check(!alive)
+            return 137
+        }
+        override fun destroy() {
+            destroyCalled = true
+        }
+        override fun destroyForcibly(): Process {
+            destroyForciblyCalled = true
+            return this
+        }
+        override fun isAlive(): Boolean = alive
     }
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
@@ -1,0 +1,92 @@
+package dev.obiente.nextcloudnative.app
+
+import java.io.File
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WindowsCloudShellRegistrarTest {
+    @Test
+    fun passesPathsAndIdentityAsSeparateArguments() {
+        val installation = createTempDirectory("nextcloud-shell-install").toFile()
+        val launcher = installation.resolve("NextcloudNative.exe").apply { writeText("launcher") }
+        installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).writeText("helper")
+        val icon = installation.resolve(WINDOWS_SHELL_ICON_NAME).apply { writeText("icon") }
+        val root = installation.resolve("Cloud root; still one argument").toPath().createDirectories()
+        val accountId = "a5".repeat(32)
+        var invocation = emptyList<String>()
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { command, timeout ->
+            invocation = command
+            assertEquals(30L, timeout)
+            0
+        }
+
+        assertTrue(registrar.available)
+        assertTrue(registrar.register(root, accountId, byteArrayOf(0, 15, -1)))
+        assertEquals(
+            listOf(
+                installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).absolutePath,
+                "register",
+                root.toAbsolutePath().normalize().toString(),
+                accountId,
+                icon.absolutePath,
+                "000fff",
+            ),
+            invocation,
+        )
+    }
+
+    @Test
+    fun missingPackagedFilesDoNotAttemptRegistration() {
+        val installation = createTempDirectory("nextcloud-shell-missing").toFile()
+        val launcher = installation.resolve("NextcloudNative.exe").apply { writeText("launcher") }
+        var invoked = false
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { _, _ ->
+            invoked = true
+            0
+        }
+
+        assertFalse(registrar.available)
+        assertFalse(registrar.unregister("a5".repeat(32)))
+        assertFalse(invoked)
+    }
+
+    @Test
+    fun failedShellRegistrationRestoresCloudFilesRegistration() {
+        val events = mutableListOf<String>()
+        val mode = migrateWindowsSyncRootRegistration(
+            shellAvailable = true,
+            unregisterCloudFilesRoot = { events += "unregister"; true },
+            registerBrandedShellRoot = { events += "shell"; false },
+            registerCloudFilesRoot = { events += "fallback" },
+        )
+
+        assertEquals(WindowsSyncRootRegistrationMode.CloudFilesOnly, mode)
+        assertEquals(listOf("shell", "unregister", "shell", "fallback"), events)
+    }
+
+    @Test
+    fun successfulShellRegistrationDoesNotCreateASecondRegistration() {
+        val events = mutableListOf<String>()
+        val mode = migrateWindowsSyncRootRegistration(
+            shellAvailable = true,
+            unregisterCloudFilesRoot = { events += "unregister"; true },
+            registerBrandedShellRoot = { events += "shell"; true },
+            registerCloudFilesRoot = { events += "fallback" },
+        )
+
+        assertEquals(WindowsSyncRootRegistrationMode.BrandedShell, mode)
+        assertEquals(listOf("shell"), events)
+    }
+
+    @Test
+    fun recognizesCurrentAndLegacyAccountRootNames() {
+        val accountId = "01".repeat(32)
+        assertEquals(accountId, windowsCloudShellAccountId(File("C:/root/$accountId-v2").toPath()))
+        assertEquals(accountId, windowsCloudShellAccountId(File("C:/root/$accountId").toPath()))
+        assertEquals(null, windowsCloudShellAccountId(File("C:/root/not-an-account").toPath()))
+    }
+}

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
@@ -25,13 +25,22 @@ class WindowsCloudShellRegistrarTest {
         }
 
         assertTrue(registrar.available)
-        assertTrue(registrar.register(root, accountId, byteArrayOf(0, 15, -1)))
+        assertEquals(
+            WindowsShellRegistrationResult.Registered,
+            registrar.register(
+                root,
+                accountId,
+                "Nextcloud Native - ada@cloud.example",
+                byteArrayOf(0, 15, -1),
+            ),
+        )
         assertEquals(
             listOf(
                 installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).absolutePath,
                 "register",
                 root.toAbsolutePath().normalize().toString(),
                 accountId,
+                "Nextcloud Native - ada@cloud.example",
                 icon.absolutePath,
                 "000fff",
             ),
@@ -50,17 +59,72 @@ class WindowsCloudShellRegistrarTest {
         }
 
         assertFalse(registrar.available)
-        assertFalse(registrar.unregister("a5".repeat(32)))
+        assertFalse(registrar.unregister(installation.toPath(), "a5".repeat(32)))
         assertFalse(invoked)
     }
 
     @Test
-    fun failedShellRegistrationRestoresCloudFilesRegistration() {
+    fun classifiesOwnedPathConflictsAndPassesTheExactRootToCleanup() {
+        val installation = createTempDirectory("nextcloud-shell-conflict").toFile()
+        val launcher = installation.resolve("NextcloudNative.exe").apply { writeText("launcher") }
+        installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).writeText("helper")
+        installation.resolve(WINDOWS_SHELL_ICON_NAME).writeText("icon")
+        val root = installation.resolve("Cloud root").toPath().createDirectories()
+        val accountId = "b6".repeat(32)
+        val invocations = mutableListOf<List<String>>()
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { command, _ ->
+            invocations += command
+            if (command[1] == "register") WINDOWS_SHELL_OWNED_PATH_CONFLICT_EXIT_CODE else 0
+        }
+
+        assertEquals(
+            WindowsShellRegistrationResult.OwnedPathConflict,
+            registrar.register(root, accountId, "Nextcloud Native - ada@cloud.example", byteArrayOf(1)),
+        )
+        assertTrue(registrar.unregister(root, accountId))
+        assertEquals(
+            listOf(
+                installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).absolutePath,
+                "unregister",
+                root.toAbsolutePath().normalize().toString(),
+                accountId,
+            ),
+            invocations.last(),
+        )
+    }
+
+    @Test
+    fun arbitraryShellFailurePreservesTheExistingCloudFilesRegistration() {
         val events = mutableListOf<String>()
         val mode = migrateWindowsSyncRootRegistration(
             shellAvailable = true,
             unregisterCloudFilesRoot = { events += "unregister"; true },
-            registerBrandedShellRoot = { events += "shell"; false },
+            registerBrandedShellRoot = {
+                events += "shell"
+                WindowsShellRegistrationResult.Failed
+            },
+            registerCloudFilesRoot = { events += "fallback" },
+        )
+
+        assertEquals(WindowsSyncRootRegistrationMode.CloudFilesOnly, mode)
+        assertEquals(listOf("shell", "fallback"), events)
+    }
+
+    @Test
+    fun ownedPathConflictMigratesAndRestoresFallbackOnRetryFailure() {
+        val events = mutableListOf<String>()
+        var attempts = 0
+        val mode = migrateWindowsSyncRootRegistration(
+            shellAvailable = true,
+            unregisterCloudFilesRoot = { events += "unregister"; true },
+            registerBrandedShellRoot = {
+                events += "shell"
+                if (attempts++ == 0) {
+                    WindowsShellRegistrationResult.OwnedPathConflict
+                } else {
+                    WindowsShellRegistrationResult.Failed
+                }
+            },
             registerCloudFilesRoot = { events += "fallback" },
         )
 
@@ -74,7 +138,10 @@ class WindowsCloudShellRegistrarTest {
         val mode = migrateWindowsSyncRootRegistration(
             shellAvailable = true,
             unregisterCloudFilesRoot = { events += "unregister"; true },
-            registerBrandedShellRoot = { events += "shell"; true },
+            registerBrandedShellRoot = {
+                events += "shell"
+                WindowsShellRegistrationResult.Registered
+            },
             registerCloudFilesRoot = { events += "fallback" },
         )
 
@@ -88,5 +155,20 @@ class WindowsCloudShellRegistrarTest {
         assertEquals(accountId, windowsCloudShellAccountId(File("C:/root/$accountId-v2").toPath()))
         assertEquals(accountId, windowsCloudShellAccountId(File("C:/root/$accountId").toPath()))
         assertEquals(null, windowsCloudShellAccountId(File("C:/root/not-an-account").toPath()))
+    }
+
+    @Test
+    fun createsBoundedAccountSpecificDisplayNamesWithoutSecrets() {
+        val first = windowsCloudShellDisplayName(
+            NextcloudSession("https://cloud.example/nextcloud", "ada", "secret-one"),
+        )
+        val second = windowsCloudShellDisplayName(
+            NextcloudSession("https://cloud.example/nextcloud", "grace", "secret-two"),
+        )
+
+        assertEquals("Nextcloud Native - ada@cloud.example", first)
+        assertEquals("Nextcloud Native - grace@cloud.example", second)
+        assertFalse(first.contains("secret"))
+        assertTrue(first.length <= 128)
     }
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -221,7 +221,7 @@ class WindowsUninstallCleanupTest {
             closed = true
         }
 
-        override fun registerSyncRoot(root: Path, syncRootIdentity: ByteArray) = unsupported()
+        override fun registerSyncRoot(root: Path, displayName: String, syncRootIdentity: ByteArray) = unsupported()
         override fun connect(root: Path, callbacks: WindowsCloudFilesCallbacks): Long = unsupported()
         override fun disconnect(connectionKey: Long) = unsupported()
         override fun createPlaceholders(baseDirectory: Path, placeholders: List<WindowsCloudPlaceholder>) = unsupported()

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -228,7 +228,7 @@
         "gradle/wrapper/gradle-wrapper.properties": "aef287d114ce3153c3d535697a61928f5034990d570cbb2e93df549e9671483d",
         "settings.gradle.kts": "0acbe4b907815189abfedb2256c8659558e5a7e6995a3681a2bdfb05e335fd1a",
         "tools/marketing-capture-inputs.txt": "3c96e83e1ba2d715b1cda9cedf036fc97b78c3ca63b7fc930325ed536940c1f3",
-        "ui/build.gradle.kts": "af1e0142bfccbf276d6ae7d9f96ec7085e5775ff7471980be1a28c3224acc573",
+        "ui/build.gradle.kts": "7c6ffb1db937fc9a352e3215c09109524d0df7631a6dde15a0f8c9250d58706e",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ActivitySemantics.kt": "fa9a949fdfd07c8f5b7388f10dd6cf21454fdbb165390c7ca5f6a27f4de07c85",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AdminAppManagement.kt": "b11fbc2c93ab17a20f123c8bde25a993c612ffb1b1525329a7e341952fefbf7d",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannels.kt": "2ad7975a0c311c7b5977581b4c63dcc105cfed59840b871cf9f7bead9881bf05",

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -228,7 +228,7 @@
         "gradle/wrapper/gradle-wrapper.properties": "aef287d114ce3153c3d535697a61928f5034990d570cbb2e93df549e9671483d",
         "settings.gradle.kts": "0acbe4b907815189abfedb2256c8659558e5a7e6995a3681a2bdfb05e335fd1a",
         "tools/marketing-capture-inputs.txt": "3c96e83e1ba2d715b1cda9cedf036fc97b78c3ca63b7fc930325ed536940c1f3",
-        "ui/build.gradle.kts": "7c6ffb1db937fc9a352e3215c09109524d0df7631a6dde15a0f8c9250d58706e",
+        "ui/build.gradle.kts": "8cb33c7710eec8a1a7be1c3a9f814f9e739d6a0fc832c8da401b8cccdfebedca",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ActivitySemantics.kt": "fa9a949fdfd07c8f5b7388f10dd6cf21454fdbb165390c7ca5f6a27f4de07c85",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AdminAppManagement.kt": "b11fbc2c93ab17a20f123c8bde25a993c612ffb1b1525329a7e341952fefbf7d",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannels.kt": "2ad7975a0c311c7b5977581b4c63dcc105cfed59840b871cf9f7bead9881bf05",


### PR DESCRIPTION
## Summary

- register Windows Cloud Files roots through the supported StorageProviderSyncRootManager API so File Explorer shows Nextcloud Native branding
- give concurrent account roots bounded labels containing the signed-in login, server host, and a short non-secret account tag so server ports and paths cannot collapse to the same label
- stage NextcloudNative.ico and the Windows-only Rust registrar in the completed `createDistributable` application image, then have MSI packaging consume that same image
- preserve raw Cloud Files registration as a safe fallback, perform migration teardown only after proving an exact-path conflict belongs to the Nextcloud Native provider, and await timed-out helper termination before fallback
- verify the exact root path before shell cleanup so legacy cleanup cannot detach the current account root
- verify the registrar and icon in the MSI, with the Rust Windows target available in CI, nightly, and prerelease packaging
- fall back to full Linux, Android, Rust, and Windows validation when GitHub cannot provide pull request diff metadata

## Safety

- expose only a short non-secret account tag in File Explorer and keep the full account hash internal
- pass no app password or other credential to the shell registrar
- place no desktop.ini, icon, or shortcut artifacts inside the synchronized namespace
- pass registrar arguments directly without shell parsing
- do not force user-owned File Explorer or Quick Access pins
- never start fallback registration until a timed-out shell registrar has exited

## Validation

- `cargo test --locked`
- `cargo check --locked --target x86_64-pc-windows-msvc --bin nextcloud-native-shell-registrar`
- `./gradlew --no-daemon --max-workers=2 :ui:desktopTest :ui:createDistributable`
- `bash tools/test-marketing-capture-workflow.sh`
- `bash tools/test-nightly-release-workflow.sh`
- `bash tools/check-repository.sh`

Exact-head Windows application-image staging, MSI construction, MSI File-table verification, and integration validation run in Windows CI.

Closes #290
Closes #294

Stacked on #291.
