### PR TITLE
fix(windows): recover stale Cloud Files state

### DIFF
--- a/changes/unreleased/296-windows-cloud-files-cleanup.md
+++ b/changes/unreleased/296-windows-cloud-files-cleanup.md
@@ -1,7 +1,7 @@
 category: fix
 issue: 296
-pull: none
+pull: 297
 platforms: windows
 user-facing: yes
 
-Windows Cloud Files can reconnect, disconnect, migrate, and uninstall cleanly when an obsolete provider root is already missing.
+Windows Cloud Files now repairs stale owned registrations, retries a missing provider connection once, and cleans up safely when a provider root or connection is already absent.

--- a/changes/unreleased/296-windows-cloud-files-cleanup.md
+++ b/changes/unreleased/296-windows-cloud-files-cleanup.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 296
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows Cloud Files can reconnect, disconnect, migrate, and uninstall cleanly when an obsolete provider root is already missing.

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -9,6 +9,11 @@ const MAX_SYNC_ROOT_IDENTITY_BYTES: usize = 4_096;
 #[cfg(any(windows, test))]
 const MAX_DISPLAY_NAME_CHARACTERS: usize = 128;
 
+#[cfg(any(windows, test))]
+fn is_windows_absence_hresult(value: i32) -> bool {
+    matches!(value as u32, 0x8007_0002 | 0x8007_0003 | 0x8007_0490)
+}
+
 #[cfg(windows)]
 #[derive(Debug)]
 struct OwnedPathConflict;
@@ -100,8 +105,8 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 #[cfg(windows)]
 mod platform {
     use super::{
-        OwnedPathConflict, PROVIDER_ID, decode_identity_hex, sid_string, valid_account_id,
-        valid_display_name,
+        OwnedPathConflict, PROVIDER_ID, decode_identity_hex, is_windows_absence_hresult,
+        sid_string, valid_account_id, valid_display_name,
     };
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
@@ -297,11 +302,22 @@ mod platform {
         }
         let id = sync_root_id(&account_id)?;
         let existing = StorageProviderSyncRootManager::GetSyncRootInformationForId(&id)?;
-        if existing.Path()?.Path()? != HSTRING::from(root.as_path()) {
-            return Err("the registered sync root path does not match".into());
+        if existing.ProviderId()? != PROVIDER_GUID {
+            return Err("the registered sync root belongs to another provider".into());
         }
-        StorageProviderSyncRootManager::Unregister(&id)?;
-        Ok(())
+        match existing.Path().and_then(|folder| folder.Path()) {
+            Ok(registered_path) if registered_path != HSTRING::from(root.as_path()) => {
+                return Err("the registered sync root path does not match".into());
+            }
+            Ok(_) => {}
+            Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
+            Err(failure) => return Err(failure.into()),
+        }
+        match StorageProviderSyncRootManager::Unregister(&id) {
+            Ok(()) => Ok(()),
+            Err(failure) if is_windows_absence_hresult(failure.code().0) => Ok(()),
+            Err(failure) => Err(failure.into()),
+        }
     }
 
     pub fn run(arguments: Vec<OsString>) -> Result<(), Box<dyn std::error::Error>> {
@@ -427,5 +443,14 @@ mod tests {
             Some("S-1-5-32-544")
         );
         assert_eq!(sid_string(&administrators_sid[..15]), None);
+    }
+
+    #[test]
+    fn classifies_only_missing_windows_objects_as_absent() {
+        assert!(is_windows_absence_hresult(0x8007_0002u32 as i32));
+        assert!(is_windows_absence_hresult(0x8007_0003u32 as i32));
+        assert!(is_windows_absence_hresult(0x8007_0490u32 as i32));
+        assert!(!is_windows_absence_hresult(0x8007_0005u32 as i32));
+        assert!(!is_windows_absence_hresult(0x8007_0057u32 as i32));
     }
 }

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -28,6 +28,34 @@ impl std::fmt::Display for OwnedPathConflict {
 #[cfg(windows)]
 impl std::error::Error for OwnedPathConflict {}
 
+#[cfg(windows)]
+#[derive(Debug)]
+struct RegistrationNotFound;
+
+#[cfg(windows)]
+impl std::fmt::Display for RegistrationNotFound {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("the Cloud Files registration was not found")
+    }
+}
+
+#[cfg(windows)]
+impl std::error::Error for RegistrationNotFound {}
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct UnsafeRegistrationConflict;
+
+#[cfg(windows)]
+impl std::fmt::Display for UnsafeRegistrationConflict {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("the Cloud Files registration cannot be changed safely")
+    }
+}
+
+#[cfg(windows)]
+impl std::error::Error for UnsafeRegistrationConflict {}
+
 #[cfg(any(windows, test))]
 fn valid_account_id(value: &str) -> bool {
     value.len() == ACCOUNT_ID_LENGTH
@@ -105,8 +133,9 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 #[cfg(windows)]
 mod platform {
     use super::{
-        OwnedPathConflict, PROVIDER_ID, decode_identity_hex, is_windows_absence_hresult,
-        sid_string, valid_account_id, valid_display_name,
+        OwnedPathConflict, PROVIDER_ID, RegistrationNotFound, UnsafeRegistrationConflict,
+        decode_identity_hex, is_windows_absence_hresult, sid_string, valid_account_id,
+        valid_display_name,
     };
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
@@ -127,6 +156,19 @@ mod platform {
     use windows::Win32::System::WinRT::{RO_INIT_MULTITHREADED, RoInitialize, RoUninitialize};
     use windows::core::{Error as WindowsError, GUID, HSTRING, Result as WindowsResult};
 
+    fn registered_path_is_missing(path: &HSTRING) -> Result<bool, std::io::Error> {
+        PathBuf::from(path.to_os_string())
+            .try_exists()
+            .map(|exists| !exists)
+    }
+
+    fn unregister_owned_registration(id: &HSTRING) -> windows::core::Result<()> {
+        match StorageProviderSyncRootManager::Unregister(id) {
+            Ok(()) => Ok(()),
+            Err(failure) if is_windows_absence_hresult(failure.code().0) => Ok(()),
+            Err(failure) => Err(failure),
+        }
+    }
     const PROVIDER_GUID: GUID = GUID::from_u128(0x6d456713_7d9a_4a39_90ce_127998de42d7);
 
     struct OwnedHandle(HANDLE);
@@ -246,24 +288,40 @@ mod platform {
         let context = CryptographicBuffer::CreateFromByteArray(&identity)?;
 
         let id = sync_root_id(&account_id)?;
-        if let Ok(existing) = StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
-            if existing.Path()?.Path()? != root_path {
-                return Err("the account is registered at a different sync root path".into());
+        match StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
+            Ok(existing) => {
+                if existing.ProviderId()? != PROVIDER_GUID {
+                    return Err(Box::new(UnsafeRegistrationConflict));
+                }
+                match existing.Path().and_then(|folder| folder.Path()) {
+                    Ok(existing_path) if existing_path == root_path => {
+                        if existing.DisplayNameResource()? == display_name
+                            && existing.IconResource()? == icon_resource
+                            && CryptographicBuffer::Compare(&existing.Context()?, &context)?
+                        {
+                            return Ok(());
+                        }
+                    }
+                    Ok(existing_path) if registered_path_is_missing(&existing_path)? => {}
+                    Ok(_) => return Err(Box::new(UnsafeRegistrationConflict)),
+                    Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
+                    Err(failure) => return Err(failure.into()),
+                }
+                unregister_owned_registration(&id)?;
             }
-            if existing.DisplayNameResource()? == display_name
-                && existing.IconResource()? == icon_resource
-                && CryptographicBuffer::Compare(&existing.Context()?, &context)?
-            {
-                return Ok(());
-            }
-            StorageProviderSyncRootManager::Unregister(&id)?;
+            Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
+            Err(failure) => return Err(failure.into()),
         }
         for existing in StorageProviderSyncRootManager::GetCurrentSyncRoots()? {
-            if existing.Id()? != id
-                && existing.ProviderId()? == PROVIDER_GUID
-                && existing.Path()?.Path()? == root_path
-            {
-                return Err(Box::new(OwnedPathConflict));
+            if existing.Id()? != id && existing.ProviderId()? == PROVIDER_GUID {
+                match existing.Path().and_then(|folder| folder.Path()) {
+                    Ok(existing_path) if existing_path == root_path => {
+                        return Err(Box::new(OwnedPathConflict));
+                    }
+                    Ok(_) => {}
+                    Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
+                    Err(failure) => return Err(failure.into()),
+                }
             }
         }
 
@@ -301,23 +359,27 @@ mod platform {
             return Err("invalid account identity".into());
         }
         let id = sync_root_id(&account_id)?;
-        let existing = StorageProviderSyncRootManager::GetSyncRootInformationForId(&id)?;
+        let existing = match StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
+            Ok(existing) => existing,
+            Err(failure) if is_windows_absence_hresult(failure.code().0) => {
+                return Err(Box::new(RegistrationNotFound));
+            }
+            Err(failure) => return Err(failure.into()),
+        };
         if existing.ProviderId()? != PROVIDER_GUID {
-            return Err("the registered sync root belongs to another provider".into());
+            return Err(Box::new(UnsafeRegistrationConflict));
         }
         match existing.Path().and_then(|folder| folder.Path()) {
             Ok(registered_path) if registered_path != HSTRING::from(root.as_path()) => {
-                return Err("the registered sync root path does not match".into());
+                if !registered_path_is_missing(&registered_path)? {
+                    return Err(Box::new(UnsafeRegistrationConflict));
+                }
             }
             Ok(_) => {}
             Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
             Err(failure) => return Err(failure.into()),
         }
-        match StorageProviderSyncRootManager::Unregister(&id) {
-            Ok(()) => Ok(()),
-            Err(failure) if is_windows_absence_hresult(failure.code().0) => Ok(()),
-            Err(failure) => Err(failure.into()),
-        }
+        unregister_owned_registration(&id).map_err(Into::into)
     }
 
     pub fn run(arguments: Vec<OsString>) -> Result<(), Box<dyn std::error::Error>> {
@@ -384,6 +446,10 @@ fn main() {
         eprintln!("Windows shell registration failed.");
         std::process::exit(if failure.is::<OwnedPathConflict>() {
             3
+        } else if failure.is::<RegistrationNotFound>() {
+            4
+        } else if failure.is::<UnsafeRegistrationConflict>() {
+            5
         } else {
             1
         });

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -14,6 +14,14 @@ fn is_windows_absence_hresult(value: i32) -> bool {
     matches!(value as u32, 0x8007_0002 | 0x8007_0003 | 0x8007_0490)
 }
 
+#[cfg(any(windows, test))]
+fn paths_refer_to_same_existing_entry(
+    first: &std::path::Path,
+    second: &std::path::Path,
+) -> std::io::Result<bool> {
+    Ok(first.canonicalize()? == second.canonicalize()?)
+}
+
 #[cfg(windows)]
 #[derive(Debug)]
 struct OwnedPathConflict;
@@ -134,8 +142,8 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 mod platform {
     use super::{
         OwnedPathConflict, PROVIDER_ID, RegistrationNotFound, UnsafeRegistrationConflict,
-        decode_identity_hex, is_windows_absence_hresult, sid_string, valid_account_id,
-        valid_display_name,
+        decode_identity_hex, is_windows_absence_hresult, paths_refer_to_same_existing_entry,
+        sid_string, valid_account_id, valid_display_name,
     };
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
@@ -160,6 +168,13 @@ mod platform {
         PathBuf::from(path.to_os_string())
             .try_exists()
             .map(|exists| !exists)
+    }
+
+    fn registered_path_matches(path: &HSTRING, requested: &Path) -> Result<bool, std::io::Error> {
+        if path == &HSTRING::from(requested) {
+            return Ok(true);
+        }
+        paths_refer_to_same_existing_entry(&PathBuf::from(path.to_os_string()), requested)
     }
 
     fn unregister_owned_registration(id: &HSTRING) -> windows::core::Result<()> {
@@ -294,7 +309,8 @@ mod platform {
                     return Err(Box::new(UnsafeRegistrationConflict));
                 }
                 match existing.Path().and_then(|folder| folder.Path()) {
-                    Ok(existing_path) if existing_path == root_path => {
+                    Ok(existing_path) if registered_path_is_missing(&existing_path)? => {}
+                    Ok(existing_path) if registered_path_matches(&existing_path, &root)? => {
                         if existing.DisplayNameResource()? == display_name
                             && existing.IconResource()? == icon_resource
                             && CryptographicBuffer::Compare(&existing.Context()?, &context)?
@@ -302,7 +318,6 @@ mod platform {
                             return Ok(());
                         }
                     }
-                    Ok(existing_path) if registered_path_is_missing(&existing_path)? => {}
                     Ok(_) => return Err(Box::new(UnsafeRegistrationConflict)),
                     Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
                     Err(failure) => return Err(failure.into()),
@@ -315,7 +330,8 @@ mod platform {
         for existing in StorageProviderSyncRootManager::GetCurrentSyncRoots()? {
             if existing.Id()? != id && existing.ProviderId()? == PROVIDER_GUID {
                 match existing.Path().and_then(|folder| folder.Path()) {
-                    Ok(existing_path) if existing_path == root_path => {
+                    Ok(existing_path) if registered_path_is_missing(&existing_path)? => {}
+                    Ok(existing_path) if registered_path_matches(&existing_path, &root)? => {
                         return Err(Box::new(OwnedPathConflict));
                     }
                     Ok(_) => {}
@@ -370,12 +386,9 @@ mod platform {
             return Err(Box::new(UnsafeRegistrationConflict));
         }
         match existing.Path().and_then(|folder| folder.Path()) {
-            Ok(registered_path) if registered_path != HSTRING::from(root.as_path()) => {
-                if !registered_path_is_missing(&registered_path)? {
-                    return Err(Box::new(UnsafeRegistrationConflict));
-                }
-            }
-            Ok(_) => {}
+            Ok(registered_path) if registered_path_is_missing(&registered_path)? => {}
+            Ok(registered_path) if registered_path_matches(&registered_path, &root)? => {}
+            Ok(_) => return Err(Box::new(UnsafeRegistrationConflict)),
             Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
             Err(failure) => return Err(failure.into()),
         }
@@ -518,5 +531,26 @@ mod tests {
         assert!(is_windows_absence_hresult(0x8007_0490u32 as i32));
         assert!(!is_windows_absence_hresult(0x8007_0005u32 as i32));
         assert!(!is_windows_absence_hresult(0x8007_0057u32 as i32));
+    }
+
+    #[test]
+    fn canonical_paths_identify_the_same_existing_directory() {
+        let base = std::env::temp_dir().join(format!(
+            "nextcloud-native-path-equivalence-{}",
+            std::process::id()
+        ));
+        let child = base.join("child");
+        std::fs::create_dir_all(&child).expect("create path-equivalence fixture");
+
+        let equivalent = child.join(".");
+        assert!(
+            paths_refer_to_same_existing_entry(&child, &equivalent)
+                .expect("compare equivalent paths")
+        );
+        assert!(
+            !paths_refer_to_same_existing_entry(&base, &child).expect("compare distinct paths")
+        );
+
+        std::fs::remove_dir_all(&base).expect("remove path-equivalence fixture");
     }
 }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -226,11 +226,13 @@ internal fun unregisterWindowsCloudFilesRootForUninstall(
     val api = apiFactory()
     var firstFailure: Throwable? = null
     try {
-        rootsByPreference.forEach { (root, preferenceKeys) ->
-            runCatching { api.unregisterSyncRoot(root) }
-                .onSuccess { preferenceKeys.forEach(preferences::remove) }
-                .onFailure { failure -> if (firstFailure == null) firstFailure = failure }
-        }
+        rootsByPreference.entries
+            .sortedByDescending { (root) -> root.fileName.toString().endsWith(WINDOWS_CLOUD_FILES_ROOT_SUFFIX) }
+            .forEach { (root, preferenceKeys) ->
+                runCatching { api.unregisterSyncRoot(root) }
+                    .onSuccess { preferenceKeys.forEach(preferences::remove) }
+                    .onFailure { failure -> if (firstFailure == null) firstFailure = failure }
+            }
     } finally {
         api.close()
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -93,14 +93,16 @@ internal class JnaWindowsCloudFilesApi(
     override fun unregisterSyncRoot(root: Path) {
         val accountId = windowsCloudShellAccountId(root)
         if (accountId != null && shellRegistrar.available && shellRegistrar.unregister(root, accountId)) return
+        val rootWasMissing = Files.notExists(root)
         val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
-        if (result in SYNC_ROOT_ALREADY_UNREGISTERED_RESULTS) return
+        if (isWindowsCloudFilesRootAbsentResult(result, rootMissing = rootWasMissing)) return
         checkHResult(result, "unregister the Windows Cloud Files root")
     }
 
     private fun unregisterCloudFilesRoot(root: Path): Boolean {
+        val rootWasMissing = Files.notExists(root)
         val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
-        return result >= 0 || result in SYNC_ROOT_ALREADY_UNREGISTERED_RESULTS
+        return result >= 0 || isWindowsCloudFilesRootAbsentResult(result, rootMissing = rootWasMissing)
     }
 
     override fun connect(root: Path, callbacks: WindowsCloudFilesCallbacks): Long {
@@ -567,11 +569,6 @@ internal class JnaWindowsCloudFilesApi(
 
         const val CF_OPERATION_TYPE_TRANSFER_DATA = 0
         const val CF_OPERATION_TYPE_TRANSFER_PLACEHOLDERS = 4
-        val SYNC_ROOT_ALREADY_UNREGISTERED_RESULTS = setOf(
-            0xC000CF13.toInt(), // STATUS_CLOUD_FILE_NOT_UNDER_SYNC_ROOT
-            0xD000CF13.toInt(), // HRESULT_FROM_NT(STATUS_CLOUD_FILE_NOT_UNDER_SYNC_ROOT)
-            0x80070186.toInt(), // HRESULT_FROM_WIN32(ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT)
-        )
         const val CF_OPERATION_TYPE_ACK_RENAME = 6
         const val CF_OPERATION_TYPE_ACK_DELETE = 7
         const val STATUS_SUCCESS = 0
@@ -618,6 +615,18 @@ internal class JnaWindowsCloudFilesApi(
         const val ACK_STATUS_OFFSET = PARAMETERS_UNION_OFFSET + 4L
     }
 }
+
+internal fun isWindowsCloudFilesRootAbsentResult(result: Int, rootMissing: Boolean): Boolean =
+    when (result) {
+        0xC000CF13.toInt(), // STATUS_CLOUD_FILE_NOT_UNDER_SYNC_ROOT
+        0xD000CF13.toInt(), // HRESULT_FROM_NT(STATUS_CLOUD_FILE_NOT_UNDER_SYNC_ROOT)
+        0x80070186.toInt(), // HRESULT_FROM_WIN32(ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT)
+        -> true
+        0x80070002.toInt(), // HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+        0x80070003.toInt(), // HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND)
+        -> rootMissing
+        else -> false
+    }
 
 internal interface CldApi : StdCallLibrary {
     fun CfRegisterSyncRoot(path: WString, registration: CfSyncRegistration, policies: CfSyncPolicies, flags: Int): Int

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -101,16 +101,14 @@ internal class JnaWindowsCloudFilesApi(
                 }
             }
         }
-        val rootWasMissing = Files.notExists(root)
         val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
-        if (isWindowsCloudFilesRootAbsentResult(result, rootMissing = rootWasMissing)) return
+        if (isWindowsCloudFilesRootAbsentResult(result, rootMissing = Files.notExists(root))) return
         checkHResult(result, "unregister the Windows Cloud Files root")
     }
 
     private fun unregisterCloudFilesRoot(root: Path): Boolean {
-        val rootWasMissing = Files.notExists(root)
         val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
-        return result >= 0 || isWindowsCloudFilesRootAbsentResult(result, rootMissing = rootWasMissing)
+        return result >= 0 || isWindowsCloudFilesRootAbsentResult(result, rootMissing = Files.notExists(root))
     }
 
     override fun connect(root: Path, callbacks: WindowsCloudFilesCallbacks): Long {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -92,7 +92,15 @@ internal class JnaWindowsCloudFilesApi(
 
     override fun unregisterSyncRoot(root: Path) {
         val accountId = windowsCloudShellAccountId(root)
-        if (accountId != null && shellRegistrar.available && shellRegistrar.unregister(root, accountId)) return
+        if (accountId != null && shellRegistrar.available) {
+            when (shellRegistrar.unregister(root, accountId)) {
+                WindowsShellUnregistrationResult.Unregistered -> return
+                WindowsShellUnregistrationResult.NotFound -> Unit
+                WindowsShellUnregistrationResult.Rejected -> {
+                    error("Windows refused to safely unregister the branded Cloud Files root.")
+                }
+            }
+        }
         val rootWasMissing = Files.notExists(root)
         val result = cldApi.CfUnregisterSyncRoot(WString(root.toAbsolutePath().toString()))
         if (isWindowsCloudFilesRootAbsentResult(result, rootMissing = rootWasMissing)) return
@@ -152,7 +160,10 @@ internal class JnaWindowsCloudFilesApi(
     }
 
     override fun disconnect(connectionKey: Long) {
-        checkHResult(cldApi.CfDisconnectSyncRoot(connectionKey), "disconnect the Windows Cloud Files provider")
+        val result = cldApi.CfDisconnectSyncRoot(connectionKey)
+        if (result < 0 && !isWindowsCloudFilesConnectionAbsentResult(result)) {
+            throw WindowsCloudFilesOperationException("disconnect the Windows Cloud Files provider", result)
+        }
         callbacksByConnection.remove(connectionKey)
     }
 
@@ -504,7 +515,7 @@ internal class JnaWindowsCloudFilesApi(
     }
 
     private fun checkHResult(result: Int, operation: String) {
-        check(result >= 0) { "Could not $operation (HRESULT 0x${result.toUInt().toString(16)})." }
+        if (result < 0) throw WindowsCloudFilesOperationException(operation, result)
     }
 
     private data class CallbackLifetime(
@@ -627,6 +638,21 @@ internal fun isWindowsCloudFilesRootAbsentResult(result: Int, rootMissing: Boole
         -> rootMissing
         else -> false
     }
+
+internal fun isWindowsCloudFilesRegistrationMissingResult(result: Int): Boolean =
+    result == 0xC000CF13.toInt() ||
+        result == 0xD000CF13.toInt() ||
+        result == 0x80070186.toInt() ||
+        result == 0x80070002.toInt() ||
+        result == 0x80070003.toInt()
+
+internal fun isWindowsCloudFilesConnectionAbsentResult(result: Int): Boolean =
+    result == 0x80070057.toInt() // HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER)
+
+internal class WindowsCloudFilesOperationException(
+    operation: String,
+    val hResult: Int,
+) : IllegalStateException("Could not $operation (HRESULT 0x${hResult.toUInt().toString(16)}).")
 
 internal interface CldApi : StdCallLibrary {
     fun CfRegisterSyncRoot(path: WString, registration: CfSyncRegistration, policies: CfSyncPolicies, flags: Int): Int

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -363,11 +363,11 @@ internal class WindowsCloudFilesProvider(
 
     fun start() {
         check(connection.get() == 0L) { "The Windows Cloud Files provider is already connected." }
-        Files.createDirectories(root)
-        check(!Files.isSymbolicLink(root)) { "The Windows Cloud Files root cannot be a symlink." }
+        prepareRootDirectory()
         val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
-        api.registerSyncRoot(root, backend.displayName, WindowsCloudFileIdentityCodec.encode(rootIdentity))
-        connection.set(api.connect(root, this))
+        val encodedRootIdentity = WindowsCloudFileIdentityCodec.encode(rootIdentity)
+        api.registerSyncRoot(root, backend.displayName, encodedRootIdentity)
+        connection.set(connectWithRegistrationRecovery(encodedRootIdentity))
         try {
             populateDirectory("", root)
             startLocalWatcher()
@@ -385,6 +385,27 @@ internal class WindowsCloudFilesProvider(
             }
             throw failure
         }
+    }
+
+    private fun connectWithRegistrationRecovery(syncRootIdentity: ByteArray): Long =
+        try {
+            api.connect(root, this)
+        } catch (firstFailure: WindowsCloudFilesOperationException) {
+            if (!isWindowsCloudFilesRegistrationMissingResult(firstFailure.hResult)) throw firstFailure
+            api.unregisterSyncRoot(root)
+            prepareRootDirectory()
+            api.registerSyncRoot(root, backend.displayName, syncRootIdentity)
+            try {
+                api.connect(root, this)
+            } catch (retryFailure: Throwable) {
+                retryFailure.addSuppressed(firstFailure)
+                throw retryFailure
+            }
+        }
+
+    private fun prepareRootDirectory() {
+        Files.createDirectories(root)
+        check(!Files.isSymbolicLink(root)) { "The Windows Cloud Files root cannot be a symlink." }
     }
 
     /** Repairs the legacy namespace and flushes recoverable local writes before changing root generations. */

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
@@ -14,13 +14,20 @@ internal interface WindowsCloudShellRegistrar {
         displayName: String,
         syncRootIdentity: ByteArray,
     ): WindowsShellRegistrationResult
-    fun unregister(root: Path, accountId: String): Boolean
+    fun unregister(root: Path, accountId: String): WindowsShellUnregistrationResult
 }
 
 internal enum class WindowsShellRegistrationResult {
     Registered,
     OwnedPathConflict,
+    UnsafeConflict,
     Failed,
+}
+
+internal enum class WindowsShellUnregistrationResult {
+    Unregistered,
+    NotFound,
+    Rejected,
 }
 
 internal class PackagedWindowsCloudShellRegistrar(
@@ -67,20 +74,26 @@ internal class PackagedWindowsCloudShellRegistrar(
         return when (exitCode) {
             0 -> WindowsShellRegistrationResult.Registered
             WINDOWS_SHELL_OWNED_PATH_CONFLICT_EXIT_CODE -> WindowsShellRegistrationResult.OwnedPathConflict
+            WINDOWS_SHELL_UNSAFE_CONFLICT_EXIT_CODE -> WindowsShellRegistrationResult.UnsafeConflict
             else -> WindowsShellRegistrationResult.Failed
         }
     }
 
-    override fun unregister(root: Path, accountId: String): Boolean {
+    override fun unregister(root: Path, accountId: String): WindowsShellUnregistrationResult {
         requireWindowsShellAccountId(accountId)
         val normalizedRoot = root.toAbsolutePath().normalize()
-        val executable = helper?.takeIf(File::isFile) ?: return false
-        return runCatching {
+        val executable = helper?.takeIf(File::isFile) ?: return WindowsShellUnregistrationResult.NotFound
+        val exitCode = runCatching {
             processRunner(
                 listOf(executable.absolutePath, "unregister", normalizedRoot.toString(), accountId),
                 REGISTRATION_TIMEOUT_SECONDS,
-            ) == 0
-        }.getOrDefault(false)
+            )
+        }.getOrNull()
+        return when (exitCode) {
+            0 -> WindowsShellUnregistrationResult.Unregistered
+            WINDOWS_SHELL_REGISTRATION_NOT_FOUND_EXIT_CODE -> WindowsShellUnregistrationResult.NotFound
+            else -> WindowsShellUnregistrationResult.Rejected
+        }
     }
 
     private companion object {
@@ -112,6 +125,9 @@ internal fun migrateWindowsSyncRootRegistration(
                 ) {
                     return WindowsSyncRootRegistrationMode.BrandedShell
                 }
+            }
+            WindowsShellRegistrationResult.UnsafeConflict -> {
+                error("Windows refused to replace a Cloud Files registration with conflicting ownership or path metadata.")
             }
             WindowsShellRegistrationResult.Failed -> Unit
         }
@@ -231,6 +247,8 @@ private const val WINDOWS_CLOUD_ROOT_GENERATION_SUFFIX = "-v2"
 internal const val WINDOWS_SHELL_REGISTRAR_NAME = "NextcloudNativeShellRegistrar.exe"
 internal const val WINDOWS_SHELL_ICON_NAME = "NextcloudNative.ico"
 internal const val WINDOWS_SHELL_OWNED_PATH_CONFLICT_EXIT_CODE = 3
+internal const val WINDOWS_SHELL_REGISTRATION_NOT_FOUND_EXIT_CODE = 4
+internal const val WINDOWS_SHELL_UNSAFE_CONFLICT_EXIT_CODE = 5
 private const val WINDOWS_SHELL_DISPLAY_NAME_MAX_CHARACTERS = 128
 private const val WINDOWS_SHELL_ACCOUNT_LABEL_PART_MAX_CHARACTERS = 44
 private const val WINDOWS_SHELL_ACCOUNT_TAG_CHARACTERS = 12

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
@@ -119,11 +119,22 @@ internal fun migrateWindowsSyncRootRegistration(
                 return WindowsSyncRootRegistrationMode.BrandedShell
             }
             WindowsShellRegistrationResult.OwnedPathConflict -> {
-                if (
-                    unregisterCloudFilesRoot() &&
-                    registerBrandedShellRoot() == WindowsShellRegistrationResult.Registered
-                ) {
-                    return WindowsSyncRootRegistrationMode.BrandedShell
+                if (unregisterCloudFilesRoot()) {
+                    when (registerBrandedShellRoot()) {
+                        WindowsShellRegistrationResult.Registered -> {
+                            return WindowsSyncRootRegistrationMode.BrandedShell
+                        }
+                        WindowsShellRegistrationResult.UnsafeConflict -> {
+                            error(
+                                "Windows refused to replace a Cloud Files registration with " +
+                                    "conflicting ownership or path metadata.",
+                            )
+                        }
+                        WindowsShellRegistrationResult.OwnedPathConflict -> {
+                            error("The owned Windows Cloud Files path conflict persisted after cleanup.")
+                        }
+                        WindowsShellRegistrationResult.Failed -> Unit
+                    }
                 }
             }
             WindowsShellRegistrationResult.UnsafeConflict -> {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -157,6 +157,80 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun missingRegistrationDuringConnectIsRepairedAndRetriedOnce() {
+        val root = createTempDirectory("windows-cloud-connect-repair")
+        val api = FakeApi().apply {
+            connectFailures += WindowsCloudFilesOperationException(
+                "connect the Windows Cloud Files provider",
+                0x80070186.toInt(),
+            )
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(ByteArray(0)), api)
+
+        try {
+            provider.start()
+
+            assertEquals(
+                listOf("register", "connect", "unregister", "register", "connect"),
+                api.lifecycleEvents.take(5),
+            )
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun unsafeConnectFailureDoesNotReplaceTheRegistration() {
+        val root = createTempDirectory("windows-cloud-connect-rejected")
+        val failure = WindowsCloudFilesOperationException(
+            "connect the Windows Cloud Files provider",
+            0x80070005.toInt(),
+        )
+        val api = FakeApi().apply { connectFailures += failure }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(ByteArray(0)), api)
+
+        try {
+            assertEquals(failure, assertFailsWith<WindowsCloudFilesOperationException> { provider.start() })
+            assertEquals(listOf("register", "connect"), api.lifecycleEvents)
+            assertEquals(null, api.unregisteredRoot)
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun registrationRepairStopsAfterOneFailedRetry() {
+        val root = createTempDirectory("windows-cloud-connect-retry-bounded")
+        val firstFailure = WindowsCloudFilesOperationException(
+            "connect the Windows Cloud Files provider",
+            0x80070003.toInt(),
+        )
+        val retryFailure = WindowsCloudFilesOperationException(
+            "connect the Windows Cloud Files provider",
+            0x80070186.toInt(),
+        )
+        val api = FakeApi().apply {
+            connectFailures += firstFailure
+            connectFailures += retryFailure
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(ByteArray(0)), api)
+
+        try {
+            assertEquals(retryFailure, assertFailsWith<WindowsCloudFilesOperationException> { provider.start() })
+            assertEquals(listOf(firstFailure), retryFailure.suppressed.toList())
+            assertEquals(
+                listOf("register", "connect", "unregister", "register", "connect"),
+                api.lifecycleEvents,
+            )
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun failedSyncRootRemovalKeepsTheNativeApiAvailableForRetry() {
         val root = createTempDirectory("windows-cloud-remove-retry")
         val api = FakeApi().apply { unregisterFailure = IllegalStateException("in use") }
@@ -792,6 +866,7 @@ class WindowsCloudFilesProviderTest {
         var lastRenameAccepted = false
         var unregisteredRoot: Path? = null
         var unregisterFailure: RuntimeException? = null
+        val connectFailures = mutableListOf<WindowsCloudFilesOperationException>()
         val disconnectAttempts = mutableListOf<Long>()
         var disconnectFailure: RuntimeException? = null
         var closed = false
@@ -802,10 +877,12 @@ class WindowsCloudFilesProviderTest {
         }
         override fun unregisterSyncRoot(root: Path) {
             unregisterFailure?.let { throw it }
+            lifecycleEvents += "unregister"
             unregisteredRoot = root
         }
         override fun connect(root: Path, callbacks: WindowsCloudFilesCallbacks): Long {
             lifecycleEvents += "connect"
+            if (connectFailures.isNotEmpty()) throw connectFailures.removeAt(0)
             return 1L
         }
         override fun disconnect(connectionKey: Long) {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
@@ -8,6 +8,7 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
@@ -63,7 +64,10 @@ class WindowsCloudShellRegistrarTest {
         }
 
         assertFalse(registrar.available)
-        assertFalse(registrar.unregister(installation.toPath(), "a5".repeat(32)))
+        assertEquals(
+            WindowsShellUnregistrationResult.NotFound,
+            registrar.unregister(installation.toPath(), "a5".repeat(32)),
+        )
         assertFalse(invoked)
     }
 
@@ -85,7 +89,7 @@ class WindowsCloudShellRegistrarTest {
             WindowsShellRegistrationResult.OwnedPathConflict,
             registrar.register(root, accountId, "Nextcloud Native - ada@cloud.example", byteArrayOf(1)),
         )
-        assertTrue(registrar.unregister(root, accountId))
+        assertEquals(WindowsShellUnregistrationResult.Unregistered, registrar.unregister(root, accountId))
         assertEquals(
             listOf(
                 installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).absolutePath,
@@ -95,6 +99,24 @@ class WindowsCloudShellRegistrarTest {
             ),
             invocations.last(),
         )
+    }
+
+    @Test
+    fun distinguishesMissingRegistrationsFromUnsafeUnregistrationFailures() {
+        val installation = createTempDirectory("nextcloud-shell-unregister-results").toFile()
+        val launcher = installation.resolve("NextcloudNative.exe").apply { writeText("launcher") }
+        installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).writeText("helper")
+        installation.resolve(WINDOWS_SHELL_ICON_NAME).writeText("icon")
+        val root = installation.resolve("Cloud root").toPath().createDirectories()
+        val accountId = "b7".repeat(32)
+        var exitCode = WINDOWS_SHELL_REGISTRATION_NOT_FOUND_EXIT_CODE
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { _, _ -> exitCode }
+
+        assertEquals(WindowsShellUnregistrationResult.NotFound, registrar.unregister(root, accountId))
+        exitCode = WINDOWS_SHELL_UNSAFE_CONFLICT_EXIT_CODE
+        assertEquals(WindowsShellUnregistrationResult.Rejected, registrar.unregister(root, accountId))
+        exitCode = 1
+        assertEquals(WindowsShellUnregistrationResult.Rejected, registrar.unregister(root, accountId))
     }
 
     @Test
@@ -151,6 +173,22 @@ class WindowsCloudShellRegistrarTest {
 
         assertEquals(WindowsSyncRootRegistrationMode.BrandedShell, mode)
         assertEquals(listOf("shell"), events)
+    }
+
+    @Test
+    fun unsafeRegistrationConflictDoesNotFallBackToPathBasedRegistration() {
+        var fallbackAttempted = false
+
+        assertFailsWith<IllegalStateException> {
+            migrateWindowsSyncRootRegistration(
+                shellAvailable = true,
+                unregisterCloudFilesRoot = { true },
+                registerBrandedShellRoot = { WindowsShellRegistrationResult.UnsafeConflict },
+                registerCloudFilesRoot = { fallbackAttempted = true },
+            )
+        }
+
+        assertFalse(fallbackAttempted)
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
@@ -159,6 +159,46 @@ class WindowsCloudShellRegistrarTest {
     }
 
     @Test
+    fun unsafeConflictDuringOwnedPathRetryDoesNotFallBack() {
+        var attempts = 0
+        var fallbackAttempted = false
+
+        assertFailsWith<IllegalStateException> {
+            migrateWindowsSyncRootRegistration(
+                shellAvailable = true,
+                unregisterCloudFilesRoot = { true },
+                registerBrandedShellRoot = {
+                    if (attempts++ == 0) {
+                        WindowsShellRegistrationResult.OwnedPathConflict
+                    } else {
+                        WindowsShellRegistrationResult.UnsafeConflict
+                    }
+                },
+                registerCloudFilesRoot = { fallbackAttempted = true },
+            )
+        }
+
+        assertEquals(2, attempts)
+        assertFalse(fallbackAttempted)
+    }
+
+    @Test
+    fun repeatedOwnedPathConflictDoesNotFallBack() {
+        var fallbackAttempted = false
+
+        assertFailsWith<IllegalStateException> {
+            migrateWindowsSyncRootRegistration(
+                shellAvailable = true,
+                unregisterCloudFilesRoot = { true },
+                registerBrandedShellRoot = { WindowsShellRegistrationResult.OwnedPathConflict },
+                registerCloudFilesRoot = { fallbackAttempted = true },
+            )
+        }
+
+        assertFalse(fallbackAttempted)
+    }
+
+    @Test
     fun successfulShellRegistrationDoesNotCreateASecondRegistration() {
         val events = mutableListOf<String>()
         val mode = migrateWindowsSyncRootRegistration(

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -23,6 +23,13 @@ class WindowsUninstallCleanupTest {
     }
 
     @Test
+    fun cloudFilesDisconnectTreatsOnlyAnAlreadyMissingConnectionAsAbsent() {
+        assertTrue(isWindowsCloudFilesConnectionAbsentResult(0x80070057.toInt()))
+        assertFalse(isWindowsCloudFilesConnectionAbsentResult(0x80070005.toInt()))
+        assertFalse(isWindowsCloudFilesConnectionAbsentResult(0x8007017C.toInt()))
+    }
+
+    @Test
     fun cloudFilesRootUsesTheCurrentProviderMetadataGeneration() {
         val home = Files.createTempDirectory("windows-root-generation-home").toFile()
         try {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -11,6 +11,18 @@ import kotlin.test.assertTrue
 
 class WindowsUninstallCleanupTest {
     @Test
+    fun cloudFilesCleanupTreatsOnlyMissingRootsAsAlreadyAbsent() {
+        assertTrue(isWindowsCloudFilesRootAbsentResult(0xC000CF13.toInt(), rootMissing = false))
+        assertTrue(isWindowsCloudFilesRootAbsentResult(0xD000CF13.toInt(), rootMissing = false))
+        assertTrue(isWindowsCloudFilesRootAbsentResult(0x80070186.toInt(), rootMissing = false))
+        assertTrue(isWindowsCloudFilesRootAbsentResult(0x80070002.toInt(), rootMissing = true))
+        assertTrue(isWindowsCloudFilesRootAbsentResult(0x80070003.toInt(), rootMissing = true))
+        assertFalse(isWindowsCloudFilesRootAbsentResult(0x80070003.toInt(), rootMissing = false))
+        assertFalse(isWindowsCloudFilesRootAbsentResult(0x80070005.toInt(), rootMissing = true))
+        assertFalse(isWindowsCloudFilesRootAbsentResult(0x8007017C.toInt(), rootMissing = true))
+    }
+
+    @Test
     fun cloudFilesRootUsesTheCurrentProviderMetadataGeneration() {
         val home = Files.createTempDirectory("windows-root-generation-home").toFile()
         try {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -227,12 +227,45 @@ class WindowsUninstallCleanupTest {
         }
     }
 
+    @Test
+    fun uninstallCleansTheCurrentRegistrationBeforeAStaleLegacyPreference() {
+        val preferences = Preferences.userRoot().node("windows-stale-legacy-pointer-test-${UUID.randomUUID()}")
+        val home = Files.createTempDirectory("windows-stale-legacy-pointer-home").toFile()
+        val session = NextcloudSession("https://cloud.invalid", "alice", "unused")
+        val accountId = desktopFileCacheAccountId(session)
+        val currentRoot = desktopWindowsCloudFilesRoot(accountId, home).toPath()
+        val legacyRoot = home.resolve("Nextcloud Native").resolve(accountId).toPath()
+        val api = RecordingWindowsCloudFilesApi().apply {
+            prerequisiteRoot = currentRoot
+            dependentRoot = legacyRoot
+        }
+        try {
+            preferences.put("server", session.serverUrl)
+            preferences.put("login", session.loginName)
+            preferences.put("windows-cloud-files-root", legacyRoot.toString())
+
+            unregisterWindowsCloudFilesRootForUninstall(preferences, home) { api }
+
+            assertEquals(listOf(currentRoot, legacyRoot), api.unregisteredRoots)
+            assertEquals(null, preferences.get("windows-cloud-files-root", null))
+            assertTrue(api.closed)
+        } finally {
+            preferences.removeNode()
+            home.deleteRecursively()
+        }
+    }
+
     private class RecordingWindowsCloudFilesApi : WindowsCloudFilesApi {
         val unregisteredRoots = mutableListOf<Path>()
         val unregisteredRoot: Path? get() = unregisteredRoots.lastOrNull()
+        var prerequisiteRoot: Path? = null
+        var dependentRoot: Path? = null
         var closed = false
 
         override fun unregisterSyncRoot(root: Path) {
+            if (root == dependentRoot && prerequisiteRoot !in unregisteredRoots) {
+                error("The stable registration still points at another candidate root.")
+            }
             unregisteredRoots.add(root)
         }
 


### PR DESCRIPTION
## Summary

- make missing legacy CFAPI roots and already-closed connections idempotent
- repair stale Obiente-owned stable-ID registrations whose folders are already absent
- retry registration and connection once when Windows reports that the root registration disappeared
- distinguish safe legacy fallback from rejected ownership, path, permission, and active-provider states

## Root cause

Cloud Files cleanup collapsed every shell-helper failure into a boolean fallback decision. That allowed harmless missing state to block activation while also leaving no way to prevent path-based fallback after an unsafe ownership or path rejection. Registration and connection also had no bounded recovery when Windows retained a stale stable ID or lost the root registration between lifecycle steps.

## Recovery boundaries

Recovery removes only a registration carrying the expected Obiente provider ID and stable account ID. It never deletes or renames user files, retries connection repair at most once, and preserves the original failure as a suppressed diagnostic when the retry fails. Foreign-provider, existing-path mismatch, access-denied, active-provider, and repeated failures remain fail-closed.

## User impact

Windows users can reconnect, disconnect, migrate, and uninstall without becoming stuck on stale or already-absent Cloud Files lifecycle state.

## Validation

- `cargo test --locked`
- `cargo check --locked --bin nextcloud-native-shell-registrar --target x86_64-pc-windows-msvc`
- `./gradlew :ui:desktopTest :ui:createDistributable --no-daemon`
- `bash tools/check-repository.sh`
- `bash tools/test-nightly-release-workflow.sh`
- marketing capture manifest freshness check

Closes #296