### PR TITLE
fix(files): accelerate large Linux directories

### DIFF
--- a/changes/unreleased/11-linux-large-directory-browsing.md
+++ b/changes/unreleased/11-linux-large-directory-browsing.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 11
+pull: none
+platforms: linux
+user-facing: yes
+
+Linux file managers now browse large Nextcloud folders from fast, stable metadata snapshots instead of repeating a server listing for every visible file.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -97,6 +97,21 @@ internal class DesktopFileReadCache(
     }
 
     @Synchronized
+    fun storeListingUnlessNewer(
+        accountId: String,
+        path: String,
+        files: List<NextcloudFile>,
+        fetchedAtEpochMillis: Long,
+    ): Boolean {
+        require(fetchedAtEpochMillis >= 0L)
+        val normalized = path.cachePath()
+        val current = load(accountId).listings.firstOrNull { listing -> listing.path == normalized }
+        if (current != null && current.fetchedAtEpochMillis >= fetchedAtEpochMillis) return false
+        storeListing(accountId, normalized, files, fetchedAtEpochMillis)
+        return true
+    }
+
+    @Synchronized
     fun cachedContent(
         accountId: String,
         path: String,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -277,9 +277,11 @@ internal class DesktopFileReadCache(
             index.copy(
                 listings = index.listings.filterNot { listing ->
                     normalized.isEmpty() ||
+                        listing.path.isEmpty() ||
                         listing.path == normalized ||
                         listing.path.startsWith("$normalized/") ||
-                        listing.path == parent
+                        listing.path == parent ||
+                        normalized.startsWith("${listing.path}/")
                 },
                 content = index.content.filterNot { it in removed },
             ),

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -69,24 +69,42 @@ internal class DesktopFileReadCache(
 
     @Synchronized
     fun cachedListingPaths(accountId: String): Set<String> =
-        load(accountId).listings.mapTo(linkedSetOf()) { listing -> listing.path }
+        load(accountId).let { index ->
+            buildSet {
+                index.listings.mapTo(this, CachedListingV1::path)
+                index.listingShards.mapTo(this, CachedListingShardReferenceV1::path)
+            }
+        }
 
     @Synchronized
     fun cachedListingSnapshot(accountId: String, path: String): DesktopCachedFileListing? {
         val normalized = path.cachePath()
-        return load(accountId).listings.firstOrNull { it.path == normalized }?.let { listing ->
+        val index = load(accountId)
+        val listing = index.listings.firstOrNull { it.path == normalized }
+            ?: hydrateListingOnDemand(accountId, normalized, index)
+            ?: return null
+        return listing.let {
             DesktopCachedFileListing(listing.files, listing.fetchedAtEpochMillis)
         }
     }
 
     @Synchronized
     fun cachedVirtualListingPaths(accountId: String): Set<String> =
-        load(accountId).virtualListings.mapTo(linkedSetOf()) { listing -> listing.path }
+        load(accountId).let { index ->
+            buildSet {
+                index.virtualListings.mapTo(this, CachedVirtualListingV1::path)
+                index.virtualListingShards.mapTo(this, CachedVirtualListingShardReferenceV1::path)
+            }
+        }
 
     @Synchronized
     fun cachedVirtualListingSnapshot(accountId: String, path: String): DesktopCachedVirtualListing? {
         val normalized = path.cachePath()
-        return load(accountId).virtualListings.firstOrNull { it.path == normalized }?.let { listing ->
+        val index = load(accountId)
+        val listing = index.virtualListings.firstOrNull { it.path == normalized }
+            ?: hydrateVirtualListingOnDemand(accountId, normalized, index)
+            ?: return null
+        return listing.let {
             DesktopCachedVirtualListing(
                 nodes = listing.nodes.map(CachedVirtualFileNodeV1::toDomain),
                 fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
@@ -137,11 +155,15 @@ internal class DesktopFileReadCache(
         require(fetchedAtEpochMillis >= 0L)
         require(nowEpochMillis >= 0L)
         val normalized = path.cachePath()
-        val current = load(accountId).listings.firstOrNull { listing -> listing.path == normalized }
+        val currentTimestamp = load(accountId).let { index ->
+            index.listings.firstOrNull { listing -> listing.path == normalized }?.fetchedAtEpochMillis
+                ?: index.listingShards.asSequence().filter { reference -> reference.path == normalized }
+                    .maxOfOrNull(CachedListingShardReferenceV1::fetchedAtEpochMillis)
+        }
         if (
-            current != null &&
-            current.fetchedAtEpochMillis <= nowEpochMillis &&
-            current.fetchedAtEpochMillis >= fetchedAtEpochMillis
+            currentTimestamp != null &&
+            currentTimestamp <= nowEpochMillis &&
+            currentTimestamp >= fetchedAtEpochMillis
         ) {
             return false
         }
@@ -163,11 +185,14 @@ internal class DesktopFileReadCache(
         val normalized = path.cachePath()
         nodes.forEach(::requireValidVirtualNode)
         val index = load(accountId)
-        val current = index.virtualListings.firstOrNull { listing -> listing.path == normalized }
+        val currentTimestamp =
+            index.virtualListings.firstOrNull { listing -> listing.path == normalized }?.fetchedAtEpochMillis
+                ?: index.virtualListingShards.asSequence().filter { reference -> reference.path == normalized }
+                    .maxOfOrNull(CachedVirtualListingShardReferenceV1::fetchedAtEpochMillis)
         if (
-            current != null &&
-            current.fetchedAtEpochMillis <= nowEpochMillis &&
-            current.fetchedAtEpochMillis >= fetchedAtEpochMillis
+            currentTimestamp != null &&
+            currentTimestamp <= nowEpochMillis &&
+            currentTimestamp >= fetchedAtEpochMillis
         ) {
             return false
         }
@@ -354,6 +379,22 @@ internal class DesktopFileReadCache(
                         listing.path == parent ||
                         normalized.startsWith("${listing.path}/")
                 },
+                listingShards = index.listingShards.filterNot { reference ->
+                    normalized.isEmpty() ||
+                        reference.path.isEmpty() ||
+                        reference.path == normalized ||
+                        reference.path.startsWith("$normalized/") ||
+                        reference.path == parent ||
+                        normalized.startsWith("${reference.path}/")
+                },
+                virtualListingShards = index.virtualListingShards.filterNot { reference ->
+                    normalized.isEmpty() ||
+                        reference.path.isEmpty() ||
+                        reference.path == normalized ||
+                        reference.path.startsWith("$normalized/") ||
+                        reference.path == parent ||
+                        normalized.startsWith("${reference.path}/")
+                },
                 content = index.content.filterNot { it in removed },
             ),
         )
@@ -425,18 +466,57 @@ internal class DesktopFileReadCache(
                 }
             }
             .take(MAX_CONTENT_ENTRIES)
+        val hydratedOrdinaryPaths = listings.mapTo(hashSetOf(), CachedListingV1::path)
+        val hydratedVirtualPaths = virtualListings.mapTo(hashSetOf(), CachedVirtualListingV1::path)
+        val unhydratedGroups = buildList {
+            listingShards.asSequence().filter { reference -> reference.path !in hydratedOrdinaryPaths }
+                .groupBy(CachedListingShardReferenceV1::path)
+                .forEach { (path, references) ->
+                    add(
+                        MetadataShardGroup(
+                            ordinary = true,
+                            path = path,
+                            fetchedAtEpochMillis = references.maxOf(CachedListingShardReferenceV1::fetchedAtEpochMillis),
+                            entryCount = references.sumOf(CachedListingShardReferenceV1::entryCount),
+                        ),
+                    )
+                }
+            virtualListingShards.asSequence().filter { reference -> reference.path !in hydratedVirtualPaths }
+                .groupBy(CachedVirtualListingShardReferenceV1::path)
+                .forEach { (path, references) ->
+                    add(
+                        MetadataShardGroup(
+                            ordinary = false,
+                            path = path,
+                            fetchedAtEpochMillis =
+                                references.maxOf(CachedVirtualListingShardReferenceV1::fetchedAtEpochMillis),
+                            entryCount = references.sumOf(CachedVirtualListingShardReferenceV1::entryCount),
+                        ),
+                    )
+                }
+        }.sortedByDescending(MetadataShardGroup::fetchedAtEpochMillis)
+        var remainingMetadataEntries = maximumTotalMetadataEntries - retainedMetadataEntries
+        val retainedUnhydratedOrdinaryPaths = hashSetOf<String>()
+        val retainedUnhydratedVirtualPaths = hashSetOf<String>()
+        unhydratedGroups.forEach { group ->
+            if (group.entryCount <= remainingMetadataEntries) {
+                if (group.ordinary) retainedUnhydratedOrdinaryPaths += group.path
+                else retainedUnhydratedVirtualPaths += group.path
+                remainingMetadataEntries -= group.entryCount
+            }
+        }
         return copy(
             listings = boundedListings,
             virtualListings = boundedVirtualListings,
             content = retainedContent,
             listingShards = listingShards.filter { reference ->
-                boundedListings.any { listing ->
+                reference.path in retainedUnhydratedOrdinaryPaths || boundedListings.any { listing ->
                     listing.path == reference.path &&
                         listing.fetchedAtEpochMillis == reference.fetchedAtEpochMillis
                 }
             },
             virtualListingShards = virtualListingShards.filter { reference ->
-                boundedVirtualListings.any { listing ->
+                reference.path in retainedUnhydratedVirtualPaths || boundedVirtualListings.any { listing ->
                     listing.path == reference.path &&
                         listing.fetchedAtEpochMillis == reference.fetchedAtEpochMillis
                 }
@@ -445,6 +525,7 @@ internal class DesktopFileReadCache(
     }
 
     private fun CacheIndexV1.persistMetadataShards(directory: File): CacheIndexV1 {
+        val hydratedOrdinaryPaths = listings.mapTo(hashSetOf(), CachedListingV1::path)
         val ordinaryReferences = listings.flatMap { listing ->
             reusableListingShards(directory, listing)?.let { return@flatMap it }
             val chunks = listing.files.metadataChunks()
@@ -468,7 +549,8 @@ internal class DesktopFileReadCache(
                     sha256 = sha256,
                 )
             }
-        }
+        } + listingShards.filter { reference -> reference.path !in hydratedOrdinaryPaths }
+        val hydratedVirtualPaths = virtualListings.mapTo(hashSetOf(), CachedVirtualListingV1::path)
         val virtualReferences = virtualListings.flatMap { listing ->
             reusableVirtualListingShards(directory, listing)?.let { return@flatMap it }
             val chunks = listing.nodes.metadataChunks()
@@ -492,7 +574,7 @@ internal class DesktopFileReadCache(
                     sha256 = sha256,
                 )
             }
-        }
+        } + virtualListingShards.filter { reference -> reference.path !in hydratedVirtualPaths }
         return copy(
             listings = emptyList(),
             virtualListings = emptyList(),
@@ -535,53 +617,29 @@ internal class DesktopFileReadCache(
 
     private fun CacheIndexV1.hydrateMetadataShards(directory: File): CacheIndexV1 {
         val hydrationBudget = MetadataHydrationBudget(maximumHydratedMetadataBytes)
-        val hydratedListings = listingShards
-            .groupBy { reference -> reference.path to reference.fetchedAtEpochMillis }
-            .mapNotNull { (_, references) ->
-                runCatching {
-                    val ordered = references.requireCompleteShardSet()
-                    val files = ordered.flatMap { reference ->
-                        val payload = loadMetadataShard<CachedListingShardV1>(
-                            directory,
-                            reference.blobName,
-                            reference.sha256,
-                            hydrationBudget,
-                        )
-                        require(
-                            payload.path == reference.path &&
-                                payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
-                                payload.partIndex == reference.partIndex &&
-                                payload.partCount == reference.partCount &&
-                                payload.files.size == reference.entryCount,
-                        ) { "A Files metadata shard does not match its index reference." }
-                        payload.files
-                    }
-                    CachedListingV1(ordered.first().path, ordered.first().fetchedAtEpochMillis, files)
-                }.getOrNull()
+        val hydratedListings = mutableListOf<CachedListingV1>()
+        val invalidListingPaths = mutableSetOf<String>()
+        listingShards.groupBy { reference -> reference.path to reference.fetchedAtEpochMillis }
+            .forEach { (key, references) ->
+                try {
+                    hydratedListings += hydrateListingReferences(directory, references, hydrationBudget)
+                } catch (_: MetadataHydrationBudgetExceededException) {
+                    // Keep valid-looking references for demand loading without growing startup memory.
+                } catch (_: Exception) {
+                    invalidListingPaths += key.first
+                }
             }
-        val hydratedVirtualListings = virtualListingShards
-            .groupBy { reference -> reference.path to reference.fetchedAtEpochMillis }
-            .mapNotNull { (_, references) ->
-                runCatching {
-                    val ordered = references.requireCompleteVirtualShardSet()
-                    val nodes = ordered.flatMap { reference ->
-                        val payload = loadMetadataShard<CachedVirtualListingShardV1>(
-                            directory,
-                            reference.blobName,
-                            reference.sha256,
-                            hydrationBudget,
-                        )
-                        require(
-                            payload.path == reference.path &&
-                                payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
-                                payload.partIndex == reference.partIndex &&
-                                payload.partCount == reference.partCount &&
-                                payload.nodes.size == reference.entryCount,
-                        ) { "A virtual Files metadata shard does not match its index reference." }
-                        payload.nodes
-                    }
-                    CachedVirtualListingV1(ordered.first().path, ordered.first().fetchedAtEpochMillis, nodes)
-                }.getOrNull()
+        val hydratedVirtualListings = mutableListOf<CachedVirtualListingV1>()
+        val invalidVirtualListingPaths = mutableSetOf<String>()
+        virtualListingShards.groupBy { reference -> reference.path to reference.fetchedAtEpochMillis }
+            .forEach { (key, references) ->
+                try {
+                    hydratedVirtualListings += hydrateVirtualListingReferences(directory, references, hydrationBudget)
+                } catch (_: MetadataHydrationBudgetExceededException) {
+                    // Keep valid-looking references for demand loading without growing startup memory.
+                } catch (_: Exception) {
+                    invalidVirtualListingPaths += key.first
+                }
             }
         val hydratedPaths = hydratedListings.mapTo(hashSetOf(), CachedListingV1::path)
         val hydratedVirtualPaths = hydratedVirtualListings.mapTo(hashSetOf(), CachedVirtualListingV1::path)
@@ -589,7 +647,141 @@ internal class DesktopFileReadCache(
             listings = listings.filterNot { listing -> listing.path in hydratedPaths } + hydratedListings,
             virtualListings = virtualListings.filterNot { listing -> listing.path in hydratedVirtualPaths } +
                 hydratedVirtualListings,
+            listingShards = listingShards.filterNot { reference -> reference.path in invalidListingPaths },
+            virtualListingShards = virtualListingShards.filterNot { reference ->
+                reference.path in invalidVirtualListingPaths
+            },
         )
+    }
+
+    private fun hydrateListingOnDemand(
+        accountId: String,
+        path: String,
+        index: CacheIndexV1,
+    ): CachedListingV1? {
+        val references = index.listingShards.filter { reference -> reference.path == path }
+        if (references.isEmpty()) return null
+        return try {
+            hydrateListingReferences(
+                accountDirectory(accountId),
+                references,
+                MetadataHydrationBudget(maximumHydratedMetadataBytes),
+            ).also { listing ->
+                val inlineListings = index.listings.filter { existing ->
+                    index.listingShards.none { reference -> reference.path == existing.path }
+                }
+                val inlineVirtualListings = index.virtualListings.filter { existing ->
+                    index.virtualListingShards.none { reference -> reference.path == existing.path }
+                }
+                rememberLoadedIndex(
+                    accountId,
+                    index.copy(
+                        listings = inlineListings.filterNot { it.path == path } + listing,
+                        virtualListings = inlineVirtualListings,
+                    )
+                        .bounded().requireValid(),
+                )
+            }
+        } catch (_: MetadataHydrationBudgetExceededException) {
+            null
+        } catch (_: Exception) {
+            rememberLoadedIndex(
+                accountId,
+                index.copy(listingShards = index.listingShards.filterNot { it.path == path })
+                    .bounded().requireValid(),
+            )
+            null
+        }
+    }
+
+    private fun hydrateVirtualListingOnDemand(
+        accountId: String,
+        path: String,
+        index: CacheIndexV1,
+    ): CachedVirtualListingV1? {
+        val references = index.virtualListingShards.filter { reference -> reference.path == path }
+        if (references.isEmpty()) return null
+        return try {
+            hydrateVirtualListingReferences(
+                accountDirectory(accountId),
+                references,
+                MetadataHydrationBudget(maximumHydratedMetadataBytes),
+            ).also { listing ->
+                val inlineListings = index.listings.filter { existing ->
+                    index.listingShards.none { reference -> reference.path == existing.path }
+                }
+                val inlineVirtualListings = index.virtualListings.filter { existing ->
+                    index.virtualListingShards.none { reference -> reference.path == existing.path }
+                }
+                rememberLoadedIndex(
+                    accountId,
+                    index.copy(
+                        listings = inlineListings,
+                        virtualListings = inlineVirtualListings.filterNot { it.path == path } + listing,
+                    ).bounded().requireValid(),
+                )
+            }
+        } catch (_: MetadataHydrationBudgetExceededException) {
+            null
+        } catch (_: Exception) {
+            rememberLoadedIndex(
+                accountId,
+                index.copy(
+                    virtualListingShards = index.virtualListingShards.filterNot { it.path == path },
+                ).bounded().requireValid(),
+            )
+            null
+        }
+    }
+
+    private fun hydrateListingReferences(
+        directory: File,
+        references: List<CachedListingShardReferenceV1>,
+        hydrationBudget: MetadataHydrationBudget,
+    ): CachedListingV1 {
+        val ordered = references.requireCompleteShardSet()
+        val files = ordered.flatMap { reference ->
+            val payload = loadMetadataShard<CachedListingShardV1>(
+                directory,
+                reference.blobName,
+                reference.sha256,
+                hydrationBudget,
+            )
+            require(
+                payload.path == reference.path &&
+                    payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
+                    payload.partIndex == reference.partIndex &&
+                    payload.partCount == reference.partCount &&
+                    payload.files.size == reference.entryCount,
+            ) { "A Files metadata shard does not match its index reference." }
+            payload.files
+        }
+        return CachedListingV1(ordered.first().path, ordered.first().fetchedAtEpochMillis, files)
+    }
+
+    private fun hydrateVirtualListingReferences(
+        directory: File,
+        references: List<CachedVirtualListingShardReferenceV1>,
+        hydrationBudget: MetadataHydrationBudget,
+    ): CachedVirtualListingV1 {
+        val ordered = references.requireCompleteVirtualShardSet()
+        val nodes = ordered.flatMap { reference ->
+            val payload = loadMetadataShard<CachedVirtualListingShardV1>(
+                directory,
+                reference.blobName,
+                reference.sha256,
+                hydrationBudget,
+            )
+            require(
+                payload.path == reference.path &&
+                    payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
+                    payload.partIndex == reference.partIndex &&
+                    payload.partCount == reference.partCount &&
+                    payload.nodes.size == reference.entryCount,
+            ) { "A virtual Files metadata shard does not match its index reference." }
+            payload.nodes
+        }
+        return CachedVirtualListingV1(ordered.first().path, ordered.first().fetchedAtEpochMillis, nodes)
     }
 
     private fun <T> List<T>.metadataChunks(): List<List<T>> =
@@ -768,6 +960,12 @@ internal class DesktopFileReadCache(
                 "${reference.path}\u0000${reference.fetchedAtEpochMillis}\u0000${reference.partIndex}"
             }.distinct().size == index.virtualListingShards.size,
         )
+        require(index.listingShards.groupBy(CachedListingShardReferenceV1::path).all { (_, references) ->
+            references.map(CachedListingShardReferenceV1::fetchedAtEpochMillis).distinct().size == 1
+        })
+        require(index.virtualListingShards.groupBy(CachedVirtualListingShardReferenceV1::path).all { (_, references) ->
+            references.map(CachedVirtualListingShardReferenceV1::fetchedAtEpochMillis).distinct().size == 1
+        })
         val ordinaryEntries = mutableMapOf<String, Long>()
         index.listings.forEach { listing -> ordinaryEntries[listing.path] = listing.files.size.toLong() }
         index.listingShards.groupBy(CachedListingShardReferenceV1::path).forEach { (path, references) ->
@@ -1055,16 +1253,26 @@ private data class CachedContentV1(
     val lastAccessedAtEpochMillis: Long = storedAtEpochMillis,
 )
 
+private data class MetadataShardGroup(
+    val ordinary: Boolean,
+    val path: String,
+    val fetchedAtEpochMillis: Long,
+    val entryCount: Int,
+)
+
 private class MetadataHydrationBudget(private val maximumBytes: Long) {
     private var reservedBytes = 0L
 
     fun reserve(bytes: Long) {
-        require(bytes > 0L && bytes <= maximumBytes - reservedBytes) {
-            "The Files metadata hydration budget was exceeded."
-        }
+        require(bytes > 0L)
+        if (bytes > maximumBytes - reservedBytes) throw MetadataHydrationBudgetExceededException()
         reservedBytes += bytes
     }
 }
+
+private class MetadataHydrationBudgetExceededException : IllegalStateException(
+    "The Files metadata hydration budget was exceeded.",
+)
 
 private val cacheJson = Json {
     encodeDefaults = true

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -42,11 +42,13 @@ internal class DesktopFileReadCache(
     private val maximumEntryBytes: Long = DEFAULT_MAXIMUM_ENTRY_BYTES,
     private val preferences: Preferences = Preferences.userRoot()
         .node("dev/obiente/nextcloudnative/virtual-file-cache"),
+    private val maximumLoadedAccountIndexes: Int = DEFAULT_MAXIMUM_LOADED_ACCOUNT_INDEXES,
 ) {
-    private val loadedIndexes = mutableMapOf<String, CacheIndexV1>()
+    private val loadedIndexes = LinkedHashMap<String, CacheIndexV1>(16, 0.75f, true)
     init {
         require(maximumContentBytes > 0L)
         require(maximumEntryBytes in 1L..maximumContentBytes)
+        require(maximumLoadedAccountIndexes > 0)
     }
 
     @Synchronized
@@ -317,7 +319,7 @@ internal class DesktopFileReadCache(
                 decoded.requireValid().bounded()
             }.getOrElse { CacheIndexV1() }
         }
-        loadedIndexes[accountId] = loaded
+        rememberLoadedIndex(accountId, loaded)
         return loaded
     }
 
@@ -329,11 +331,21 @@ internal class DesktopFileReadCache(
         val encoded = cacheJson.encodeToString(bounded).encodeToByteArray()
         require(encoded.size.toLong() <= MAX_INDEX_BYTES) { "The Files cache index is too large." }
         publishBytes(directory, INDEX_FILE_NAME, encoded)
-        loadedIndexes[accountId] = bounded
+        rememberLoadedIndex(accountId, bounded)
         val referenced = bounded.content.mapTo(hashSetOf(), CachedContentV1::blobName)
         directory.listFiles().orEmpty()
             .filter { file -> file.isFile && file.extension == "blob" && file.name !in referenced }
             .forEach(File::delete)
+    }
+
+    private fun rememberLoadedIndex(accountId: String, index: CacheIndexV1) {
+        loadedIndexes[accountId] = index
+        while (loadedIndexes.size > maximumLoadedAccountIndexes) {
+            loadedIndexes.entries.iterator().apply {
+                next()
+                remove()
+            }
+        }
     }
 
     private fun applyEviction(
@@ -449,6 +461,7 @@ internal class DesktopFileReadCache(
         const val MAX_MIME_TYPE_LENGTH = 512
         const val DEFAULT_MAXIMUM_ENTRY_BYTES = 512L * 1024L * 1024L
         const val DEFAULT_MAXIMUM_CONTENT_BYTES = 256L * 1024L * 1024L * 1024L
+        const val DEFAULT_MAXIMUM_LOADED_ACCOUNT_INDEXES = 4
         const val KEY_AUTOMATIC_CLEANUP = "automatic-cleanup"
         const val KEY_MAXIMUM_CACHE_BYTES = "maximum-cache-bytes"
         const val KEY_MINIMUM_FREE_BYTES = "minimum-free-bytes"

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -16,6 +16,11 @@ internal data class DesktopCachedFileContent(
     val etag: String,
 )
 
+internal data class DesktopCachedFileListing(
+    val files: List<NextcloudFile>,
+    val fetchedAtEpochMillis: Long,
+)
+
 internal data class DesktopVirtualFileCacheSummary(
     val policy: VirtualFileCachePolicy,
     val cachedBytes: Long,
@@ -35,18 +40,25 @@ internal class DesktopFileReadCache(
     private val root: File,
     private val maximumContentBytes: Long = DEFAULT_MAXIMUM_CONTENT_BYTES,
     private val maximumEntryBytes: Long = DEFAULT_MAXIMUM_ENTRY_BYTES,
+    private val preferences: Preferences = Preferences.userRoot()
+        .node("dev/obiente/nextcloudnative/virtual-file-cache"),
 ) {
-    private val preferences = Preferences.userRoot()
-        .node("dev/obiente/nextcloudnative/virtual-file-cache")
+    private val loadedIndexes = mutableMapOf<String, CacheIndexV1>()
     init {
         require(maximumContentBytes > 0L)
         require(maximumEntryBytes in 1L..maximumContentBytes)
     }
 
     @Synchronized
-    fun cachedListing(accountId: String, path: String): List<NextcloudFile>? {
+    fun cachedListing(accountId: String, path: String): List<NextcloudFile>? =
+        cachedListingSnapshot(accountId, path)?.files
+
+    @Synchronized
+    fun cachedListingSnapshot(accountId: String, path: String): DesktopCachedFileListing? {
         val normalized = path.cachePath()
-        return load(accountId).listings.firstOrNull { it.path == normalized }?.files
+        return load(accountId).listings.firstOrNull { it.path == normalized }?.let { listing ->
+            DesktopCachedFileListing(listing.files, listing.fetchedAtEpochMillis)
+        }
     }
 
     @Synchronized
@@ -246,11 +258,16 @@ internal class DesktopFileReadCache(
     }
 
     private fun CacheIndexV1.bounded(): CacheIndexV1 {
-        val boundedListings = listings
-            .sortedByDescending(CachedListingV1::fetchedAtEpochMillis)
-            .take(MAX_LISTINGS)
-        require(boundedListings.sumOf { it.files.size } <= MAX_TOTAL_METADATA_ENTRIES) {
-            "The Files metadata cache exceeds its entry limit."
+        var retainedMetadataEntries = 0
+        val boundedListings = buildList {
+            listings.sortedByDescending(CachedListingV1::fetchedAtEpochMillis)
+                .take(MAX_LISTINGS)
+                .forEach { listing ->
+                    if (retainedMetadataEntries + listing.files.size <= MAX_TOTAL_METADATA_ENTRIES) {
+                        add(listing)
+                        retainedMetadataEntries += listing.files.size
+                    }
+                }
         }
         val policyBudget = if (loadPolicy().automaticCleanup) {
             loadPolicy().maximumCacheBytes ?: maximumContentBytes
@@ -274,13 +291,19 @@ internal class DesktopFileReadCache(
     }
 
     private fun load(accountId: String): CacheIndexV1 {
+        loadedIndexes[accountId]?.let { return it }
         val directory = accountDirectory(accountId)
         val indexFile = File(directory, INDEX_FILE_NAME)
-        if (!indexFile.isFile || indexFile.length() !in 1..MAX_INDEX_BYTES) return CacheIndexV1()
-        return runCatching {
-            val decoded = cacheJson.decodeFromString<CacheIndexV1>(indexFile.readText(Charsets.UTF_8))
-            decoded.requireValid().bounded()
-        }.getOrElse { CacheIndexV1() }
+        val loaded = if (!indexFile.isFile || indexFile.length() !in 1..MAX_INDEX_BYTES) {
+            CacheIndexV1()
+        } else {
+            runCatching {
+                val decoded = cacheJson.decodeFromString<CacheIndexV1>(indexFile.readText(Charsets.UTF_8))
+                decoded.requireValid().bounded()
+            }.getOrElse { CacheIndexV1() }
+        }
+        loadedIndexes[accountId] = loaded
+        return loaded
     }
 
     private fun save(accountId: String, index: CacheIndexV1) {
@@ -291,6 +314,7 @@ internal class DesktopFileReadCache(
         val encoded = cacheJson.encodeToString(bounded).encodeToByteArray()
         require(encoded.size.toLong() <= MAX_INDEX_BYTES) { "The Files cache index is too large." }
         publishBytes(directory, INDEX_FILE_NAME, encoded)
+        loadedIndexes[accountId] = bounded
         val referenced = bounded.content.mapTo(hashSetOf(), CachedContentV1::blobName)
         directory.listFiles().orEmpty()
             .filter { file -> file.isFile && file.extension == "blob" && file.name !in referenced }
@@ -400,10 +424,10 @@ internal class DesktopFileReadCache(
     private companion object {
         const val FORMAT_VERSION = 1
         const val INDEX_FILE_NAME = "index-v1.json"
-        const val MAX_INDEX_BYTES = 8L * 1024L * 1024L
+        const val MAX_INDEX_BYTES = 64L * 1024L * 1024L
         const val MAX_LISTINGS = 256
-        const val MAX_FILES_PER_LISTING = 5_000
-        const val MAX_TOTAL_METADATA_ENTRIES = 20_000
+        const val MAX_FILES_PER_LISTING = 50_000
+        const val MAX_TOTAL_METADATA_ENTRIES = 250_000
         const val MAX_CONTENT_ENTRIES = 256
         const val MAX_FILE_NAME_LENGTH = 1_024
         const val MAX_ETAG_LENGTH = 4_096

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -48,12 +48,14 @@ internal class DesktopFileReadCache(
     private val preferences: Preferences = Preferences.userRoot()
         .node("dev/obiente/nextcloudnative/virtual-file-cache"),
     private val maximumLoadedAccountIndexes: Int = DEFAULT_MAXIMUM_LOADED_ACCOUNT_INDEXES,
+    private val maximumTotalMetadataEntries: Int = MAX_TOTAL_METADATA_ENTRIES,
 ) {
     private val loadedIndexes = LinkedHashMap<String, CacheIndexV1>(16, 0.75f, true)
     init {
         require(maximumContentBytes > 0L)
         require(maximumEntryBytes in 1L..maximumContentBytes)
         require(maximumLoadedAccountIndexes > 0)
+        require(maximumTotalMetadataEntries >= 2)
     }
 
     @Synchronized
@@ -353,26 +355,52 @@ internal class DesktopFileReadCache(
     }
 
     private fun CacheIndexV1.bounded(): CacheIndexV1 {
+        val perTypeReserve = minOf(MAX_FILES_PER_LISTING, maximumTotalMetadataEntries / 2)
         var retainedMetadataEntries = 0
-        val boundedListings = buildList {
-            listings.sortedByDescending(CachedListingV1::fetchedAtEpochMillis)
-                .take(MAX_LISTINGS)
-                .forEach { listing ->
-                    if (retainedMetadataEntries + listing.files.size <= MAX_TOTAL_METADATA_ENTRIES) {
-                        add(listing)
-                        retainedMetadataEntries += listing.files.size
-                    }
-                }
+        val ordinary = listings.sortedByDescending(CachedListingV1::fetchedAtEpochMillis).take(MAX_LISTINGS)
+        val virtual = virtualListings.sortedByDescending(CachedVirtualListingV1::fetchedAtEpochMillis)
+            .take(MAX_LISTINGS)
+        val boundedListings = mutableListOf<CachedListingV1>()
+        val boundedVirtualListings = mutableListOf<CachedVirtualListingV1>()
+        var ordinaryIndex = 0
+        var virtualIndex = 0
+        var ordinaryEntries = 0
+        var virtualEntries = 0
+        while (ordinaryIndex < ordinary.size) {
+            val candidate = ordinary[ordinaryIndex]
+            if (ordinaryEntries + candidate.files.size > perTypeReserve) break
+            boundedListings += candidate
+            ordinaryEntries += candidate.files.size
+            retainedMetadataEntries += candidate.files.size
+            ordinaryIndex += 1
         }
-        val boundedVirtualListings = buildList {
-            virtualListings.sortedByDescending(CachedVirtualListingV1::fetchedAtEpochMillis)
-                .take(MAX_LISTINGS)
-                .forEach { listing ->
-                    if (retainedMetadataEntries + listing.nodes.size <= MAX_TOTAL_METADATA_ENTRIES) {
-                        add(listing)
-                        retainedMetadataEntries += listing.nodes.size
-                    }
+        while (virtualIndex < virtual.size) {
+            val candidate = virtual[virtualIndex]
+            if (virtualEntries + candidate.nodes.size > perTypeReserve) break
+            boundedVirtualListings += candidate
+            virtualEntries += candidate.nodes.size
+            retainedMetadataEntries += candidate.nodes.size
+            virtualIndex += 1
+        }
+        while (ordinaryIndex < ordinary.size || virtualIndex < virtual.size) {
+            val nextOrdinary = ordinary.getOrNull(ordinaryIndex)
+            val nextVirtual = virtual.getOrNull(virtualIndex)
+            val chooseOrdinary = nextVirtual == null ||
+                nextOrdinary != null && nextOrdinary.fetchedAtEpochMillis >= nextVirtual.fetchedAtEpochMillis
+            if (chooseOrdinary) {
+                val candidate = requireNotNull(nextOrdinary)
+                if (candidate.files.size <= maximumTotalMetadataEntries - retainedMetadataEntries) {
+                    boundedListings += candidate
+                    retainedMetadataEntries += candidate.files.size
                 }
+            } else {
+                val candidate = requireNotNull(nextVirtual)
+                if (candidate.nodes.size <= maximumTotalMetadataEntries - retainedMetadataEntries) {
+                    boundedVirtualListings += candidate
+                    retainedMetadataEntries += candidate.nodes.size
+                }
+            }
+            if (chooseOrdinary) ordinaryIndex += 1 else virtualIndex += 1
         }
         val policyBudget = if (loadPolicy().automaticCleanup) {
             loadPolicy().maximumCacheBytes ?: maximumContentBytes

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -104,11 +104,19 @@ internal class DesktopFileReadCache(
         path: String,
         files: List<NextcloudFile>,
         fetchedAtEpochMillis: Long,
+        nowEpochMillis: Long = System.currentTimeMillis(),
     ): Boolean {
         require(fetchedAtEpochMillis >= 0L)
+        require(nowEpochMillis >= 0L)
         val normalized = path.cachePath()
         val current = load(accountId).listings.firstOrNull { listing -> listing.path == normalized }
-        if (current != null && current.fetchedAtEpochMillis >= fetchedAtEpochMillis) return false
+        if (
+            current != null &&
+            current.fetchedAtEpochMillis <= nowEpochMillis &&
+            current.fetchedAtEpochMillis >= fetchedAtEpochMillis
+        ) {
+            return false
+        }
         storeListing(accountId, normalized, files, fetchedAtEpochMillis)
         return true
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -665,7 +665,7 @@ internal class DesktopFileReadCache(
             hydrateListingReferences(
                 accountDirectory(accountId),
                 references,
-                MetadataHydrationBudget(maximumHydratedMetadataBytes),
+                MetadataHydrationBudget.perShard(MAX_METADATA_SHARD_BYTES),
             ).also { listing ->
                 val inlineListings = index.listings.filter { existing ->
                     index.listingShards.none { reference -> reference.path == existing.path }
@@ -705,7 +705,7 @@ internal class DesktopFileReadCache(
             hydrateVirtualListingReferences(
                 accountDirectory(accountId),
                 references,
-                MetadataHydrationBudget(maximumHydratedMetadataBytes),
+                MetadataHydrationBudget.perShard(MAX_METADATA_SHARD_BYTES),
             ).also { listing ->
                 val inlineListings = index.listings.filter { existing ->
                     index.listingShards.none { reference -> reference.path == existing.path }
@@ -1260,13 +1260,22 @@ private data class MetadataShardGroup(
     val entryCount: Int,
 )
 
-private class MetadataHydrationBudget(private val maximumBytes: Long) {
+private class MetadataHydrationBudget(
+    private val maximumBytes: Long,
+    private val cumulative: Boolean = true,
+) {
     private var reservedBytes = 0L
 
     fun reserve(bytes: Long) {
         require(bytes > 0L)
-        if (bytes > maximumBytes - reservedBytes) throw MetadataHydrationBudgetExceededException()
-        reservedBytes += bytes
+        val alreadyReserved = if (cumulative) reservedBytes else 0L
+        if (bytes > maximumBytes - alreadyReserved) throw MetadataHydrationBudgetExceededException()
+        if (cumulative) reservedBytes += bytes
+    }
+
+    companion object {
+        fun perShard(maximumBytes: Long): MetadataHydrationBudget =
+            MetadataHydrationBudget(maximumBytes, cumulative = false)
     }
 }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -54,6 +54,7 @@ internal class DesktopFileReadCache(
     private val metadataShardReadObserver: (File) -> Unit = {},
 ) {
     private val loadedIndexes = LinkedHashMap<String, CacheIndexV1>(16, 0.75f, true)
+    private val failedVirtualListingInvalidations = mutableMapOf<String, Set<String>>()
     init {
         require(maximumContentBytes > 0L)
         require(maximumEntryBytes in 1L..maximumContentBytes)
@@ -110,6 +111,16 @@ internal class DesktopFileReadCache(
                 fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
             )
         }
+    }
+
+    @Synchronized
+    fun failedVirtualListingInvalidations(accountId: String): Set<String> =
+        failedVirtualListingInvalidations[accountId].orEmpty().toSet()
+
+    @Synchronized
+    fun replaceFailedVirtualListingInvalidations(accountId: String, paths: Set<String>) {
+        if (paths.isEmpty()) failedVirtualListingInvalidations.remove(accountId)
+        else failedVirtualListingInvalidations[accountId] = paths.toSet()
     }
 
     @Synchronized

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -24,6 +24,7 @@ internal data class DesktopCachedFileListing(
 internal data class DesktopCachedVirtualListing(
     val nodes: List<LinuxVirtualFileNode>,
     val fetchedAtEpochMillis: Long,
+    val freshAtEpochMillis: Long = fetchedAtEpochMillis,
 )
 
 internal data class DesktopVirtualFileCacheSummary(
@@ -112,6 +113,7 @@ internal class DesktopFileReadCache(
             DesktopCachedVirtualListing(
                 nodes = listing.nodes.map(CachedVirtualFileNodeV1::toDomain),
                 fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
+                freshAtEpochMillis = listing.freshAtEpochMillis,
             )
         }
     }
@@ -205,9 +207,11 @@ internal class DesktopFileReadCache(
         path: String,
         nodes: List<LinuxVirtualFileNode>,
         fetchedAtEpochMillis: Long,
+        freshAtEpochMillis: Long = fetchedAtEpochMillis,
         nowEpochMillis: Long = System.currentTimeMillis(),
     ): Boolean {
         require(fetchedAtEpochMillis >= 0L)
+        require(freshAtEpochMillis >= fetchedAtEpochMillis)
         require(nowEpochMillis >= 0L)
         require(nodes.size <= MAX_FILES_PER_LISTING) { "The folder contains too many cacheable entries." }
         val normalized = path.cachePath()
@@ -232,6 +236,7 @@ internal class DesktopFileReadCache(
                         path = normalized,
                         fetchedAtEpochMillis = fetchedAtEpochMillis,
                         nodes = nodes.map(CachedVirtualFileNodeV1::fromDomain),
+                        freshAtEpochMillis = freshAtEpochMillis,
                     ),
                 virtualListingShards = index.virtualListingShards.filterNot { reference ->
                     reference.path == normalized
@@ -589,6 +594,7 @@ internal class DesktopFileReadCache(
                     partIndex = partIndex,
                     partCount = chunks.size,
                     nodes = nodes,
+                    freshAtEpochMillis = listing.freshAtEpochMillis,
                 )
                 val encoded = cacheJson.encodeToString(payload).encodeToByteArray()
                 val (blobName, sha256) = publishMetadataShard(directory, encoded)
@@ -600,6 +606,7 @@ internal class DesktopFileReadCache(
                     entryCount = nodes.size,
                     blobName = blobName,
                     sha256 = sha256,
+                    freshAtEpochMillis = listing.freshAtEpochMillis,
                 )
             }
         } + virtualListingShards.filter { reference -> reference.path !in hydratedVirtualPaths }
@@ -630,7 +637,8 @@ internal class DesktopFileReadCache(
     ): List<CachedVirtualListingShardReferenceV1>? {
         val references = virtualListingShards.filter { reference ->
             reference.path == listing.path &&
-                reference.fetchedAtEpochMillis == listing.fetchedAtEpochMillis
+                reference.fetchedAtEpochMillis == listing.fetchedAtEpochMillis &&
+                reference.freshAtEpochMillis == listing.freshAtEpochMillis
         }
         val ordered = runCatching { references.requireCompleteVirtualShardSet() }.getOrNull() ?: return null
         if (ordered.sumOf(CachedVirtualListingShardReferenceV1::entryCount) != listing.nodes.size) return null
@@ -803,13 +811,19 @@ internal class DesktopFileReadCache(
             require(
                 payload.path == reference.path &&
                     payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
+                    payload.freshAtEpochMillis == reference.freshAtEpochMillis &&
                     payload.partIndex == reference.partIndex &&
                     payload.partCount == reference.partCount &&
                     payload.nodes.size == reference.entryCount,
             ) { "A virtual Files metadata shard does not match its index reference." }
             payload.nodes
         }
-        return CachedVirtualListingV1(ordered.first().path, ordered.first().fetchedAtEpochMillis, nodes)
+        return CachedVirtualListingV1(
+            path = ordered.first().path,
+            fetchedAtEpochMillis = ordered.first().fetchedAtEpochMillis,
+            nodes = nodes,
+            freshAtEpochMillis = ordered.first().freshAtEpochMillis,
+        )
     }
 
     private fun <T> List<T>.metadataChunks(): List<List<T>> =
@@ -992,7 +1006,9 @@ internal class DesktopFileReadCache(
             references.map(CachedListingShardReferenceV1::fetchedAtEpochMillis).distinct().size == 1
         })
         require(index.virtualListingShards.groupBy(CachedVirtualListingShardReferenceV1::path).all { (_, references) ->
-            references.map(CachedVirtualListingShardReferenceV1::fetchedAtEpochMillis).distinct().size == 1
+            references.map { reference ->
+                reference.fetchedAtEpochMillis to reference.freshAtEpochMillis
+            }.distinct().size == 1
         })
         val ordinaryEntries = mutableMapOf<String, Long>()
         index.listings.forEach { listing -> ordinaryEntries[listing.path] = listing.files.size.toLong() }
@@ -1020,6 +1036,7 @@ internal class DesktopFileReadCache(
         index.virtualListings.forEach { listing ->
             require(listing.path.cachePath() == listing.path)
             require(listing.fetchedAtEpochMillis >= 0L)
+            require(listing.freshAtEpochMillis >= listing.fetchedAtEpochMillis)
             require(listing.nodes.size <= MAX_FILES_PER_LISTING)
             listing.nodes.forEach { node -> requireValidVirtualNode(node.toDomain()) }
         }
@@ -1051,6 +1068,7 @@ internal class DesktopFileReadCache(
     private fun CachedVirtualListingShardReferenceV1.requireValid() {
         path.cachePath()
         require(fetchedAtEpochMillis >= 0L)
+        require(freshAtEpochMillis >= fetchedAtEpochMillis)
         require(partCount in 1..MAX_METADATA_SHARDS_PER_LISTING && partIndex in 0 until partCount)
         require(entryCount in 0..MAX_METADATA_SHARD_ENTRIES)
         require(blobName == "$sha256.$METADATA_SHARD_EXTENSION" && sha256.isSha256Hex())
@@ -1206,6 +1224,7 @@ private data class CachedVirtualListingV1(
     val path: String,
     val fetchedAtEpochMillis: Long,
     val nodes: List<CachedVirtualFileNodeV1>,
+    val freshAtEpochMillis: Long = fetchedAtEpochMillis,
 )
 
 @Serializable
@@ -1228,6 +1247,7 @@ private data class CachedVirtualListingShardReferenceV1(
     val entryCount: Int,
     val blobName: String,
     val sha256: String,
+    val freshAtEpochMillis: Long = fetchedAtEpochMillis,
 )
 
 @Serializable
@@ -1246,6 +1266,7 @@ private data class CachedVirtualListingShardV1(
     val partIndex: Int,
     val partCount: Int,
     val nodes: List<CachedVirtualFileNodeV1>,
+    val freshAtEpochMillis: Long = fetchedAtEpochMillis,
 )
 
 @Serializable

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -49,6 +49,7 @@ internal class DesktopFileReadCache(
         .node("dev/obiente/nextcloudnative/virtual-file-cache"),
     private val maximumLoadedAccountIndexes: Int = DEFAULT_MAXIMUM_LOADED_ACCOUNT_INDEXES,
     private val maximumTotalMetadataEntries: Int = MAX_TOTAL_METADATA_ENTRIES,
+    private val maximumIndexBytes: Long = MAX_INDEX_BYTES,
 ) {
     private val loadedIndexes = LinkedHashMap<String, CacheIndexV1>(16, 0.75f, true)
     init {
@@ -56,6 +57,7 @@ internal class DesktopFileReadCache(
         require(maximumEntryBytes in 1L..maximumContentBytes)
         require(maximumLoadedAccountIndexes > 0)
         require(maximumTotalMetadataEntries >= 2)
+        require(maximumIndexBytes in 1L..MAX_INDEX_BYTES)
     }
 
     @Synchronized
@@ -99,11 +101,7 @@ internal class DesktopFileReadCache(
         require(nowEpochMillis >= 0L)
         require(files.size <= MAX_FILES_PER_LISTING) { "The folder contains too many cacheable entries." }
         val normalized = path.cachePath()
-        files.forEach { file ->
-            require(file.path.cachePath() == file.path) { "A cached file path is not canonical." }
-            require(file.name.length <= MAX_FILE_NAME_LENGTH && file.name.none(Char::isISOControl))
-            require(file.etag == null || file.etag.length <= MAX_ETAG_LENGTH && file.etag.none(Char::isISOControl))
-        }
+        files.forEach(::requireValidCachedFile)
         val accountDirectory = accountDirectory(accountId)
         var index = load(accountId)
         val currentByPath = files.associateBy(NextcloudFile::path)
@@ -424,19 +422,180 @@ internal class DesktopFileReadCache(
             listings = boundedListings,
             virtualListings = boundedVirtualListings,
             content = retainedContent,
+            listingShards = emptyList(),
+            virtualListingShards = emptyList(),
         )
+    }
+
+    private fun CacheIndexV1.persistMetadataShards(directory: File): CacheIndexV1 {
+        val ordinaryReferences = listings.flatMap { listing ->
+            val chunks = listing.files.metadataChunks()
+            chunks.mapIndexed { partIndex, files ->
+                val payload = CachedListingShardV1(
+                    path = listing.path,
+                    fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
+                    partIndex = partIndex,
+                    partCount = chunks.size,
+                    files = files,
+                )
+                val encoded = cacheJson.encodeToString(payload).encodeToByteArray()
+                val (blobName, sha256) = publishMetadataShard(directory, encoded)
+                CachedListingShardReferenceV1(
+                    path = listing.path,
+                    fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
+                    partIndex = partIndex,
+                    partCount = chunks.size,
+                    entryCount = files.size,
+                    blobName = blobName,
+                    sha256 = sha256,
+                )
+            }
+        }
+        val virtualReferences = virtualListings.flatMap { listing ->
+            val chunks = listing.nodes.metadataChunks()
+            chunks.mapIndexed { partIndex, nodes ->
+                val payload = CachedVirtualListingShardV1(
+                    path = listing.path,
+                    fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
+                    partIndex = partIndex,
+                    partCount = chunks.size,
+                    nodes = nodes,
+                )
+                val encoded = cacheJson.encodeToString(payload).encodeToByteArray()
+                val (blobName, sha256) = publishMetadataShard(directory, encoded)
+                CachedVirtualListingShardReferenceV1(
+                    path = listing.path,
+                    fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
+                    partIndex = partIndex,
+                    partCount = chunks.size,
+                    entryCount = nodes.size,
+                    blobName = blobName,
+                    sha256 = sha256,
+                )
+            }
+        }
+        return copy(
+            listings = emptyList(),
+            virtualListings = emptyList(),
+            listingShards = ordinaryReferences,
+            virtualListingShards = virtualReferences,
+        ).also { persisted -> persisted.requireValid() }
+    }
+
+    private fun CacheIndexV1.hydrateMetadataShards(directory: File): CacheIndexV1 {
+        val hydratedListings = listingShards
+            .groupBy { reference -> reference.path to reference.fetchedAtEpochMillis }
+            .mapNotNull { (_, references) ->
+                runCatching {
+                    val ordered = references.requireCompleteShardSet()
+                    val files = ordered.flatMap { reference ->
+                        val payload = loadMetadataShard<CachedListingShardV1>(directory, reference.blobName, reference.sha256)
+                        require(
+                            payload.path == reference.path &&
+                                payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
+                                payload.partIndex == reference.partIndex &&
+                                payload.partCount == reference.partCount &&
+                                payload.files.size == reference.entryCount,
+                        ) { "A Files metadata shard does not match its index reference." }
+                        payload.files
+                    }
+                    CachedListingV1(ordered.first().path, ordered.first().fetchedAtEpochMillis, files)
+                }.getOrNull()
+            }
+        val hydratedVirtualListings = virtualListingShards
+            .groupBy { reference -> reference.path to reference.fetchedAtEpochMillis }
+            .mapNotNull { (_, references) ->
+                runCatching {
+                    val ordered = references.requireCompleteVirtualShardSet()
+                    val nodes = ordered.flatMap { reference ->
+                        val payload = loadMetadataShard<CachedVirtualListingShardV1>(
+                            directory,
+                            reference.blobName,
+                            reference.sha256,
+                        )
+                        require(
+                            payload.path == reference.path &&
+                                payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
+                                payload.partIndex == reference.partIndex &&
+                                payload.partCount == reference.partCount &&
+                                payload.nodes.size == reference.entryCount,
+                        ) { "A virtual Files metadata shard does not match its index reference." }
+                        payload.nodes
+                    }
+                    CachedVirtualListingV1(ordered.first().path, ordered.first().fetchedAtEpochMillis, nodes)
+                }.getOrNull()
+            }
+        val hydratedPaths = hydratedListings.mapTo(hashSetOf(), CachedListingV1::path)
+        val hydratedVirtualPaths = hydratedVirtualListings.mapTo(hashSetOf(), CachedVirtualListingV1::path)
+        return copy(
+            listings = listings.filterNot { listing -> listing.path in hydratedPaths } + hydratedListings,
+            virtualListings = virtualListings.filterNot { listing -> listing.path in hydratedVirtualPaths } +
+                hydratedVirtualListings,
+            listingShards = emptyList(),
+            virtualListingShards = emptyList(),
+        )
+    }
+
+    private fun <T> List<T>.metadataChunks(): List<List<T>> =
+        if (isEmpty()) listOf(emptyList()) else chunked(MAX_METADATA_SHARD_ENTRIES)
+
+    private fun publishMetadataShard(directory: File, encoded: ByteArray): Pair<String, String> {
+        require(encoded.size.toLong() <= MAX_METADATA_SHARD_BYTES) { "A Files metadata shard is too large." }
+        val sha256 = sha256Hex(encoded)
+        val blobName = "$sha256.$METADATA_SHARD_EXTENSION"
+        val current = File(directory, blobName)
+        if (!current.isFile || current.length() != encoded.size.toLong() || sha256Hex(current.readBytes()) != sha256) {
+            publishBytes(directory, blobName, encoded)
+        }
+        return blobName to sha256
+    }
+
+    private inline fun <reified T> loadMetadataShard(
+        directory: File,
+        blobName: String,
+        expectedSha256: String,
+    ): T {
+        val shard = File(directory, blobName)
+        require(shard.isFile && shard.length() in 1L..MAX_METADATA_SHARD_BYTES) {
+            "A Files metadata shard is missing or too large."
+        }
+        val bytes = shard.readBytes()
+        require(sha256Hex(bytes) == expectedSha256) { "A Files metadata shard failed integrity validation." }
+        return cacheJson.decodeFromString(bytes.toString(Charsets.UTF_8))
+    }
+
+    private fun List<CachedListingShardReferenceV1>.requireCompleteShardSet(): List<CachedListingShardReferenceV1> {
+        val ordered = sortedBy(CachedListingShardReferenceV1::partIndex)
+        val partCount = ordered.first().partCount
+        require(ordered.size == partCount && ordered.map(CachedListingShardReferenceV1::partIndex) == (0 until partCount).toList())
+        require(ordered.all { reference -> reference.partCount == partCount })
+        return ordered
+    }
+
+    private fun List<CachedVirtualListingShardReferenceV1>.requireCompleteVirtualShardSet(): List<CachedVirtualListingShardReferenceV1> {
+        val ordered = sortedBy(CachedVirtualListingShardReferenceV1::partIndex)
+        val partCount = ordered.first().partCount
+        require(
+            ordered.size == partCount &&
+                ordered.map(CachedVirtualListingShardReferenceV1::partIndex) == (0 until partCount).toList(),
+        )
+        require(ordered.all { reference -> reference.partCount == partCount })
+        return ordered
     }
 
     private fun load(accountId: String): CacheIndexV1 {
         loadedIndexes[accountId]?.let { return it }
         val directory = accountDirectory(accountId)
         val indexFile = File(directory, INDEX_FILE_NAME)
-        val loaded = if (!indexFile.isFile || indexFile.length() !in 1..MAX_INDEX_BYTES) {
+        val loaded = if (!indexFile.isFile || indexFile.length() !in 1..maximumIndexBytes) {
             CacheIndexV1()
         } else {
             runCatching {
                 val decoded = cacheJson.decodeFromString<CacheIndexV1>(indexFile.readText(Charsets.UTF_8))
-                decoded.requireValid().bounded()
+                decoded.requireValid()
+                    .hydrateMetadataShards(directory)
+                    .requireValid()
+                    .bounded()
             }.getOrElse { CacheIndexV1() }
         }
         rememberLoadedIndex(accountId, loaded)
@@ -448,13 +607,21 @@ internal class DesktopFileReadCache(
             check(isDirectory || mkdirs()) { "Could not create the desktop Files cache." }
         }
         val bounded = index.bounded()
-        val encoded = cacheJson.encodeToString(bounded).encodeToByteArray()
-        require(encoded.size.toLong() <= MAX_INDEX_BYTES) { "The Files cache index is too large." }
+        val persisted = bounded.persistMetadataShards(directory)
+        val encoded = cacheJson.encodeToString(persisted).encodeToByteArray()
+        require(encoded.size.toLong() <= maximumIndexBytes) { "The Files cache index is too large." }
         publishBytes(directory, INDEX_FILE_NAME, encoded)
         rememberLoadedIndex(accountId, bounded)
         val referenced = bounded.content.mapTo(hashSetOf(), CachedContentV1::blobName)
         directory.listFiles().orEmpty()
             .filter { file -> file.isFile && file.extension == "blob" && file.name !in referenced }
+            .forEach(File::delete)
+        val referencedMetadata = buildSet {
+            persisted.listingShards.mapTo(this, CachedListingShardReferenceV1::blobName)
+            persisted.virtualListingShards.mapTo(this, CachedVirtualListingShardReferenceV1::blobName)
+        }
+        directory.listFiles().orEmpty()
+            .filter { file -> file.isFile && file.extension == METADATA_SHARD_EXTENSION && file.name !in referencedMetadata }
             .forEach(File::delete)
     }
 
@@ -518,19 +685,34 @@ internal class DesktopFileReadCache(
         require(index.version == FORMAT_VERSION)
         require(index.listings.size <= MAX_LISTINGS)
         require(index.virtualListings.size <= MAX_LISTINGS)
+        require(index.listingShards.size <= MAX_METADATA_SHARDS)
+        require(index.virtualListingShards.size <= MAX_METADATA_SHARDS)
         require(index.content.size <= MAX_CONTENT_ENTRIES)
         require(index.listings.map(CachedListingV1::path).distinct().size == index.listings.size)
         require(index.virtualListings.map(CachedVirtualListingV1::path).distinct().size == index.virtualListings.size)
         require(index.content.map(CachedContentV1::path).distinct().size == index.content.size)
+        require(
+            index.listingShards.map { reference ->
+                "${reference.path}\u0000${reference.fetchedAtEpochMillis}\u0000${reference.partIndex}"
+            }.distinct().size == index.listingShards.size,
+        )
+        require(
+            index.virtualListingShards.map { reference ->
+                "${reference.path}\u0000${reference.fetchedAtEpochMillis}\u0000${reference.partIndex}"
+            }.distinct().size == index.virtualListingShards.size,
+        )
+        require(
+            index.listings.sumOf { listing -> listing.files.size.toLong() } +
+                index.virtualListings.sumOf { listing -> listing.nodes.size.toLong() } +
+                index.listingShards.sumOf { reference -> reference.entryCount.toLong() } +
+                index.virtualListingShards.sumOf { reference -> reference.entryCount.toLong() } <=
+                maximumTotalMetadataEntries.toLong(),
+        )
         index.listings.forEach { listing ->
             require(listing.path.cachePath() == listing.path)
             require(listing.fetchedAtEpochMillis >= 0L)
             require(listing.files.size <= MAX_FILES_PER_LISTING)
-            listing.files.forEach { file ->
-                require(file.path.cachePath() == file.path)
-                require(file.name.length <= MAX_FILE_NAME_LENGTH && file.name.none(Char::isISOControl))
-                require(file.etag == null || file.etag.length <= MAX_ETAG_LENGTH && file.etag.none(Char::isISOControl))
-            }
+            listing.files.forEach(::requireValidCachedFile)
         }
         index.virtualListings.forEach { listing ->
             require(listing.path.cachePath() == listing.path)
@@ -551,6 +733,24 @@ internal class DesktopFileReadCache(
             require(content.storedAtEpochMillis >= 0L)
             require(content.lastAccessedAtEpochMillis >= content.storedAtEpochMillis)
         }
+        index.listingShards.forEach { reference -> reference.requireValid() }
+        index.virtualListingShards.forEach { reference -> reference.requireValid() }
+    }
+
+    private fun CachedListingShardReferenceV1.requireValid() {
+        path.cachePath()
+        require(fetchedAtEpochMillis >= 0L)
+        require(partCount in 1..MAX_METADATA_SHARDS_PER_LISTING && partIndex in 0 until partCount)
+        require(entryCount in 0..MAX_METADATA_SHARD_ENTRIES)
+        require(blobName == "$sha256.$METADATA_SHARD_EXTENSION" && sha256.isSha256Hex())
+    }
+
+    private fun CachedVirtualListingShardReferenceV1.requireValid() {
+        path.cachePath()
+        require(fetchedAtEpochMillis >= 0L)
+        require(partCount in 1..MAX_METADATA_SHARDS_PER_LISTING && partIndex in 0 until partCount)
+        require(entryCount in 0..MAX_METADATA_SHARD_ENTRIES)
+        require(blobName == "$sha256.$METADATA_SHARD_EXTENSION" && sha256.isSha256Hex())
     }
 
     private fun requireValidVirtualNode(node: LinuxVirtualFileNode) {
@@ -559,6 +759,30 @@ internal class DesktopFileReadCache(
         require(node.remoteRevision.isNotBlank() && node.remoteRevision.length <= MAX_ETAG_LENGTH)
         require(node.remoteRevision.none(Char::isISOControl))
         require(node.size >= 0L)
+    }
+
+    private fun requireValidCachedFile(file: NextcloudFile) {
+        require(file.path.cachePath() == file.path) { "A cached file path is not canonical." }
+        require(file.name.length <= MAX_FILE_NAME_LENGTH && file.name.none(Char::isISOControl))
+        require(
+            file.mimeType == null ||
+                file.mimeType.length <= MAX_MIME_TYPE_LENGTH && file.mimeType.none(Char::isISOControl),
+        )
+        require(
+            file.lastModified == null ||
+                file.lastModified.length <= MAX_LAST_MODIFIED_LENGTH && file.lastModified.none(Char::isISOControl),
+        )
+        require(file.etag == null || file.etag.length <= MAX_ETAG_LENGTH && file.etag.none(Char::isISOControl))
+        require(
+            file.permissions == null ||
+                file.permissions.length <= MAX_PERMISSIONS_LENGTH && file.permissions.none(Char::isISOControl),
+        )
+        require(file.checksums.size <= MAX_CHECKSUMS)
+        require(file.checksums.all { checksum ->
+            checksum.length <= MAX_CHECKSUM_LENGTH && checksum.none(Char::isISOControl)
+        })
+        require(file.directoryPreviewFileIds.size <= MAX_DIRECTORY_PREVIEW_FILE_IDS)
+        require(file.size == null || file.size >= 0L)
     }
 
     private fun publishBytes(directory: File, name: String, bytes: ByteArray) {
@@ -591,10 +815,23 @@ internal class DesktopFileReadCache(
         const val MAX_LISTINGS = 256
         const val MAX_FILES_PER_LISTING = 50_000
         const val MAX_TOTAL_METADATA_ENTRIES = 250_000
+        const val MAX_METADATA_SHARD_ENTRIES = 64
+        const val MAX_METADATA_SHARDS_PER_LISTING =
+            (MAX_FILES_PER_LISTING + MAX_METADATA_SHARD_ENTRIES - 1) / MAX_METADATA_SHARD_ENTRIES
+        const val MAX_METADATA_SHARDS =
+            (MAX_TOTAL_METADATA_ENTRIES + MAX_METADATA_SHARD_ENTRIES - 1) / MAX_METADATA_SHARD_ENTRIES +
+                MAX_LISTINGS * 2
+        const val MAX_METADATA_SHARD_BYTES = 4L * 1024L * 1024L
+        const val METADATA_SHARD_EXTENSION = "metadata"
         const val MAX_CONTENT_ENTRIES = 256
         const val MAX_FILE_NAME_LENGTH = 1_024
         const val MAX_ETAG_LENGTH = 4_096
         const val MAX_MIME_TYPE_LENGTH = 512
+        const val MAX_LAST_MODIFIED_LENGTH = 128
+        const val MAX_PERMISSIONS_LENGTH = 256
+        const val MAX_CHECKSUMS = 16
+        const val MAX_CHECKSUM_LENGTH = 512
+        const val MAX_DIRECTORY_PREVIEW_FILE_IDS = 64
         const val DEFAULT_MAXIMUM_ENTRY_BYTES = 512L * 1024L * 1024L
         const val DEFAULT_MAXIMUM_CONTENT_BYTES = 256L * 1024L * 1024L * 1024L
         const val DEFAULT_MAXIMUM_LOADED_ACCOUNT_INDEXES = 4
@@ -649,6 +886,8 @@ private data class CacheIndexV1(
     val listings: List<CachedListingV1> = emptyList(),
     val virtualListings: List<CachedVirtualListingV1> = emptyList(),
     val content: List<CachedContentV1> = emptyList(),
+    val listingShards: List<CachedListingShardReferenceV1> = emptyList(),
+    val virtualListingShards: List<CachedVirtualListingShardReferenceV1> = emptyList(),
 )
 
 @Serializable
@@ -662,6 +901,46 @@ private data class CachedListingV1(
 private data class CachedVirtualListingV1(
     val path: String,
     val fetchedAtEpochMillis: Long,
+    val nodes: List<CachedVirtualFileNodeV1>,
+)
+
+@Serializable
+private data class CachedListingShardReferenceV1(
+    val path: String,
+    val fetchedAtEpochMillis: Long,
+    val partIndex: Int,
+    val partCount: Int,
+    val entryCount: Int,
+    val blobName: String,
+    val sha256: String,
+)
+
+@Serializable
+private data class CachedVirtualListingShardReferenceV1(
+    val path: String,
+    val fetchedAtEpochMillis: Long,
+    val partIndex: Int,
+    val partCount: Int,
+    val entryCount: Int,
+    val blobName: String,
+    val sha256: String,
+)
+
+@Serializable
+private data class CachedListingShardV1(
+    val path: String,
+    val fetchedAtEpochMillis: Long,
+    val partIndex: Int,
+    val partCount: Int,
+    val files: List<NextcloudFile>,
+)
+
+@Serializable
+private data class CachedVirtualListingShardV1(
+    val path: String,
+    val fetchedAtEpochMillis: Long,
+    val partIndex: Int,
+    val partCount: Int,
     val nodes: List<CachedVirtualFileNodeV1>,
 )
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -50,6 +50,8 @@ internal class DesktopFileReadCache(
     private val maximumLoadedAccountIndexes: Int = DEFAULT_MAXIMUM_LOADED_ACCOUNT_INDEXES,
     private val maximumTotalMetadataEntries: Int = MAX_TOTAL_METADATA_ENTRIES,
     private val maximumIndexBytes: Long = MAX_INDEX_BYTES,
+    private val maximumHydratedMetadataBytes: Long = MAX_HYDRATED_METADATA_BYTES,
+    private val metadataShardReadObserver: (File) -> Unit = {},
 ) {
     private val loadedIndexes = LinkedHashMap<String, CacheIndexV1>(16, 0.75f, true)
     init {
@@ -58,6 +60,7 @@ internal class DesktopFileReadCache(
         require(maximumLoadedAccountIndexes > 0)
         require(maximumTotalMetadataEntries >= 2)
         require(maximumIndexBytes in 1L..MAX_INDEX_BYTES)
+        require(maximumHydratedMetadataBytes in 1L..MAX_HYDRATED_METADATA_BYTES)
     }
 
     @Synchronized
@@ -118,6 +121,7 @@ internal class DesktopFileReadCache(
         index = index.copy(
             listings = listings,
             content = index.content.filterNot { cached -> cached in invalidContent },
+            listingShards = index.listingShards.filterNot { reference -> reference.path == normalized },
         ).bounded()
         save(accountId, index)
     }
@@ -176,6 +180,9 @@ internal class DesktopFileReadCache(
                         fetchedAtEpochMillis = fetchedAtEpochMillis,
                         nodes = nodes.map(CachedVirtualFileNodeV1::fromDomain),
                     ),
+                virtualListingShards = index.virtualListingShards.filterNot { reference ->
+                    reference.path == normalized
+                },
             ),
         )
         return true
@@ -422,13 +429,24 @@ internal class DesktopFileReadCache(
             listings = boundedListings,
             virtualListings = boundedVirtualListings,
             content = retainedContent,
-            listingShards = emptyList(),
-            virtualListingShards = emptyList(),
+            listingShards = listingShards.filter { reference ->
+                boundedListings.any { listing ->
+                    listing.path == reference.path &&
+                        listing.fetchedAtEpochMillis == reference.fetchedAtEpochMillis
+                }
+            },
+            virtualListingShards = virtualListingShards.filter { reference ->
+                boundedVirtualListings.any { listing ->
+                    listing.path == reference.path &&
+                        listing.fetchedAtEpochMillis == reference.fetchedAtEpochMillis
+                }
+            },
         )
     }
 
     private fun CacheIndexV1.persistMetadataShards(directory: File): CacheIndexV1 {
         val ordinaryReferences = listings.flatMap { listing ->
+            reusableListingShards(directory, listing)?.let { return@flatMap it }
             val chunks = listing.files.metadataChunks()
             chunks.mapIndexed { partIndex, files ->
                 val payload = CachedListingShardV1(
@@ -452,6 +470,7 @@ internal class DesktopFileReadCache(
             }
         }
         val virtualReferences = virtualListings.flatMap { listing ->
+            reusableVirtualListingShards(directory, listing)?.let { return@flatMap it }
             val chunks = listing.nodes.metadataChunks()
             chunks.mapIndexed { partIndex, nodes ->
                 val payload = CachedVirtualListingShardV1(
@@ -482,14 +501,52 @@ internal class DesktopFileReadCache(
         ).also { persisted -> persisted.requireValid() }
     }
 
+    private fun CacheIndexV1.reusableListingShards(
+        directory: File,
+        listing: CachedListingV1,
+    ): List<CachedListingShardReferenceV1>? {
+        val references = listingShards.filter { reference ->
+            reference.path == listing.path &&
+                reference.fetchedAtEpochMillis == listing.fetchedAtEpochMillis
+        }
+        val ordered = runCatching { references.requireCompleteShardSet() }.getOrNull() ?: return null
+        if (ordered.sumOf(CachedListingShardReferenceV1::entryCount) != listing.files.size) return null
+        return ordered.takeIf { shards -> shards.all { reference -> reference.isAvailableIn(directory) } }
+    }
+
+    private fun CacheIndexV1.reusableVirtualListingShards(
+        directory: File,
+        listing: CachedVirtualListingV1,
+    ): List<CachedVirtualListingShardReferenceV1>? {
+        val references = virtualListingShards.filter { reference ->
+            reference.path == listing.path &&
+                reference.fetchedAtEpochMillis == listing.fetchedAtEpochMillis
+        }
+        val ordered = runCatching { references.requireCompleteVirtualShardSet() }.getOrNull() ?: return null
+        if (ordered.sumOf(CachedVirtualListingShardReferenceV1::entryCount) != listing.nodes.size) return null
+        return ordered.takeIf { shards -> shards.all { reference -> reference.isAvailableIn(directory) } }
+    }
+
+    private fun CachedListingShardReferenceV1.isAvailableIn(directory: File): Boolean =
+        File(directory, blobName).let { shard -> shard.isFile && shard.length() in 1L..MAX_METADATA_SHARD_BYTES }
+
+    private fun CachedVirtualListingShardReferenceV1.isAvailableIn(directory: File): Boolean =
+        File(directory, blobName).let { shard -> shard.isFile && shard.length() in 1L..MAX_METADATA_SHARD_BYTES }
+
     private fun CacheIndexV1.hydrateMetadataShards(directory: File): CacheIndexV1 {
+        val hydrationBudget = MetadataHydrationBudget(maximumHydratedMetadataBytes)
         val hydratedListings = listingShards
             .groupBy { reference -> reference.path to reference.fetchedAtEpochMillis }
             .mapNotNull { (_, references) ->
                 runCatching {
                     val ordered = references.requireCompleteShardSet()
                     val files = ordered.flatMap { reference ->
-                        val payload = loadMetadataShard<CachedListingShardV1>(directory, reference.blobName, reference.sha256)
+                        val payload = loadMetadataShard<CachedListingShardV1>(
+                            directory,
+                            reference.blobName,
+                            reference.sha256,
+                            hydrationBudget,
+                        )
                         require(
                             payload.path == reference.path &&
                                 payload.fetchedAtEpochMillis == reference.fetchedAtEpochMillis &&
@@ -512,6 +569,7 @@ internal class DesktopFileReadCache(
                             directory,
                             reference.blobName,
                             reference.sha256,
+                            hydrationBudget,
                         )
                         require(
                             payload.path == reference.path &&
@@ -531,8 +589,6 @@ internal class DesktopFileReadCache(
             listings = listings.filterNot { listing -> listing.path in hydratedPaths } + hydratedListings,
             virtualListings = virtualListings.filterNot { listing -> listing.path in hydratedVirtualPaths } +
                 hydratedVirtualListings,
-            listingShards = emptyList(),
-            virtualListingShards = emptyList(),
         )
     }
 
@@ -544,7 +600,11 @@ internal class DesktopFileReadCache(
         val sha256 = sha256Hex(encoded)
         val blobName = "$sha256.$METADATA_SHARD_EXTENSION"
         val current = File(directory, blobName)
-        if (!current.isFile || current.length() != encoded.size.toLong() || sha256Hex(current.readBytes()) != sha256) {
+        if (
+            !current.isFile ||
+            current.length() != encoded.size.toLong() ||
+            metadataShardBytes(current).let(::sha256Hex) != sha256
+        ) {
             publishBytes(directory, blobName, encoded)
         }
         return blobName to sha256
@@ -554,14 +614,21 @@ internal class DesktopFileReadCache(
         directory: File,
         blobName: String,
         expectedSha256: String,
+        hydrationBudget: MetadataHydrationBudget,
     ): T {
         val shard = File(directory, blobName)
         require(shard.isFile && shard.length() in 1L..MAX_METADATA_SHARD_BYTES) {
             "A Files metadata shard is missing or too large."
         }
-        val bytes = shard.readBytes()
+        hydrationBudget.reserve(shard.length())
+        val bytes = metadataShardBytes(shard)
         require(sha256Hex(bytes) == expectedSha256) { "A Files metadata shard failed integrity validation." }
         return cacheJson.decodeFromString(bytes.toString(Charsets.UTF_8))
+    }
+
+    private fun metadataShardBytes(shard: File): ByteArray {
+        metadataShardReadObserver(shard)
+        return shard.readBytes()
     }
 
     private fun List<CachedListingShardReferenceV1>.requireCompleteShardSet(): List<CachedListingShardReferenceV1> {
@@ -701,13 +768,23 @@ internal class DesktopFileReadCache(
                 "${reference.path}\u0000${reference.fetchedAtEpochMillis}\u0000${reference.partIndex}"
             }.distinct().size == index.virtualListingShards.size,
         )
-        require(
-            index.listings.sumOf { listing -> listing.files.size.toLong() } +
-                index.virtualListings.sumOf { listing -> listing.nodes.size.toLong() } +
-                index.listingShards.sumOf { reference -> reference.entryCount.toLong() } +
-                index.virtualListingShards.sumOf { reference -> reference.entryCount.toLong() } <=
-                maximumTotalMetadataEntries.toLong(),
-        )
+        val ordinaryEntries = mutableMapOf<String, Long>()
+        index.listings.forEach { listing -> ordinaryEntries[listing.path] = listing.files.size.toLong() }
+        index.listingShards.groupBy(CachedListingShardReferenceV1::path).forEach { (path, references) ->
+            ordinaryEntries[path] = maxOf(
+                ordinaryEntries[path] ?: 0L,
+                references.sumOf { reference -> reference.entryCount.toLong() },
+            )
+        }
+        val virtualEntries = mutableMapOf<String, Long>()
+        index.virtualListings.forEach { listing -> virtualEntries[listing.path] = listing.nodes.size.toLong() }
+        index.virtualListingShards.groupBy(CachedVirtualListingShardReferenceV1::path).forEach { (path, references) ->
+            virtualEntries[path] = maxOf(
+                virtualEntries[path] ?: 0L,
+                references.sumOf { reference -> reference.entryCount.toLong() },
+            )
+        }
+        require(ordinaryEntries.values.sum() + virtualEntries.values.sum() <= maximumTotalMetadataEntries.toLong())
         index.listings.forEach { listing ->
             require(listing.path.cachePath() == listing.path)
             require(listing.fetchedAtEpochMillis >= 0L)
@@ -822,6 +899,7 @@ internal class DesktopFileReadCache(
             (MAX_TOTAL_METADATA_ENTRIES + MAX_METADATA_SHARD_ENTRIES - 1) / MAX_METADATA_SHARD_ENTRIES +
                 MAX_LISTINGS * 2
         const val MAX_METADATA_SHARD_BYTES = 4L * 1024L * 1024L
+        const val MAX_HYDRATED_METADATA_BYTES = 32L * 1024L * 1024L
         const val METADATA_SHARD_EXTENSION = "metadata"
         const val MAX_CONTENT_ENTRIES = 256
         const val MAX_FILE_NAME_LENGTH = 1_024
@@ -976,6 +1054,17 @@ private data class CachedContentV1(
     val storedAtEpochMillis: Long,
     val lastAccessedAtEpochMillis: Long = storedAtEpochMillis,
 )
+
+private class MetadataHydrationBudget(private val maximumBytes: Long) {
+    private var reservedBytes = 0L
+
+    fun reserve(bytes: Long) {
+        require(bytes > 0L && bytes <= maximumBytes - reservedBytes) {
+            "The Files metadata hydration budget was exceeded."
+        }
+        reservedBytes += bytes
+    }
+}
 
 private val cacheJson = Json {
     encodeDefaults = true

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -55,6 +55,9 @@ internal class DesktopFileReadCache(
 ) {
     private val loadedIndexes = LinkedHashMap<String, CacheIndexV1>(16, 0.75f, true)
     private val failedVirtualListingInvalidations = mutableMapOf<String, Set<String>>()
+    private val virtualListingInvalidationPreferences = preferences.node(
+        "linux-virtual-metadata-invalidations-v1",
+    )
     init {
         require(maximumContentBytes > 0L)
         require(maximumEntryBytes in 1L..maximumContentBytes)
@@ -114,13 +117,27 @@ internal class DesktopFileReadCache(
     }
 
     @Synchronized
-    fun failedVirtualListingInvalidations(accountId: String): Set<String> =
-        failedVirtualListingInvalidations[accountId].orEmpty().toSet()
+    fun failedVirtualListingInvalidations(accountId: String): Set<String> {
+        failedVirtualListingInvalidations[accountId]?.let { return it.toSet() }
+        return if (virtualListingInvalidationPreferences.getBoolean(accountId, false)) {
+            setOf("")
+        } else {
+            emptySet()
+        }
+    }
 
     @Synchronized
     fun replaceFailedVirtualListingInvalidations(accountId: String, paths: Set<String>) {
-        if (paths.isEmpty()) failedVirtualListingInvalidations.remove(accountId)
-        else failedVirtualListingInvalidations[accountId] = paths.toSet()
+        if (paths.isEmpty()) {
+            failedVirtualListingInvalidations.remove(accountId)
+            virtualListingInvalidationPreferences.remove(accountId)
+        } else {
+            failedVirtualListingInvalidations[accountId] = paths.toSet()
+            // One durable bit deliberately quarantines every persisted virtual listing for this
+            // account. It remains safe and bounded even when thousands of paths were affected.
+            virtualListingInvalidationPreferences.putBoolean(accountId, true)
+        }
+        virtualListingInvalidationPreferences.flush()
     }
 
     @Synchronized

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -56,6 +56,10 @@ internal class DesktopFileReadCache(
         cachedListingSnapshot(accountId, path)?.files
 
     @Synchronized
+    fun cachedListingPaths(accountId: String): Set<String> =
+        load(accountId).listings.mapTo(linkedSetOf()) { listing -> listing.path }
+
+    @Synchronized
     fun cachedListingSnapshot(accountId: String, path: String): DesktopCachedFileListing? {
         val normalized = path.cachePath()
         return load(accountId).listings.firstOrNull { it.path == normalized }?.let { listing ->

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCache.kt
@@ -21,6 +21,11 @@ internal data class DesktopCachedFileListing(
     val fetchedAtEpochMillis: Long,
 )
 
+internal data class DesktopCachedVirtualListing(
+    val nodes: List<LinuxVirtualFileNode>,
+    val fetchedAtEpochMillis: Long,
+)
+
 internal data class DesktopVirtualFileCacheSummary(
     val policy: VirtualFileCachePolicy,
     val cachedBytes: Long,
@@ -64,6 +69,21 @@ internal class DesktopFileReadCache(
         val normalized = path.cachePath()
         return load(accountId).listings.firstOrNull { it.path == normalized }?.let { listing ->
             DesktopCachedFileListing(listing.files, listing.fetchedAtEpochMillis)
+        }
+    }
+
+    @Synchronized
+    fun cachedVirtualListingPaths(accountId: String): Set<String> =
+        load(accountId).virtualListings.mapTo(linkedSetOf()) { listing -> listing.path }
+
+    @Synchronized
+    fun cachedVirtualListingSnapshot(accountId: String, path: String): DesktopCachedVirtualListing? {
+        val normalized = path.cachePath()
+        return load(accountId).virtualListings.firstOrNull { it.path == normalized }?.let { listing ->
+            DesktopCachedVirtualListing(
+                nodes = listing.nodes.map(CachedVirtualFileNodeV1::toDomain),
+                fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
+            )
         }
     }
 
@@ -122,6 +142,42 @@ internal class DesktopFileReadCache(
             return false
         }
         storeListing(accountId, normalized, files, fetchedAtEpochMillis)
+        return true
+    }
+
+    @Synchronized
+    fun storeVirtualListingUnlessNewer(
+        accountId: String,
+        path: String,
+        nodes: List<LinuxVirtualFileNode>,
+        fetchedAtEpochMillis: Long,
+        nowEpochMillis: Long = System.currentTimeMillis(),
+    ): Boolean {
+        require(fetchedAtEpochMillis >= 0L)
+        require(nowEpochMillis >= 0L)
+        require(nodes.size <= MAX_FILES_PER_LISTING) { "The folder contains too many cacheable entries." }
+        val normalized = path.cachePath()
+        nodes.forEach(::requireValidVirtualNode)
+        val index = load(accountId)
+        val current = index.virtualListings.firstOrNull { listing -> listing.path == normalized }
+        if (
+            current != null &&
+            current.fetchedAtEpochMillis <= nowEpochMillis &&
+            current.fetchedAtEpochMillis >= fetchedAtEpochMillis
+        ) {
+            return false
+        }
+        save(
+            accountId,
+            index.copy(
+                virtualListings = index.virtualListings.filterNot { it.path == normalized } +
+                    CachedVirtualListingV1(
+                        path = normalized,
+                        fetchedAtEpochMillis = fetchedAtEpochMillis,
+                        nodes = nodes.map(CachedVirtualFileNodeV1::fromDomain),
+                    ),
+            ),
+        )
         return true
     }
 
@@ -283,6 +339,14 @@ internal class DesktopFileReadCache(
                         listing.path == parent ||
                         normalized.startsWith("${listing.path}/")
                 },
+                virtualListings = index.virtualListings.filterNot { listing ->
+                    normalized.isEmpty() ||
+                        listing.path.isEmpty() ||
+                        listing.path == normalized ||
+                        listing.path.startsWith("$normalized/") ||
+                        listing.path == parent ||
+                        normalized.startsWith("${listing.path}/")
+                },
                 content = index.content.filterNot { it in removed },
             ),
         )
@@ -297,6 +361,16 @@ internal class DesktopFileReadCache(
                     if (retainedMetadataEntries + listing.files.size <= MAX_TOTAL_METADATA_ENTRIES) {
                         add(listing)
                         retainedMetadataEntries += listing.files.size
+                    }
+                }
+        }
+        val boundedVirtualListings = buildList {
+            virtualListings.sortedByDescending(CachedVirtualListingV1::fetchedAtEpochMillis)
+                .take(MAX_LISTINGS)
+                .forEach { listing ->
+                    if (retainedMetadataEntries + listing.nodes.size <= MAX_TOTAL_METADATA_ENTRIES) {
+                        add(listing)
+                        retainedMetadataEntries += listing.nodes.size
                     }
                 }
         }
@@ -318,7 +392,11 @@ internal class DesktopFileReadCache(
                 }
             }
             .take(MAX_CONTENT_ENTRIES)
-        return copy(listings = boundedListings, content = retainedContent)
+        return copy(
+            listings = boundedListings,
+            virtualListings = boundedVirtualListings,
+            content = retainedContent,
+        )
     }
 
     private fun load(accountId: String): CacheIndexV1 {
@@ -411,8 +489,10 @@ internal class DesktopFileReadCache(
     private fun CacheIndexV1.requireValid(): CacheIndexV1 = also { index ->
         require(index.version == FORMAT_VERSION)
         require(index.listings.size <= MAX_LISTINGS)
+        require(index.virtualListings.size <= MAX_LISTINGS)
         require(index.content.size <= MAX_CONTENT_ENTRIES)
         require(index.listings.map(CachedListingV1::path).distinct().size == index.listings.size)
+        require(index.virtualListings.map(CachedVirtualListingV1::path).distinct().size == index.virtualListings.size)
         require(index.content.map(CachedContentV1::path).distinct().size == index.content.size)
         index.listings.forEach { listing ->
             require(listing.path.cachePath() == listing.path)
@@ -423,6 +503,12 @@ internal class DesktopFileReadCache(
                 require(file.name.length <= MAX_FILE_NAME_LENGTH && file.name.none(Char::isISOControl))
                 require(file.etag == null || file.etag.length <= MAX_ETAG_LENGTH && file.etag.none(Char::isISOControl))
             }
+        }
+        index.virtualListings.forEach { listing ->
+            require(listing.path.cachePath() == listing.path)
+            require(listing.fetchedAtEpochMillis >= 0L)
+            require(listing.nodes.size <= MAX_FILES_PER_LISTING)
+            listing.nodes.forEach { node -> requireValidVirtualNode(node.toDomain()) }
         }
         index.content.forEach { content ->
             require(content.path.cachePath() == content.path)
@@ -437,6 +523,14 @@ internal class DesktopFileReadCache(
             require(content.storedAtEpochMillis >= 0L)
             require(content.lastAccessedAtEpochMillis >= content.storedAtEpochMillis)
         }
+    }
+
+    private fun requireValidVirtualNode(node: LinuxVirtualFileNode) {
+        require(node.path.cachePath() == node.path)
+        require(node.name.length <= MAX_FILE_NAME_LENGTH && node.name.none(Char::isISOControl))
+        require(node.remoteRevision.isNotBlank() && node.remoteRevision.length <= MAX_ETAG_LENGTH)
+        require(node.remoteRevision.none(Char::isISOControl))
+        require(node.size >= 0L)
     }
 
     private fun publishBytes(directory: File, name: String, bytes: ByteArray) {
@@ -525,6 +619,7 @@ private fun String.isSha256Hex(): Boolean =
 private data class CacheIndexV1(
     val version: Int = 1,
     val listings: List<CachedListingV1> = emptyList(),
+    val virtualListings: List<CachedVirtualListingV1> = emptyList(),
     val content: List<CachedContentV1> = emptyList(),
 )
 
@@ -534,6 +629,34 @@ private data class CachedListingV1(
     val fetchedAtEpochMillis: Long,
     val files: List<NextcloudFile>,
 )
+
+@Serializable
+private data class CachedVirtualListingV1(
+    val path: String,
+    val fetchedAtEpochMillis: Long,
+    val nodes: List<CachedVirtualFileNodeV1>,
+)
+
+@Serializable
+private data class CachedVirtualFileNodeV1(
+    val path: String,
+    val name: String,
+    val directory: Boolean,
+    val size: Long,
+    val remoteRevision: String,
+) {
+    fun toDomain(): LinuxVirtualFileNode = LinuxVirtualFileNode(path, name, directory, size, remoteRevision)
+
+    companion object {
+        fun fromDomain(node: LinuxVirtualFileNode): CachedVirtualFileNodeV1 = CachedVirtualFileNodeV1(
+            path = node.path,
+            name = node.name,
+            directory = node.directory,
+            size = node.size,
+            remoteRevision = node.remoteRevision,
+        )
+    }
+}
 
 @Serializable
 private data class CachedContentV1(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncEngine.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncEngine.kt
@@ -17,6 +17,8 @@ internal class DesktopFileSyncEngine(
     private val store: DesktopFileSyncStore = DesktopFileSyncStore(),
     private val stagingRoot: File = desktopFileSyncStagingDirectory(),
     private val minimumFreeSpaceBytes: () -> Long = { 0L },
+    private val onRemoteMutationCommitted: (session: NextcloudSession, userId: String, path: String) -> Unit =
+        { _, _, _ -> },
 ) {
     private val selectedRoots = ConcurrentHashMap<String, File>()
     private val lock = Mutex()
@@ -256,7 +258,15 @@ internal class DesktopFileSyncEngine(
         val root = persisted.roots.firstOrNull { it.id == initialPair.localRootId }
             ?: return FileSyncCenterActionResult.Rejected("The local folder record is missing.")
         val local = DesktopFileSyncLocalTree(File(root.absolutePath))
-        val remote = DesktopFileSyncRemoteTree(session, userId, initialPair.remoteRootPath)
+        val remote = DesktopFileSyncRemoteTree(
+            session = session,
+            userId = userId,
+            remoteRootPath = initialPair.remoteRootPath,
+            onMutationCommitted = { relativePath ->
+                val path = desktopFileSyncRemoteMutationPath(initialPair.remoteRootPath, relativePath)
+                runCatching { onRemoteMutationCommitted(session, userId, path) }
+            },
+        )
         val includes: (String, SyncEntryKind) -> Boolean = { path, kind ->
             initialPair.configuration.includesSyncPath(path, kind)
         }
@@ -690,6 +700,14 @@ internal class DesktopFileSyncEngine(
     private companion object {
         const val MAX_SYNC_FILE_BYTES = 8L * 1024L * 1024L * 1024L
     }
+}
+
+internal fun desktopFileSyncRemoteMutationPath(remoteRootPath: String, relativePath: String): String {
+    val relative = relativePath.trim('/')
+    requireValidSyncPath(relative)
+    val root = remoteRootPath.trim('/')
+    if (root.isNotEmpty()) requireValidSyncPath(root)
+    return listOf(root, relative).filter(String::isNotBlank).joinToString("/")
 }
 
 internal fun reclaimDesktopFileSyncStages(stagingRoot: File): Int {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -79,6 +79,23 @@ internal class DesktopFileSyncRemoteTree(
         }.sortedBy { it.entry.relativePath }
     }
 
+    fun isDirectoryEmpty(relativeDirectoryPath: String, expectedRemoteEtag: String): Boolean {
+        val normalizedDirectory = relativeDirectoryPath.trim('/')
+        requireValidSyncPath(normalizedDirectory)
+        val fullDirectoryPath = fullPath(normalizedDirectory)
+        val documents = executeDirectoryListing(directoryListingRequest(fullDirectoryPath))
+        val directory = requireNotNull(
+            documents.singleOrNull { document -> document.entry.relativePath == fullDirectoryPath },
+        ) { "The server folder disappeared before it could be changed." }
+        require(directory.isDirectory && directory.entry.etag == expectedRemoteEtag) {
+            "The server folder changed before it could be changed."
+        }
+        return documents.none { document ->
+            document.entry.relativePath != fullDirectoryPath &&
+                document.entry.relativePath.substringBeforeLast('/', "") == fullDirectoryPath
+        }
+    }
+
     override fun stageDownload(
         relativePath: String,
         expectedRemoteEtag: String,
@@ -307,18 +324,18 @@ internal class DesktopFileSyncRemoteTree(
     }
 
     private fun rawListDirectory(path: String): List<DesktopRemoteSyncDocument> {
-        val documents = executeDirectoryListing(
-            requestBuilder(fileUrl(path))
-                .header("Accept", "application/xml")
-                .header("Depth", "1")
-                .method("PROPFIND", DIRECTORY_PROPERTIES.toRequestBody(XML_CONTENT_TYPE))
-                .build(),
-        )
+        val documents = executeDirectoryListing(directoryListingRequest(path))
         val parent = path.trim('/')
         return documents
             .filter { it.entry.relativePath.substringBeforeLast('/', "") == parent }
             .also { require(it.size <= MAX_CHILDREN + MAX_RECOVERY_ITEMS) { "A Nextcloud folder contains too many entries." } }
     }
+
+    private fun directoryListingRequest(path: String): Request = requestBuilder(fileUrl(path))
+        .header("Accept", "application/xml")
+        .header("Depth", "1")
+        .method("PROPFIND", DIRECTORY_PROPERTIES.toRequestBody(XML_CONTENT_TYPE))
+        .build()
 
     private fun executeDirectoryListing(request: Request): List<DesktopRemoteSyncDocument> =
         client.newCall(request).execute().use { response ->
@@ -464,10 +481,11 @@ internal class DesktopFileSyncRemoteTree(
     ): String? = mutationExecutor.execute(
         request = request,
         onAmbiguousNetworkResult = { notifyAmbiguousMutationResult(*mutationRelativePaths) },
+        onAcceptedResponse = { notifyMutationCommitted(*mutationRelativePaths) },
     ) { response ->
             require(response.code in 200..299) { response.failure(operation) }
             response.header("ETag") ?: response.header("OC-Etag")
-        }.also { notifyMutationCommitted(*mutationRelativePaths) }
+        }
 
     private fun executeMutation(
         request: Request,
@@ -478,11 +496,12 @@ internal class DesktopFileSyncRemoteTree(
     ): ByteArray = mutationExecutor.execute(
         request = request,
         onAmbiguousNetworkResult = { notifyAmbiguousMutationResult(*mutationRelativePaths) },
+        onAcceptedResponse = { notifyMutationCommitted(*mutationRelativePaths) },
     ) { response ->
         val accepted = expectedStatus?.let { response.code == it } ?: (response.code in 200..299)
         require(accepted) { response.failure(operation) }
         response.body.byteStream().readBounded(maximumResponseBytes)
-    }.also { notifyMutationCommitted(*mutationRelativePaths) }
+    }
 
     private fun execute(
         request: Request,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -639,6 +639,7 @@ private fun parseDesktopSyncDav(
         StandardCharsets.UTF_8.name(),
     )
     val documents = ArrayList<DesktopRemoteSyncDocument>()
+    var responseCount = 0
     var response: DesktopDavResponseBuilder? = null
     var textField: String? = null
     val text = StringBuilder()
@@ -648,7 +649,13 @@ private fun parseDesktopSyncDav(
                 XMLStreamConstants.START_ELEMENT -> {
                     if (reader.namespaceURI == DAV_NAMESPACE) {
                         when (reader.localName) {
-                            "response" -> response = DesktopDavResponseBuilder()
+                            "response" -> {
+                                require(responseCount < maximumDocuments) {
+                                    "A Nextcloud folder contains too many entries."
+                                }
+                                responseCount += 1
+                                response = DesktopDavResponseBuilder()
+                            }
                             "href", "getetag", "getcontentlength", "getlastmodified" -> if (response != null) {
                                 textField = reader.localName
                                 text.clear()

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -507,11 +507,11 @@ internal fun desktopOwnedBackupRecoveryPlan(
 ): List<Pair<String, String>> {
     require(maximumRecoveryItems >= 0)
     val listedPaths = relativePaths.toHashSet()
-    val backups = relativePaths.mapNotNull { source ->
+    val recoveries = relativePaths.mapNotNull { source ->
         desktopOwnedBackupDestination(source)?.let { destination -> source to destination }
-    }
-    require(backups.size <= maximumRecoveryItems) { "A Nextcloud folder contains too many recovery items." }
-    return backups.filterNot { (_, destination) -> destination in listedPaths }
+    }.filterNot { (_, destination) -> destination in listedPaths }
+    require(recoveries.size <= maximumRecoveryItems) { "A Nextcloud folder contains too many recovery items." }
+    return recoveries
 }
 
 internal fun parseDesktopSyncDav(
@@ -536,7 +536,7 @@ private fun parseDesktopSyncDav(
         setProperty(XMLInputFactory.IS_COALESCING, false)
     }
     val reader = factory.createXMLStreamReader(
-        RejectingXmlCdataInputStream(BoundedInputStream(input, maximumBytes)),
+        GuardedXmlInputStream(BoundedInputStream(input, maximumBytes)),
         StandardCharsets.UTF_8.name(),
     )
     val documents = ArrayList<DesktopRemoteSyncDocument>()
@@ -659,8 +659,12 @@ private class BoundedInputStream(
     }
 }
 
-private class RejectingXmlCdataInputStream(input: InputStream) : FilterInputStream(input) {
-    private var matchedPrefixBytes = 0
+private class GuardedXmlInputStream(input: InputStream) : FilterInputStream(input) {
+    private var insideMarkup = false
+    private var markupBytes = 0
+    private var quote: Byte? = null
+    private var previous: Byte? = null
+    private var markupCount = 0
 
     override fun read(): Int = super.read().also { value ->
         if (value >= 0) inspect(value.toByte())
@@ -686,16 +690,32 @@ private class RejectingXmlCdataInputStream(input: InputStream) : FilterInputStre
     }
 
     private fun inspect(value: Byte) {
-        if (value == CDATA_PREFIX[matchedPrefixBytes]) {
-            matchedPrefixBytes += 1
-            require(matchedPrefixBytes < CDATA_PREFIX.size) { "DAV CDATA properties are not supported." }
-        } else {
-            matchedPrefixBytes = if (value == CDATA_PREFIX[0]) 1 else 0
+        if (!insideMarkup) {
+            if (value == '<'.code.toByte()) {
+                insideMarkup = true
+                markupBytes = 1
+                markupCount += 1
+            }
+            previous = value
+            return
         }
-    }
-
-    private companion object {
-        val CDATA_PREFIX = "<![CDATA[".encodeToByteArray()
+        markupBytes += 1
+        require(markupBytes <= MAX_XML_MARKUP_BYTES) { "A DAV XML token is too large." }
+        if (previous == '<'.code.toByte()) {
+            require(value != '!'.code.toByte()) { "DAV XML declarations are not supported." }
+            require(value != '?'.code.toByte() || markupCount == 1) {
+                "DAV XML processing instructions are not supported."
+            }
+        }
+        if (quote == null && (value == '\''.code.toByte() || value == '"'.code.toByte())) {
+            quote = value
+        } else if (quote == value) {
+            quote = null
+        } else if (quote == null && value == '>'.code.toByte()) {
+            insideMarkup = false
+            markupBytes = 0
+        }
+        previous = value
     }
 }
 
@@ -731,5 +751,6 @@ private fun desktopFileSyncHttpClient(): OkHttpClient = OkHttpClient.Builder()
     .build()
 
 private const val MAX_DAV_PROPERTY_CHARS = 16_384
+private const val MAX_XML_MARKUP_BYTES = 16_384
 private const val MAX_PARSED_DAV_DOCUMENTS = 50_032
 private const val DAV_NAMESPACE = "DAV:"

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -771,6 +771,9 @@ private class GuardedXmlInputStream(input: InputStream) : FilterInputStream(inpu
     private var quote: Byte? = null
     private var previous: Byte? = null
     private var markupCount = 0
+    private var cdataPrefixIndex = -1
+    private var insideCdata = false
+    private var cdataClosingBrackets = 0
 
     override fun read(): Int = super.read().also { value ->
         if (value >= 0) inspect(value.toByte())
@@ -796,6 +799,17 @@ private class GuardedXmlInputStream(input: InputStream) : FilterInputStream(inpu
     }
 
     private fun inspect(value: Byte) {
+        if (insideCdata) {
+            when {
+                value == ']'.code.toByte() -> cdataClosingBrackets = (cdataClosingBrackets + 1).coerceAtMost(2)
+                value == '>'.code.toByte() && cdataClosingBrackets == 2 -> {
+                    insideCdata = false
+                    cdataClosingBrackets = 0
+                }
+                else -> cdataClosingBrackets = 0
+            }
+            return
+        }
         if (!insideMarkup) {
             if (value == '<'.code.toByte()) {
                 insideMarkup = true
@@ -807,8 +821,26 @@ private class GuardedXmlInputStream(input: InputStream) : FilterInputStream(inpu
         }
         markupBytes += 1
         require(markupBytes <= MAX_XML_MARKUP_BYTES) { "A DAV XML token is too large." }
+        if (cdataPrefixIndex >= 0) {
+            require(value == CDATA_PREFIX[cdataPrefixIndex].code.toByte()) {
+                "DAV XML declarations are not supported."
+            }
+            cdataPrefixIndex += 1
+            if (cdataPrefixIndex == CDATA_PREFIX.length) {
+                cdataPrefixIndex = -1
+                insideMarkup = false
+                insideCdata = true
+                markupBytes = 0
+            }
+            previous = value
+            return
+        }
         if (previous == '<'.code.toByte()) {
-            require(value != '!'.code.toByte()) { "DAV XML declarations are not supported." }
+            if (value == '!'.code.toByte()) {
+                cdataPrefixIndex = 0
+                previous = value
+                return
+            }
             require(value != '?'.code.toByte() || markupCount == 1) {
                 "DAV XML processing instructions are not supported."
             }
@@ -822,6 +854,10 @@ private class GuardedXmlInputStream(input: InputStream) : FilterInputStream(inpu
             markupBytes = 0
         }
         previous = value
+    }
+
+    private companion object {
+        const val CDATA_PREFIX = "[CDATA["
     }
 }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -308,6 +308,7 @@ internal class DesktopFileSyncRemoteTree(
                 input = response.body.byteStream(),
                 userId = userId,
                 maximumBytes = MAX_DIRECTORY_RESPONSE_BYTES,
+                maximumDocuments = MAX_CHILDREN + MAX_RECOVERY_ITEMS,
             )
         }
 
@@ -502,16 +503,21 @@ internal fun shouldSuppressDesktopOwnedBackup(
     return destination !in listedPaths
 }
 
-internal fun parseDesktopSyncDav(bytes: ByteArray, userId: String): List<DesktopRemoteSyncDocument> {
-    return parseDesktopSyncDav(ByteArrayInputStream(bytes), userId, bytes.size.toLong())
+internal fun parseDesktopSyncDav(
+    bytes: ByteArray,
+    userId: String,
+    maximumDocuments: Int = MAX_PARSED_DAV_DOCUMENTS,
+): List<DesktopRemoteSyncDocument> {
+    return parseDesktopSyncDav(ByteArrayInputStream(bytes), userId, bytes.size.toLong(), maximumDocuments)
 }
 
 private fun parseDesktopSyncDav(
     input: InputStream,
     userId: String,
     maximumBytes: Long,
+    maximumDocuments: Int,
 ): List<DesktopRemoteSyncDocument> {
-    require(maximumBytes > 0L)
+    require(maximumBytes > 0L && maximumDocuments > 0)
     val factory = XMLInputFactory.newFactory().apply {
         setProperty(XMLInputFactory.SUPPORT_DTD, false)
         setProperty("javax.xml.stream.isSupportingExternalEntities", false)
@@ -551,7 +557,12 @@ private fun parseDesktopSyncDav(
                         text.clear()
                     }
                     if (reader.namespaceURI == DAV_NAMESPACE && reader.localName == "response") {
-                        response?.toDocument(userId)?.let(documents::add)
+                        response?.toDocument(userId)?.let { document ->
+                            require(documents.size < maximumDocuments) {
+                                "A Nextcloud folder contains too many entries."
+                            }
+                            documents.add(document)
+                        }
                         response = null
                     }
                 }
@@ -663,4 +674,5 @@ private fun desktopFileSyncHttpClient(): OkHttpClient = OkHttpClient.Builder()
     .build()
 
 private const val MAX_DAV_PROPERTY_CHARS = 16_384
+private const val MAX_PARSED_DAV_DOCUMENTS = 50_032
 private const val DAV_NAMESPACE = "DAV:"

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -32,6 +32,7 @@ internal class DesktopFileSyncRemoteTree(
     private val userId: String,
     remoteRootPath: String,
     private val client: OkHttpClient = desktopFileSyncHttpClient(),
+    private val onMutationCommitted: (relativePath: String) -> Unit = {},
 ) : LinuxVirtualWritebackRemote {
     private val rootPath = remoteRootPath.trim('/')
 
@@ -136,6 +137,7 @@ internal class DesktopFileSyncRemoteTree(
                 .build(),
             "create folder",
         )
+        notifyMutationCommitted(relativePath)
     }
 
     fun replaceWithDirectory(relativePath: String, expectedRemoteEtag: String) {
@@ -155,11 +157,13 @@ internal class DesktopFileSyncRemoteTree(
                     .build(),
                 "replace item with folder",
             )
+            notifyMutationCommitted(relativePath)
             require(resolve(relativePath)?.isDirectory == true) {
                 "The replacement server folder could not be verified."
             }
         } catch (failure: Throwable) {
             restoreRemoteBackup(destinationPath, backupPath)
+            notifyMutationCommitted(relativePath)
             throw failure
         }
         deleteRemoteBackup(backupPath)
@@ -177,6 +181,7 @@ internal class DesktopFileSyncRemoteTree(
             }
             replaceFileAtomically(fullPath(relativePath), source, expectedRemoteEtag)
         }
+        notifyMutationCommitted(relativePath)
         val after = requireNotNull(resolve(relativePath)) { "The uploaded server file disappeared." }
         require(!after.isDirectory) { "The uploaded server item is not a file." }
         return after.entry
@@ -205,12 +210,14 @@ internal class DesktopFileSyncRemoteTree(
                 sourceEtag = stagedEtag,
                 sourceIsDirectory = false,
             )
+            notifyMutationCommitted(relativePath)
             val after = requireNotNull(resolve(relativePath)) { "The uploaded server file disappeared." }
             require(!after.isDirectory) { "The uploaded server item is not a file." }
             deleteRemoteBackup(backupPath)
             return after.entry
         } catch (failure: Throwable) {
             if (protected) restoreRemoteBackup(destinationPath, backupPath)
+            if (protected) notifyMutationCommitted(relativePath)
             deleteRemoteStage(stagingPath, stagedEtag)
             throw failure
         }
@@ -224,6 +231,7 @@ internal class DesktopFileSyncRemoteTree(
         if (current.isDirectory) builder.header("If", "<$url> ([$expectedRemoteEtag])")
         else builder.header("If-Match", safeEtag(expectedRemoteEtag))
         execute(builder.delete().build(), "delete item")
+        notifyMutationCommitted(relativePath)
     }
 
     fun move(sourceRelativePath: String, destinationRelativePath: String, expectedRemoteEtag: String) {
@@ -233,6 +241,7 @@ internal class DesktopFileSyncRemoteTree(
         val current = requireNotNull(resolve(sourceRelativePath)) { "The server item was already removed." }
         require(current.entry.etag == expectedRemoteEtag) { "The server item changed before it could be moved." }
         moveRemoteDocument(current.withPath(fullPath(sourceRelativePath)), fullPath(destinationRelativePath))
+        notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
     }
 
     fun moveReplacing(
@@ -258,12 +267,14 @@ internal class DesktopFileSyncRemoteTree(
         moveRemoteDocument(destination.withPath(destinationPath), backupPath)
         try {
             moveRemoteDocument(source.withPath(sourcePath), destinationPath)
+            notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
             val published = requireNotNull(resolve(destinationRelativePath)) {
                 "The moved server item could not be verified."
             }
             require(published.isDirectory == source.isDirectory) { "The moved server item type changed." }
         } catch (failure: Throwable) {
             restoreRemoteBackup(destinationPath, backupPath)
+            notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
             throw failure
         }
         deleteRemoteBackup(backupPath)
@@ -275,6 +286,7 @@ internal class DesktopFileSyncRemoteTree(
         val documentsByPath = documents.associateBy { document -> document.entry.relativePath }
         desktopOwnedBackupRecoveryPlan(documentsByPath.keys, MAX_RECOVERY_ITEMS).forEach { (source, destination) ->
             moveRemoteDocument(requireNotNull(documentsByPath[source]), destination)
+            toRelativePath(destination)?.let(::notifyMutationCommitted)
             recovered = true
         }
         if (recovered) documents = rawListDirectory(path)
@@ -447,6 +459,12 @@ internal class DesktopFileSyncRemoteTree(
         val normalized = fullPath.trim('/')
         if (rootPath.isBlank()) return normalized.takeIf(String::isNotBlank)
         return normalized.removePrefix("$rootPath/").takeIf { normalized.startsWith("$rootPath/") && it.isNotBlank() }
+    }
+
+    private fun notifyMutationCommitted(vararg relativePaths: String) {
+        relativePaths.asSequence().map(String::trim).map { it.trim('/') }
+            .filter(String::isNotBlank).distinct()
+            .forEach { path -> runCatching { onMutationCommitted(path) } }
     }
 
     private fun safeEtag(value: String): String = value.also {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -522,7 +522,7 @@ private fun parseDesktopSyncDav(
         setProperty(XMLInputFactory.SUPPORT_DTD, false)
         setProperty("javax.xml.stream.isSupportingExternalEntities", false)
         setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true)
-        setProperty(XMLInputFactory.IS_COALESCING, true)
+        setProperty(XMLInputFactory.IS_COALESCING, false)
     }
     val reader = factory.createXMLStreamReader(BoundedInputStream(input, maximumBytes))
     val documents = ArrayList<DesktopRemoteSyncDocument>()
@@ -547,8 +547,11 @@ private fun parseDesktopSyncDav(
                 XMLStreamConstants.CHARACTERS,
                 XMLStreamConstants.CDATA,
                 -> if (textField != null) {
-                    text.append(reader.text)
-                    require(text.length <= MAX_DAV_PROPERTY_CHARS) { "A DAV property is too large." }
+                    val eventLength = reader.textLength
+                    require(eventLength <= MAX_DAV_PROPERTY_CHARS - text.length) {
+                        "A DAV property is too large."
+                    }
+                    text.append(reader.textCharacters, reader.textStart, eventLength)
                 }
                 XMLStreamConstants.END_ELEMENT -> {
                     if (reader.namespaceURI == DAV_NAMESPACE && reader.localName == textField) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -35,6 +35,7 @@ internal class DesktopFileSyncRemoteTree(
     private val onMutationCommitted: (relativePath: String) -> Unit = {},
 ) : LinuxVirtualWritebackRemote {
     private val rootPath = remoteRootPath.trim('/')
+    private val mutationExecutor = DesktopHttpMutationExecutor(client)
 
     fun scan(
         includes: (relativePath: String, kind: SyncEntryKind) -> Boolean = { _, _ -> true },
@@ -130,15 +131,14 @@ internal class DesktopFileSyncRemoteTree(
             return
         }
         require(current == null) { "The server folder appeared after the sync scan." }
-        notifyMutationCommitted(relativePath)
-        execute(
+        executeMutation(
             requestBuilder(fileUrl(fullPath(relativePath)))
                 .header("If-None-Match", "*")
                 .method("MKCOL", EMPTY_BODY)
                 .build(),
             "create folder",
+            relativePath,
         )
-        notifyMutationCommitted(relativePath)
     }
 
     fun replaceWithDirectory(relativePath: String, expectedRemoteEtag: String) {
@@ -149,23 +149,21 @@ internal class DesktopFileSyncRemoteTree(
         val destinationPath = fullPath(relativePath)
         val backupPath = replacementBackupPath(destinationPath)
         val currentAtFullPath = current.withPath(destinationPath)
-        notifyMutationCommitted(relativePath)
-        moveRemoteDocument(currentAtFullPath, backupPath)
+        moveRemoteDocument(currentAtFullPath, backupPath, relativePath)
         try {
-            execute(
+            executeMutation(
                 requestBuilder(fileUrl(destinationPath))
                     .header("If-None-Match", "*")
                     .method("MKCOL", EMPTY_BODY)
                     .build(),
                 "replace item with folder",
+                relativePath,
             )
-            notifyMutationCommitted(relativePath)
             require(resolve(relativePath)?.isDirectory == true) {
                 "The replacement server folder could not be verified."
             }
         } catch (failure: Throwable) {
-            restoreRemoteBackup(destinationPath, backupPath)
-            notifyMutationCommitted(relativePath)
+            restoreRemoteBackup(destinationPath, backupPath, relativePath)
             throw failure
         }
         deleteRemoteBackup(backupPath)
@@ -176,16 +174,13 @@ internal class DesktopFileSyncRemoteTree(
         val current = resolve(relativePath)
         if (expectedRemoteEtag == null) {
             require(current == null) { "The server file appeared after the sync scan." }
-            notifyMutationCommitted(relativePath)
-            createFile(fullPath(relativePath), source)
+            createFile(fullPath(relativePath), source, relativePath)
         } else {
             require(current?.entry?.etag == expectedRemoteEtag && !current.isDirectory) {
                 "The server file changed after the sync scan."
             }
-            notifyMutationCommitted(relativePath)
-            replaceFileAtomically(fullPath(relativePath), source, expectedRemoteEtag)
+            replaceFileAtomically(fullPath(relativePath), source, expectedRemoteEtag, relativePath)
         }
-        notifyMutationCommitted(relativePath)
         val after = requireNotNull(resolve(relativePath)) { "The uploaded server file disappeared." }
         require(!after.isDirectory) { "The uploaded server item is not a file." }
         return after.entry
@@ -206,23 +201,21 @@ internal class DesktopFileSyncRemoteTree(
         val stagedEtag = createFile(stagingPath, source)
         var protected = false
         try {
-            notifyMutationCommitted(relativePath)
-            moveRemoteDocument(current.withPath(destinationPath), backupPath)
+            moveRemoteDocument(current.withPath(destinationPath), backupPath, relativePath)
             protected = true
             moveRemotePath(
                 sourcePath = stagingPath,
                 destinationPath = destinationPath,
                 sourceEtag = stagedEtag,
                 sourceIsDirectory = false,
+                mutationRelativePaths = arrayOf(relativePath),
             )
-            notifyMutationCommitted(relativePath)
             val after = requireNotNull(resolve(relativePath)) { "The uploaded server file disappeared." }
             require(!after.isDirectory) { "The uploaded server item is not a file." }
             deleteRemoteBackup(backupPath)
             return after.entry
         } catch (failure: Throwable) {
-            if (protected) restoreRemoteBackup(destinationPath, backupPath)
-            if (protected) notifyMutationCommitted(relativePath)
+            if (protected) restoreRemoteBackup(destinationPath, backupPath, relativePath)
             deleteRemoteStage(stagingPath, stagedEtag)
             throw failure
         }
@@ -235,9 +228,7 @@ internal class DesktopFileSyncRemoteTree(
         val builder = requestBuilder(url)
         if (current.isDirectory) builder.header("If", "<$url> ([$expectedRemoteEtag])")
         else builder.header("If-Match", safeEtag(expectedRemoteEtag))
-        notifyMutationCommitted(relativePath)
-        execute(builder.delete().build(), "delete item")
-        notifyMutationCommitted(relativePath)
+        executeMutation(builder.delete().build(), "delete item", relativePath)
     }
 
     fun move(sourceRelativePath: String, destinationRelativePath: String, expectedRemoteEtag: String) {
@@ -246,9 +237,12 @@ internal class DesktopFileSyncRemoteTree(
         require(resolve(destinationRelativePath) == null) { "The move destination already exists." }
         val current = requireNotNull(resolve(sourceRelativePath)) { "The server item was already removed." }
         require(current.entry.etag == expectedRemoteEtag) { "The server item changed before it could be moved." }
-        notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
-        moveRemoteDocument(current.withPath(fullPath(sourceRelativePath)), fullPath(destinationRelativePath))
-        notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
+        moveRemoteDocument(
+            current.withPath(fullPath(sourceRelativePath)),
+            fullPath(destinationRelativePath),
+            sourceRelativePath,
+            destinationRelativePath,
+        )
     }
 
     fun moveReplacing(
@@ -271,18 +265,20 @@ internal class DesktopFileSyncRemoteTree(
         val sourcePath = fullPath(sourceRelativePath)
         val destinationPath = fullPath(destinationRelativePath)
         val backupPath = replacementBackupPath(destinationPath)
-        notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
-        moveRemoteDocument(destination.withPath(destinationPath), backupPath)
+        moveRemoteDocument(destination.withPath(destinationPath), backupPath, destinationRelativePath)
         try {
-            moveRemoteDocument(source.withPath(sourcePath), destinationPath)
-            notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
+            moveRemoteDocument(
+                source.withPath(sourcePath),
+                destinationPath,
+                sourceRelativePath,
+                destinationRelativePath,
+            )
             val published = requireNotNull(resolve(destinationRelativePath)) {
                 "The moved server item could not be verified."
             }
             require(published.isDirectory == source.isDirectory) { "The moved server item type changed." }
         } catch (failure: Throwable) {
-            restoreRemoteBackup(destinationPath, backupPath)
-            notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
+            restoreRemoteBackup(destinationPath, backupPath, destinationRelativePath)
             throw failure
         }
         deleteRemoteBackup(backupPath)
@@ -293,9 +289,12 @@ internal class DesktopFileSyncRemoteTree(
         var recovered = false
         val documentsByPath = documents.associateBy { document -> document.entry.relativePath }
         desktopOwnedBackupRecoveryPlan(documentsByPath.keys, MAX_RECOVERY_ITEMS).forEach { (source, destination) ->
-            toRelativePath(destination)?.let(::notifyMutationCommitted)
-            moveRemoteDocument(requireNotNull(documentsByPath[source]), destination)
-            toRelativePath(destination)?.let(::notifyMutationCommitted)
+            val recoveredRelativePath = toRelativePath(destination)
+            moveRemoteDocument(
+                requireNotNull(documentsByPath[source]),
+                destination,
+                *recoveredRelativePath?.let(::arrayOf).orEmpty(),
+            )
             recovered = true
         }
         if (recovered) documents = rawListDirectory(path)
@@ -341,12 +340,17 @@ internal class DesktopFileSyncRemoteTree(
             .filter(String::isNotBlank).joinToString("/")
     }
 
-    private fun moveRemoteDocument(source: DesktopRemoteSyncDocument, destinationPath: String) {
+    private fun moveRemoteDocument(
+        source: DesktopRemoteSyncDocument,
+        destinationPath: String,
+        vararg mutationRelativePaths: String,
+    ) {
         moveRemotePath(
             sourcePath = source.entry.relativePath,
             destinationPath = destinationPath,
             sourceEtag = source.entry.etag,
             sourceIsDirectory = source.isDirectory,
+            mutationRelativePaths = mutationRelativePaths,
         )
     }
 
@@ -355,6 +359,7 @@ internal class DesktopFileSyncRemoteTree(
         destinationPath: String,
         sourceEtag: String?,
         sourceIsDirectory: Boolean,
+        mutationRelativePaths: Array<out String> = emptyArray(),
     ) {
         val sourceUrl = fileUrl(sourcePath)
         val builder = requestBuilder(sourceUrl)
@@ -364,15 +369,19 @@ internal class DesktopFileSyncRemoteTree(
             if (sourceIsDirectory) builder.header("If", "<$sourceUrl> ([${safeEtag(sourceEtag)}])")
             else builder.header("If-Match", safeEtag(sourceEtag))
         }
-        execute(builder.method("MOVE", EMPTY_BODY).build(), "move item")
+        executeMutation(builder.method("MOVE", EMPTY_BODY).build(), "move item", *mutationRelativePaths)
     }
 
-    private fun restoreRemoteBackup(destinationPath: String, backupPath: String) {
+    private fun restoreRemoteBackup(
+        destinationPath: String,
+        backupPath: String,
+        vararg mutationRelativePaths: String,
+    ) {
         runCatching {
             val documents = rawListDirectory(destinationPath.substringBeforeLast('/', ""))
             if (documents.none { it.entry.relativePath == destinationPath }) {
                 documents.firstOrNull { it.entry.relativePath == backupPath }
-                    ?.let { moveRemoteDocument(it, destinationPath) }
+                    ?.let { moveRemoteDocument(it, destinationPath, *mutationRelativePaths) }
             }
         }
     }
@@ -401,15 +410,25 @@ internal class DesktopFileSyncRemoteTree(
         execute(builder.delete().build(), "remove protected backup")
     }
 
-    private fun createFile(path: String, source: File): String? = executeForEtag(
+    private fun createFile(
+        path: String,
+        source: File,
+        vararg mutationRelativePaths: String,
+    ): String? = executeMutationForEtag(
         requestBuilder(fileUrl(path))
             .header("If-None-Match", "*")
             .put(source.asRequestBody(OCTET_STREAM))
             .build(),
         "create file",
+        *mutationRelativePaths,
     )
 
-    private fun replaceFileAtomically(path: String, source: File, expectedEtag: String) {
+    private fun replaceFileAtomically(
+        path: String,
+        source: File,
+        expectedEtag: String,
+        vararg mutationRelativePaths: String,
+    ) {
         val parent = path.substringBeforeLast('/', "")
         val stagingPath = listOf(parent, ".nextcloud-native-${UUID.randomUUID()}.upload")
             .filter(String::isNotBlank).joinToString("/")
@@ -422,7 +441,11 @@ internal class DesktopFileSyncRemoteTree(
                 .header("Overwrite", "T")
                 .header("If", "<$destinationUrl> ([$expectedEtag])")
             stagedEtag?.let { builder.header("If-Match", it) }
-            execute(builder.method("MOVE", EMPTY_BODY).build(), "replace file")
+            executeMutation(
+                builder.method("MOVE", EMPTY_BODY).build(),
+                "replace file",
+                *mutationRelativePaths,
+            )
         } catch (failure: Throwable) {
             runCatching {
                 val cleanup = requestBuilder(stagingUrl)
@@ -433,11 +456,32 @@ internal class DesktopFileSyncRemoteTree(
         }
     }
 
-    private fun executeForEtag(request: Request, operation: String): String? =
-        client.newCall(request).execute().use { response ->
+    private fun executeMutationForEtag(
+        request: Request,
+        operation: String,
+        vararg mutationRelativePaths: String,
+    ): String? = mutationExecutor.execute(
+        request = request,
+        onAmbiguousNetworkResult = { notifyMutationCommitted(*mutationRelativePaths) },
+    ) { response ->
             require(response.code in 200..299) { response.failure(operation) }
             response.header("ETag") ?: response.header("OC-Etag")
-        }
+        }.also { notifyMutationCommitted(*mutationRelativePaths) }
+
+    private fun executeMutation(
+        request: Request,
+        operation: String,
+        vararg mutationRelativePaths: String,
+        expectedStatus: Int? = null,
+        maximumResponseBytes: Long = MAX_ERROR_RESPONSE_BYTES,
+    ): ByteArray = mutationExecutor.execute(
+        request = request,
+        onAmbiguousNetworkResult = { notifyMutationCommitted(*mutationRelativePaths) },
+    ) { response ->
+        val accepted = expectedStatus?.let { response.code == it } ?: (response.code in 200..299)
+        require(accepted) { response.failure(operation) }
+        response.body.byteStream().readBounded(maximumResponseBytes)
+    }.also { notifyMutationCommitted(*mutationRelativePaths) }
 
     private fun execute(
         request: Request,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -308,7 +308,7 @@ internal class DesktopFileSyncRemoteTree(
                 input = response.body.byteStream(),
                 userId = userId,
                 maximumBytes = MAX_DIRECTORY_RESPONSE_BYTES,
-                maximumDocuments = MAX_CHILDREN + MAX_RECOVERY_ITEMS,
+                maximumDocuments = MAX_CHILDREN + MAX_RECOVERY_ITEMS + 1,
             )
         }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -33,6 +33,7 @@ internal class DesktopFileSyncRemoteTree(
     remoteRootPath: String,
     private val client: OkHttpClient = desktopFileSyncHttpClient(),
     private val onMutationCommitted: (relativePath: String) -> Unit = {},
+    private val onAmbiguousMutationResult: (relativePath: String) -> Unit = onMutationCommitted,
 ) : LinuxVirtualWritebackRemote {
     private val rootPath = remoteRootPath.trim('/')
     private val mutationExecutor = DesktopHttpMutationExecutor(client)
@@ -462,7 +463,7 @@ internal class DesktopFileSyncRemoteTree(
         vararg mutationRelativePaths: String,
     ): String? = mutationExecutor.execute(
         request = request,
-        onAmbiguousNetworkResult = { notifyMutationCommitted(*mutationRelativePaths) },
+        onAmbiguousNetworkResult = { notifyAmbiguousMutationResult(*mutationRelativePaths) },
     ) { response ->
             require(response.code in 200..299) { response.failure(operation) }
             response.header("ETag") ?: response.header("OC-Etag")
@@ -476,7 +477,7 @@ internal class DesktopFileSyncRemoteTree(
         maximumResponseBytes: Long = MAX_ERROR_RESPONSE_BYTES,
     ): ByteArray = mutationExecutor.execute(
         request = request,
-        onAmbiguousNetworkResult = { notifyMutationCommitted(*mutationRelativePaths) },
+        onAmbiguousNetworkResult = { notifyAmbiguousMutationResult(*mutationRelativePaths) },
     ) { response ->
         val accepted = expectedStatus?.let { response.code == it } ?: (response.code in 200..299)
         require(accepted) { response.failure(operation) }
@@ -514,10 +515,18 @@ internal class DesktopFileSyncRemoteTree(
         return normalized.removePrefix("$rootPath/").takeIf { normalized.startsWith("$rootPath/") && it.isNotBlank() }
     }
 
+    private fun notifyAmbiguousMutationResult(vararg relativePaths: String) {
+        notifyMutation(onAmbiguousMutationResult, *relativePaths)
+    }
+
     private fun notifyMutationCommitted(vararg relativePaths: String) {
+        notifyMutation(onMutationCommitted, *relativePaths)
+    }
+
+    private fun notifyMutation(callback: (String) -> Unit, vararg relativePaths: String) {
         relativePaths.asSequence().map(String::trim).map { it.trim('/') }
             .filter(String::isNotBlank).distinct()
-            .forEach { path -> runCatching { onMutationCommitted(path) } }
+            .forEach { path -> runCatching { callback(path) } }
     }
 
     private fun safeEtag(value: String): String = value.also {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -4,13 +4,16 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.io.FilterInputStream
+import java.io.InputStream
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Base64
 import java.util.UUID
-import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.stream.XMLInputFactory
+import javax.xml.stream.XMLStreamConstants
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -285,21 +288,28 @@ internal class DesktopFileSyncRemoteTree(
     }
 
     private fun rawListDirectory(path: String): List<DesktopRemoteSyncDocument> {
-        val response = execute(
+        val documents = executeDirectoryListing(
             requestBuilder(fileUrl(path))
                 .header("Accept", "application/xml")
                 .header("Depth", "1")
                 .method("PROPFIND", DIRECTORY_PROPERTIES.toRequestBody(XML_CONTENT_TYPE))
                 .build(),
-            "list folder",
-            expectedStatus = 207,
-            maximumResponseBytes = MAX_DIRECTORY_RESPONSE_BYTES,
         )
         val parent = path.trim('/')
-        return parseDesktopSyncDav(response, userId)
+        return documents
             .filter { it.entry.relativePath.substringBeforeLast('/', "") == parent }
             .also { require(it.size <= MAX_CHILDREN + MAX_RECOVERY_ITEMS) { "A Nextcloud folder contains too many entries." } }
     }
+
+    private fun executeDirectoryListing(request: Request): List<DesktopRemoteSyncDocument> =
+        client.newCall(request).execute().use { response ->
+            require(response.code == 207) { response.failure("list folder") }
+            parseDesktopSyncDav(
+                input = response.body.byteStream(),
+                userId = userId,
+                maximumBytes = MAX_DIRECTORY_RESPONSE_BYTES,
+            )
+        }
 
     private fun DesktopRemoteSyncDocument.withPath(path: String): DesktopRemoteSyncDocument =
         copy(entry = entry.copy(relativePath = path))
@@ -446,10 +456,10 @@ internal class DesktopFileSyncRemoteTree(
 
     private companion object {
         const val MAX_ENTRIES = 20_000
-        const val MAX_CHILDREN = 5_000
+        const val MAX_CHILDREN = 50_000
         const val MAX_RECOVERY_ITEMS = 32
         const val MAX_DEPTH = 64
-        const val MAX_DIRECTORY_RESPONSE_BYTES = 16L * 1024L * 1024L
+        const val MAX_DIRECTORY_RESPONSE_BYTES = 128L * 1024L * 1024L
         const val MAX_ERROR_RESPONSE_BYTES = 64L * 1024L
         const val USER_AGENT = "Nextcloud-Native/0.1.0 (Desktop file sync)"
         val XML_CONTENT_TYPE = "application/xml; charset=utf-8".toMediaType()
@@ -493,38 +503,131 @@ internal fun shouldSuppressDesktopOwnedBackup(
 }
 
 internal fun parseDesktopSyncDav(bytes: ByteArray, userId: String): List<DesktopRemoteSyncDocument> {
-    val factory = DocumentBuilderFactory.newInstance().apply {
-        isNamespaceAware = true
-        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-        setFeature("http://xml.org/sax/features/external-general-entities", false)
-        setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+    return parseDesktopSyncDav(ByteArrayInputStream(bytes), userId, bytes.size.toLong())
+}
+
+private fun parseDesktopSyncDav(
+    input: InputStream,
+    userId: String,
+    maximumBytes: Long,
+): List<DesktopRemoteSyncDocument> {
+    require(maximumBytes > 0L)
+    val factory = XMLInputFactory.newFactory().apply {
+        setProperty(XMLInputFactory.SUPPORT_DTD, false)
+        setProperty("javax.xml.stream.isSupportingExternalEntities", false)
+        setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true)
+        setProperty(XMLInputFactory.IS_COALESCING, true)
     }
-    val responses = factory.newDocumentBuilder().parse(ByteArrayInputStream(bytes))
-        .getElementsByTagNameNS(DAV_NAMESPACE, "response")
-    return buildList {
-        for (index in 0 until responses.length) {
-            val response = responses.item(index) as? org.w3c.dom.Element ?: continue
-            val href = response.syncText("href") ?: continue
-            val decoded = URLDecoder.decode(href.replace("+", "%2B"), StandardCharsets.UTF_8)
-            val path = decoded.substringAfter("/files/$userId/", "").trim('/')
-            if (path.isBlank()) continue
-            val etag = response.syncText("getetag") ?: error("A server item has no usable revision.")
-            val isDirectory = response.getElementsByTagNameNS(DAV_NAMESPACE, "collection").length > 0
-            add(
-                DesktopRemoteSyncDocument(
-                    RemoteSyncEntry(
-                        relativePath = path,
-                        kind = if (isDirectory) SyncEntryKind.Directory else SyncEntryKind.File,
-                        etag = etag,
-                        size = response.syncText("getcontentlength")?.toLongOrNull()
-                            ?.takeIf { !isDirectory },
-                    ),
-                    isDirectory,
-                    lastModifiedEpochMillis = response.syncText("getlastmodified")
-                        ?.let(::parseDesktopSyncDavTimestamp),
-                ),
-            )
+    val reader = factory.createXMLStreamReader(BoundedInputStream(input, maximumBytes))
+    val documents = ArrayList<DesktopRemoteSyncDocument>()
+    var response: DesktopDavResponseBuilder? = null
+    var textField: String? = null
+    val text = StringBuilder()
+    try {
+        while (reader.hasNext()) {
+            when (reader.next()) {
+                XMLStreamConstants.START_ELEMENT -> {
+                    if (reader.namespaceURI == DAV_NAMESPACE) {
+                        when (reader.localName) {
+                            "response" -> response = DesktopDavResponseBuilder()
+                            "href", "getetag", "getcontentlength", "getlastmodified" -> if (response != null) {
+                                textField = reader.localName
+                                text.clear()
+                            }
+                            "collection" -> response?.isDirectory = true
+                        }
+                    }
+                }
+                XMLStreamConstants.CHARACTERS,
+                XMLStreamConstants.CDATA,
+                -> if (textField != null) {
+                    text.append(reader.text)
+                    require(text.length <= MAX_DAV_PROPERTY_CHARS) { "A DAV property is too large." }
+                }
+                XMLStreamConstants.END_ELEMENT -> {
+                    if (reader.namespaceURI == DAV_NAMESPACE && reader.localName == textField) {
+                        response?.set(reader.localName, text.toString())
+                        textField = null
+                        text.clear()
+                    }
+                    if (reader.namespaceURI == DAV_NAMESPACE && reader.localName == "response") {
+                        response?.toDocument(userId)?.let(documents::add)
+                        response = null
+                    }
+                }
+            }
         }
+    } finally {
+        reader.close()
+    }
+    return documents
+}
+
+private class DesktopDavResponseBuilder {
+    private var href: String? = null
+    private var etag: String? = null
+    private var contentLength: String? = null
+    private var lastModified: String? = null
+    var isDirectory: Boolean = false
+
+    fun set(name: String, value: String) {
+        when (name) {
+            "href" -> href = value
+            "getetag" -> etag = value
+            "getcontentlength" -> contentLength = value
+            "getlastmodified" -> lastModified = value
+        }
+    }
+
+    fun toDocument(userId: String): DesktopRemoteSyncDocument? {
+        val encodedHref = href ?: return null
+        val decoded = URLDecoder.decode(encodedHref.replace("+", "%2B"), StandardCharsets.UTF_8)
+        val path = decoded.substringAfter("/files/$userId/", "").trim('/')
+        if (path.isBlank()) return null
+        val revision = etag?.takeIf(String::isNotBlank) ?: error("A server item has no usable revision.")
+        return DesktopRemoteSyncDocument(
+            RemoteSyncEntry(
+                relativePath = path,
+                kind = if (isDirectory) SyncEntryKind.Directory else SyncEntryKind.File,
+                etag = revision,
+                size = contentLength?.toLongOrNull()?.takeIf { !isDirectory },
+            ),
+            isDirectory,
+            lastModifiedEpochMillis = lastModified?.let(::parseDesktopSyncDavTimestamp),
+        )
+    }
+}
+
+private class BoundedInputStream(
+    input: InputStream,
+    private val maximumBytes: Long,
+) : FilterInputStream(input) {
+    private var consumed = 0L
+
+    override fun read(): Int = super.read().also { value ->
+        if (value >= 0) count(1L)
+    }
+
+    override fun read(destination: ByteArray, offset: Int, length: Int): Int =
+        super.read(destination, offset, length).also { read ->
+            if (read > 0) count(read.toLong())
+        }
+
+    override fun skip(requested: Long): Long {
+        if (requested <= 0L) return 0L
+        val buffer = ByteArray(minOf(requested, 64L * 1024L).toInt())
+        var skipped = 0L
+        while (skipped < requested) {
+            val read = read(buffer, 0, minOf(buffer.size.toLong(), requested - skipped).toInt())
+            if (read < 0) break
+            skipped += read
+        }
+        return skipped
+    }
+
+    private fun count(bytes: Long) {
+        consumed += bytes
+        require(consumed <= maximumBytes) { "The server response exceeds its safe size limit." }
     }
 }
 
@@ -532,9 +635,6 @@ internal fun parseDesktopSyncDavTimestamp(value: String): Long? = runCatching {
     ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant().toEpochMilli()
         .takeIf { it >= 0L }
 }.getOrNull()
-
-private fun org.w3c.dom.Element.syncText(localName: String): String? =
-    getElementsByTagNameNS(DAV_NAMESPACE, localName).item(0)?.textContent?.takeIf(String::isNotBlank)
 
 private fun java.io.InputStream.readBounded(maximumBytes: Long): ByteArray {
     val output = ByteArrayOutputStream()
@@ -562,4 +662,5 @@ private fun desktopFileSyncHttpClient(): OkHttpClient = OkHttpClient.Builder()
     .followSslRedirects(false)
     .build()
 
+private const val MAX_DAV_PROPERTY_CHARS = 16_384
 private const val DAV_NAMESPACE = "DAV:"

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -535,7 +535,10 @@ private fun parseDesktopSyncDav(
         setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true)
         setProperty(XMLInputFactory.IS_COALESCING, false)
     }
-    val reader = factory.createXMLStreamReader(RejectingXmlCdataInputStream(BoundedInputStream(input, maximumBytes)))
+    val reader = factory.createXMLStreamReader(
+        RejectingXmlCdataInputStream(BoundedInputStream(input, maximumBytes)),
+        StandardCharsets.UTF_8.name(),
+    )
     val documents = ArrayList<DesktopRemoteSyncDocument>()
     var response: DesktopDavResponseBuilder? = null
     var textField: String? = null

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -130,6 +130,7 @@ internal class DesktopFileSyncRemoteTree(
             return
         }
         require(current == null) { "The server folder appeared after the sync scan." }
+        notifyMutationCommitted(relativePath)
         execute(
             requestBuilder(fileUrl(fullPath(relativePath)))
                 .header("If-None-Match", "*")
@@ -148,6 +149,7 @@ internal class DesktopFileSyncRemoteTree(
         val destinationPath = fullPath(relativePath)
         val backupPath = replacementBackupPath(destinationPath)
         val currentAtFullPath = current.withPath(destinationPath)
+        notifyMutationCommitted(relativePath)
         moveRemoteDocument(currentAtFullPath, backupPath)
         try {
             execute(
@@ -174,11 +176,13 @@ internal class DesktopFileSyncRemoteTree(
         val current = resolve(relativePath)
         if (expectedRemoteEtag == null) {
             require(current == null) { "The server file appeared after the sync scan." }
+            notifyMutationCommitted(relativePath)
             createFile(fullPath(relativePath), source)
         } else {
             require(current?.entry?.etag == expectedRemoteEtag && !current.isDirectory) {
                 "The server file changed after the sync scan."
             }
+            notifyMutationCommitted(relativePath)
             replaceFileAtomically(fullPath(relativePath), source, expectedRemoteEtag)
         }
         notifyMutationCommitted(relativePath)
@@ -202,6 +206,7 @@ internal class DesktopFileSyncRemoteTree(
         val stagedEtag = createFile(stagingPath, source)
         var protected = false
         try {
+            notifyMutationCommitted(relativePath)
             moveRemoteDocument(current.withPath(destinationPath), backupPath)
             protected = true
             moveRemotePath(
@@ -230,6 +235,7 @@ internal class DesktopFileSyncRemoteTree(
         val builder = requestBuilder(url)
         if (current.isDirectory) builder.header("If", "<$url> ([$expectedRemoteEtag])")
         else builder.header("If-Match", safeEtag(expectedRemoteEtag))
+        notifyMutationCommitted(relativePath)
         execute(builder.delete().build(), "delete item")
         notifyMutationCommitted(relativePath)
     }
@@ -240,6 +246,7 @@ internal class DesktopFileSyncRemoteTree(
         require(resolve(destinationRelativePath) == null) { "The move destination already exists." }
         val current = requireNotNull(resolve(sourceRelativePath)) { "The server item was already removed." }
         require(current.entry.etag == expectedRemoteEtag) { "The server item changed before it could be moved." }
+        notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
         moveRemoteDocument(current.withPath(fullPath(sourceRelativePath)), fullPath(destinationRelativePath))
         notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
     }
@@ -264,6 +271,7 @@ internal class DesktopFileSyncRemoteTree(
         val sourcePath = fullPath(sourceRelativePath)
         val destinationPath = fullPath(destinationRelativePath)
         val backupPath = replacementBackupPath(destinationPath)
+        notifyMutationCommitted(sourceRelativePath, destinationRelativePath)
         moveRemoteDocument(destination.withPath(destinationPath), backupPath)
         try {
             moveRemoteDocument(source.withPath(sourcePath), destinationPath)
@@ -285,6 +293,7 @@ internal class DesktopFileSyncRemoteTree(
         var recovered = false
         val documentsByPath = documents.associateBy { document -> document.entry.relativePath }
         desktopOwnedBackupRecoveryPlan(documentsByPath.keys, MAX_RECOVERY_ITEMS).forEach { (source, destination) ->
+            toRelativePath(destination)?.let(::notifyMutationCommitted)
             moveRemoteDocument(requireNotNull(documentsByPath[source]), destination)
             toRelativePath(destination)?.let(::notifyMutationCommitted)
             recovered = true

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -272,18 +272,16 @@ internal class DesktopFileSyncRemoteTree(
     private fun listDirectory(path: String): List<DesktopRemoteSyncDocument> {
         var documents = rawListDirectory(path)
         var recovered = false
-        documents.filter { desktopOwnedBackupDestination(it.entry.relativePath) != null }.forEach { backup ->
-            val destination = requireNotNull(desktopOwnedBackupDestination(backup.entry.relativePath))
-            if (documents.none { it.entry.relativePath == destination }) {
-                moveRemoteDocument(backup, destination)
-                recovered = true
-            }
+        val documentsByPath = documents.associateBy { document -> document.entry.relativePath }
+        desktopOwnedBackupRecoveryPlan(documentsByPath.keys, MAX_RECOVERY_ITEMS).forEach { (source, destination) ->
+            moveRemoteDocument(requireNotNull(documentsByPath[source]), destination)
+            recovered = true
         }
         if (recovered) documents = rawListDirectory(path)
-        val listedPaths = documents.mapTo(hashSetOf()) { it.entry.relativePath }
+        val recoveredPaths = documents.mapTo(hashSetOf()) { it.entry.relativePath }
         return documents
             .filterNot { isDesktopOwnedUploadStage(it.entry.relativePath) }
-            .filterNot { backup -> shouldSuppressDesktopOwnedBackup(backup.entry.relativePath, listedPaths) }
+            .filterNot { backup -> shouldSuppressDesktopOwnedBackup(backup.entry.relativePath, recoveredPaths) }
             .also { require(it.size <= MAX_CHILDREN) { "A Nextcloud folder contains too many entries." } }
     }
 
@@ -503,6 +501,19 @@ internal fun shouldSuppressDesktopOwnedBackup(
     return destination !in listedPaths
 }
 
+internal fun desktopOwnedBackupRecoveryPlan(
+    relativePaths: Collection<String>,
+    maximumRecoveryItems: Int,
+): List<Pair<String, String>> {
+    require(maximumRecoveryItems >= 0)
+    val listedPaths = relativePaths.toHashSet()
+    val backups = relativePaths.mapNotNull { source ->
+        desktopOwnedBackupDestination(source)?.let { destination -> source to destination }
+    }
+    require(backups.size <= maximumRecoveryItems) { "A Nextcloud folder contains too many recovery items." }
+    return backups.filterNot { (_, destination) -> destination in listedPaths }
+}
+
 internal fun parseDesktopSyncDav(
     bytes: ByteArray,
     userId: String,
@@ -524,7 +535,7 @@ private fun parseDesktopSyncDav(
         setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true)
         setProperty(XMLInputFactory.IS_COALESCING, false)
     }
-    val reader = factory.createXMLStreamReader(BoundedInputStream(input, maximumBytes))
+    val reader = factory.createXMLStreamReader(RejectingXmlCdataInputStream(BoundedInputStream(input, maximumBytes)))
     val documents = ArrayList<DesktopRemoteSyncDocument>()
     var response: DesktopDavResponseBuilder? = null
     var textField: String? = null
@@ -642,6 +653,46 @@ private class BoundedInputStream(
     private fun count(bytes: Long) {
         consumed += bytes
         require(consumed <= maximumBytes) { "The server response exceeds its safe size limit." }
+    }
+}
+
+private class RejectingXmlCdataInputStream(input: InputStream) : FilterInputStream(input) {
+    private var matchedPrefixBytes = 0
+
+    override fun read(): Int = super.read().also { value ->
+        if (value >= 0) inspect(value.toByte())
+    }
+
+    override fun read(destination: ByteArray, offset: Int, length: Int): Int =
+        super.read(destination, offset, length).also { read ->
+            if (read > 0) {
+                for (index in offset until offset + read) inspect(destination[index])
+            }
+        }
+
+    override fun skip(requested: Long): Long {
+        if (requested <= 0L) return 0L
+        val buffer = ByteArray(minOf(requested, 64L * 1024L).toInt())
+        var skipped = 0L
+        while (skipped < requested) {
+            val read = read(buffer, 0, minOf(buffer.size.toLong(), requested - skipped).toInt())
+            if (read < 0) break
+            skipped += read
+        }
+        return skipped
+    }
+
+    private fun inspect(value: Byte) {
+        if (value == CDATA_PREFIX[matchedPrefixBytes]) {
+            matchedPrefixBytes += 1
+            require(matchedPrefixBytes < CDATA_PREFIX.size) { "DAV CDATA properties are not supported." }
+        } else {
+            matchedPrefixBytes = if (value == CDATA_PREFIX[0]) 1 else 0
+        }
+    }
+
+    private companion object {
+        val CDATA_PREFIX = "<![CDATA[".encodeToByteArray()
     }
 }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopHttpMutationExecutor.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopHttpMutationExecutor.kt
@@ -18,6 +18,7 @@ internal class DesktopHttpMutationExecutor(client: OkHttpClient) {
     fun <T> execute(
         request: Request,
         onAmbiguousNetworkResult: () -> Unit,
+        onAcceptedResponse: () -> Unit = {},
         consume: (Response) -> T,
     ): T {
         val attempt = DesktopHttpMutationAttempt()
@@ -25,7 +26,10 @@ internal class DesktopHttpMutationExecutor(client: OkHttpClient) {
             .tag(DesktopHttpMutationAttempt::class.java, attempt)
             .build()
         return try {
-            trackedClient.newCall(trackedRequest).execute().use(consume)
+            trackedClient.newCall(trackedRequest).execute().use { response ->
+                if (response.isSuccessful) runCatching(onAcceptedResponse)
+                consume(response)
+            }
         } catch (failure: IOException) {
             if (desktopMutationResultIsAmbiguous(attempt.networkExchangeStarted, failure)) {
                 runCatching(onAmbiguousNetworkResult)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopHttpMutationExecutor.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopHttpMutationExecutor.kt
@@ -1,0 +1,46 @@
+package dev.obiente.nextcloudnative.app
+
+import java.io.IOException
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+
+/** Tracks whether a mutating HTTP request reached a network exchange before an I/O failure. */
+internal class DesktopHttpMutationExecutor(client: OkHttpClient) {
+    private val trackedClient = client.newBuilder()
+        .retryOnConnectionFailure(false)
+        .addNetworkInterceptor { chain ->
+            chain.request().tag(DesktopHttpMutationAttempt::class.java)?.networkExchangeStarted = true
+            chain.proceed(chain.request())
+        }
+        .build()
+
+    fun <T> execute(
+        request: Request,
+        onAmbiguousNetworkResult: () -> Unit,
+        consume: (Response) -> T,
+    ): T {
+        val attempt = DesktopHttpMutationAttempt()
+        val trackedRequest = request.newBuilder()
+            .tag(DesktopHttpMutationAttempt::class.java, attempt)
+            .build()
+        return try {
+            trackedClient.newCall(trackedRequest).execute().use(consume)
+        } catch (failure: IOException) {
+            if (desktopMutationResultIsAmbiguous(attempt.networkExchangeStarted, failure)) {
+                runCatching(onAmbiguousNetworkResult)
+            }
+            throw failure
+        }
+    }
+}
+
+internal fun desktopMutationResultIsAmbiguous(
+    networkExchangeStarted: Boolean,
+    failure: Throwable,
+): Boolean = networkExchangeStarted && failure is IOException
+
+private class DesktopHttpMutationAttempt {
+    @Volatile
+    var networkExchangeStarted: Boolean = false
+}

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStore.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStore.kt
@@ -87,7 +87,14 @@ internal class DesktopLinuxVirtualFileWritebackStore(
             try {
                 saveManifest(
                     manifestFile,
-                    WritebackManifest(path, expectedRevision, stagedAt, dirty, stage.name),
+                    WritebackManifest(
+                        path = path,
+                        expectedRemoteRevision = expectedRevision,
+                        stagedAtEpochMillis = stagedAt,
+                        dirty = dirty,
+                        stageName = stage.name,
+                        committed = false,
+                    ),
                 )
                 if (truncate) {
                     afterDirtyIntentPersisted()
@@ -153,7 +160,14 @@ internal class DesktopLinuxVirtualFileWritebackStore(
                     if (dirty) return
                     saveManifest(
                         manifestFile,
-                        WritebackManifest(path, expectedRevision, stagedAt, true, stage.name),
+                        WritebackManifest(
+                            path = path,
+                            expectedRemoteRevision = expectedRevision,
+                            stagedAtEpochMillis = stagedAt,
+                            dirty = true,
+                            stageName = stage.name,
+                            committed = false,
+                        ),
                     )
                     dirty = true
                     afterDirtyIntentPersisted()
@@ -169,7 +183,14 @@ internal class DesktopLinuxVirtualFileWritebackStore(
                     dirty = false
                     saveManifest(
                         manifestFile,
-                        WritebackManifest(path, expectedRevision, stagedAt, false, stage.name),
+                        WritebackManifest(
+                            path = path,
+                            expectedRemoteRevision = expectedRevision,
+                            stagedAtEpochMillis = stagedAt,
+                            dirty = false,
+                            stageName = stage.name,
+                            committed = true,
+                        ),
                     )
                     onCommitted(path)
                 }
@@ -235,7 +256,9 @@ internal class DesktopLinuxVirtualFileWritebackStore(
             val stage = File(root, manifest.stageName)
             if (!stage.isFile) return@forEach
             if (!manifest.dirty) {
-                onCommitted(manifest.path)
+                // Missing values are legacy clean manifests, whose pre- and post-upload states
+                // were indistinguishable. Preserve their conservative invalidation behavior.
+                if (manifest.committed != false) onCommitted(manifest.path)
                 manifestFile.delete()
                 stage.delete()
                 recovered += 1
@@ -358,6 +381,7 @@ private data class WritebackManifest(
     val stagedAtEpochMillis: Long,
     val dirty: Boolean,
     val stageName: String,
+    val committed: Boolean? = null,
 ) {
     fun requireValid() {
         FileOfflineKey("account", path)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStore.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStore.kt
@@ -235,6 +235,7 @@ internal class DesktopLinuxVirtualFileWritebackStore(
             val stage = File(root, manifest.stageName)
             if (!stage.isFile) return@forEach
             if (!manifest.dirty) {
+                onCommitted(manifest.path)
                 manifestFile.delete()
                 stage.delete()
                 recovered += 1

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStore.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStore.kt
@@ -93,7 +93,7 @@ internal class DesktopLinuxVirtualFileWritebackStore(
                         stagedAtEpochMillis = stagedAt,
                         dirty = dirty,
                         stageName = stage.name,
-                        committed = false,
+                        committed = if (dirty) null else false,
                     ),
                 )
                 if (truncate) {
@@ -166,7 +166,7 @@ internal class DesktopLinuxVirtualFileWritebackStore(
                             stagedAtEpochMillis = stagedAt,
                             dirty = true,
                             stageName = stage.name,
-                            committed = false,
+                            committed = null,
                         ),
                     )
                     dirty = true

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -535,6 +535,7 @@ class DesktopNextcloudServices(
         onInstallerConfirmationOpened = { target -> onDesktopUpdateInstallerOpened(target.platform) },
     )
     private val httpClient = OkHttpClient()
+    private val fileMutationHttpExecutor = DesktopHttpMutationExecutor(httpClient)
     private val noRedirectHttpClient = httpClient.newBuilder()
         .followRedirects(false)
         .followSslRedirects(false)
@@ -2176,19 +2177,24 @@ class DesktopNextcloudServices(
                 put("Overwrite", if (spec.overwrite) "T" else "F")
             }
         }
+        val accountId = desktopFileCacheAccountId(session)
+        fun invalidateAffectedMetadata() {
+            runCatching {
+                invalidateDesktopFileMetadata(accountId, spec.sourcePath)
+                spec.destinationPath?.let { invalidateDesktopFileMetadata(accountId, it) }
+            }
+        }
         val response = request(
             method = spec.method,
             url = buildNextcloudFileUrl(session.serverUrl, userId, spec.sourcePath),
             session = session,
             headers = headers,
             maxResponseBytes = 64 * 1024,
+            mutationExecutor = fileMutationHttpExecutor,
+            onAmbiguousMutationResult = ::invalidateAffectedMetadata,
         )
         if (response.status !in 200..299) throw fileOperationException(response.status)
-        runCatching {
-            val accountId = desktopFileCacheAccountId(session)
-            invalidateDesktopFileMetadata(accountId, spec.sourcePath)
-            spec.destinationPath?.let { invalidateDesktopFileMetadata(accountId, it) }
-        }
+        invalidateAffectedMetadata()
         NextcloudFileMutationResult(spec.destinationPath, response.etag)
     }
 
@@ -2897,6 +2903,8 @@ class DesktopNextcloudServices(
         maxResponseBytes: Long = MAX_API_RESPONSE_BYTES,
         client: OkHttpClient = httpClient,
         streamingBody: RequestBody? = null,
+        mutationExecutor: DesktopHttpMutationExecutor? = null,
+        onAmbiguousMutationResult: () -> Unit = {},
     ): HttpResponse {
         val requestBody = when {
             streamingBody != null -> streamingBody
@@ -2913,16 +2921,22 @@ class DesktopNextcloudServices(
             val encoded = Base64.getEncoder().encodeToString("${it.loginName}:${it.appPassword}".toByteArray())
             builder.header("Authorization", "Basic $encoded")
         }
-        return client.newCall(builder.build()).execute().use { response ->
+        val request = builder.build()
+        fun consumeResponse(response: okhttp3.Response): HttpResponse {
             val responseBody = response.body
             val contentLength = responseBody.contentLength()
             val readLimit = if (response.isSuccessful) maxResponseBytes else MAX_ERROR_RESPONSE_BYTES
             check(contentLength <= readLimit || contentLength == -1L) {
                 "The server response is larger than the allowed ${formatByteLimit(readLimit)} limit."
             }
-            HttpResponse(
+            val bodyBytes = if (mutationExecutor != null && !response.isSuccessful) {
+                runCatching { responseBody.byteStream().readBounded(readLimit) }.getOrDefault(byteArrayOf())
+            } else {
+                responseBody.byteStream().readBounded(readLimit)
+            }
+            return HttpResponse(
                 response.code,
-                responseBody.byteStream().readBounded(readLimit),
+                bodyBytes,
                 responseBody.contentType()?.toString(),
                 response.header("ETag") ?: response.header("OC-Etag"),
                 if (session == null) {
@@ -2937,6 +2951,11 @@ class DesktopNextcloudServices(
                 response.header("X-Chat-Last-Given"),
                 response.header("Content-Range"),
             )
+        }
+        return if (mutationExecutor == null) {
+            client.newCall(request).execute().use(::consumeResponse)
+        } else {
+            mutationExecutor.execute(request, onAmbiguousMutationResult, ::consumeResponse)
         }
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -854,12 +854,15 @@ class DesktopNextcloudServices(
                 onCommitted = { path -> virtualRangeCache.invalidate(accountId, path) },
             )
             val fileSystem = LinuxNextcloudVirtualFileSystem(
-                DesktopNextcloudVirtualFileBackend(
-                    session = session,
-                    userId = userId,
-                    services = this@DesktopNextcloudServices,
-                    rangeCache = virtualRangeCache,
-                    writebacks = writebackStore,
+                CachingLinuxVirtualFileBackend(
+                    delegate = DesktopNextcloudVirtualFileBackend(
+                        session = session,
+                        userId = userId,
+                        services = this@DesktopNextcloudServices,
+                        rangeCache = virtualRangeCache,
+                        writebacks = writebackStore,
+                    ),
+                    store = DesktopLinuxVirtualMetadataStore(fileReadCache, accountId),
                 ),
             )
             try {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -851,7 +851,10 @@ class DesktopNextcloudServices(
             val writebackStore = defaultDesktopLinuxWritebackStore(session)
             writebackStore.recoverPending(
                 tree = DesktopFileSyncRemoteTree(session, userId, ""),
-                onCommitted = { path -> virtualRangeCache.invalidate(accountId, path) },
+                onCommitted = { path ->
+                    virtualRangeCache.invalidate(accountId, path)
+                    fileReadCache.invalidate(accountId, path)
+                },
             )
             val fileSystem = LinuxNextcloudVirtualFileSystem(
                 CachingLinuxVirtualFileBackend(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -842,7 +842,7 @@ class DesktopNextcloudServices(
                 )
             }
             if (linuxVirtualFileSystem != null) {
-                runCatching { linuxVirtualFileSystem?.unmount() }
+                linuxVirtualFileSystem?.unmount()
                 linuxVirtualFileSystem = null
                 linuxVirtualMetadataBackend = null
                 linuxVirtualFileMountIdentity = null
@@ -863,16 +863,22 @@ class DesktopNextcloudServices(
                     recoveredWritebackPaths += path
                 },
             )
+            var metadataBackendReference: CachingLinuxVirtualFileBackend? = null
+            val virtualBackend = DesktopNextcloudVirtualFileBackend(
+                session = session,
+                userId = userId,
+                services = this@DesktopNextcloudServices,
+                rangeCache = virtualRangeCache,
+                writebacks = writebackStore,
+                onAmbiguousMutationResult = { path ->
+                    metadataBackendReference?.invalidateAfterExternalMutation(path)
+                },
+            )
             val metadataBackend = CachingLinuxVirtualFileBackend(
-                delegate = DesktopNextcloudVirtualFileBackend(
-                    session = session,
-                    userId = userId,
-                    services = this@DesktopNextcloudServices,
-                    rangeCache = virtualRangeCache,
-                    writebacks = writebackStore,
-                ),
+                delegate = virtualBackend,
                 store = DesktopLinuxVirtualMetadataStore(fileReadCache, accountId),
             )
+            metadataBackendReference = metadataBackend
             recoveredWritebackPaths.forEach(metadataBackend::invalidateAfterExternalMutation)
             val fileSystem = LinuxNextcloudVirtualFileSystem(metadataBackend)
             try {
@@ -926,10 +932,11 @@ class DesktopNextcloudServices(
     override fun close() {
         serviceScope.cancel()
         synchronized(virtualFileProviderLock) {
-            runCatching { linuxVirtualFileSystem?.unmount() }
-            linuxVirtualFileSystem = null
-            linuxVirtualMetadataBackend = null
-            linuxVirtualFileMountIdentity = null
+            if (runCatching { linuxVirtualFileSystem?.unmount() }.isSuccess) {
+                linuxVirtualFileSystem = null
+                linuxVirtualMetadataBackend = null
+                linuxVirtualFileMountIdentity = null
+            }
             runCatching { windowsCloudFilesProvider?.close() }
             windowsCloudFilesProvider = null
             windowsCloudFilesIdentity = null
@@ -1467,7 +1474,7 @@ class DesktopNextcloudServices(
             backgroundFileSyncJob = null
         }
         synchronized(virtualFileProviderLock) {
-            runCatching { linuxVirtualFileSystem?.unmount() }
+            linuxVirtualFileSystem?.unmount()
             linuxVirtualFileSystem = null
             linuxVirtualMetadataBackend = null
             linuxVirtualFileMountIdentity = null

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -2981,7 +2981,12 @@ class DesktopNextcloudServices(
         return if (mutationExecutor == null) {
             client.newCall(request).execute().use(::consumeResponse)
         } else {
-            mutationExecutor.execute(request, onAmbiguousMutationResult, ::consumeResponse)
+            mutationExecutor.execute(
+                request = request,
+                onAmbiguousNetworkResult = onAmbiguousMutationResult,
+                onAcceptedResponse = onAmbiguousMutationResult,
+                consume = ::consumeResponse,
+            )
         }
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -567,6 +567,9 @@ class DesktopNextcloudServices(
     private val deckCardDrafts = DesktopDeckCardDraftStore()
     private val fileSyncEngine = DesktopFileSyncEngine(
         minimumFreeSpaceBytes = { fileReadCache.loadPolicy().minimumFreeSpaceBytes },
+        onRemoteMutationCommitted = { session, _, path ->
+            invalidateDesktopFileMetadata(desktopFileCacheAccountId(session), path)
+        },
     )
     private val startOnLoginController = DesktopStartOnLoginController()
     private val fileSyncRunLock = Mutex()

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -540,6 +540,7 @@ class DesktopNextcloudServices(
         .followRedirects(false)
         .followSslRedirects(false)
         .build()
+    private val noRedirectFileMutationHttpExecutor = DesktopHttpMutationExecutor(noRedirectHttpClient)
     private val projectContentHttpClient = buildDesktopProjectContentHttpClient()
     private val contractAcquirer = SignedAppStoreContractAcquirer(
         catalogCache = FileAppStoreCatalogCache(desktopContractCacheDirectory("catalogs")),
@@ -2051,6 +2052,8 @@ class DesktopNextcloudServices(
         version: NextcloudFileVersion,
     ): Unit = withContext(Dispatchers.IO) {
         val specification = fileVersionRestoreRequest(userId, file, version)
+        val accountId = desktopFileCacheAccountId(session)
+        fun invalidateAffectedMetadata() = invalidateDesktopFileMetadata(accountId, file.path)
         val response = request(
             method = specification.method,
             url = session.serverUrl + specification.relativePath,
@@ -2061,9 +2064,14 @@ class DesktopNextcloudServices(
             ),
             maxResponseBytes = specification.maximumResponseBytes,
             client = noRedirectHttpClient,
+            mutationExecutor = noRedirectFileMutationHttpExecutor,
+            onAmbiguousMutationResult = ::invalidateAffectedMetadata,
         )
+        if (response.status in 200..299) {
+            runCatching(::invalidateAffectedMetadata)
+            return@withContext
+        }
         when (response.status) {
-            in 200..299 -> Unit
             403 -> error("You do not have permission to restore this file version.")
             404 -> error("This historical version no longer exists.")
             409 -> error("The server could not restore this version to the current file.")
@@ -2089,6 +2097,8 @@ class DesktopNextcloudServices(
             put("Accept", "*/*")
             put("If-Match", expectedEtag)
         }
+        val accountId = desktopFileCacheAccountId(session)
+        fun invalidateAffectedMetadata() = invalidateDesktopFileMetadata(accountId, path)
         val response = request(
             "PUT",
             buildNextcloudFileUrl(session.serverUrl, userId, path),
@@ -2096,13 +2106,14 @@ class DesktopNextcloudServices(
             rawBody = utf8,
             contentType = "text/plain; charset=utf-8",
             headers = headers,
+            mutationExecutor = fileMutationHttpExecutor,
+            onAmbiguousMutationResult = ::invalidateAffectedMetadata,
         )
         check(response.status != 412) { "The file changed on the server. Reload it before saving your changes." }
         check(response.status in 200..299) { "Saving the text file failed (HTTP ${response.status})." }
         val etag = response.etag ?: runCatching { loadFileEtag(session, userId, path) }.getOrNull()
-        val accountId = desktopFileCacheAccountId(session)
         runCatching {
-            invalidateDesktopFileMetadata(accountId, path)
+            invalidateAffectedMetadata()
             etag?.let {
                 fileReadCache.storeContent(
                     accountId,
@@ -2124,6 +2135,8 @@ class DesktopNextcloudServices(
         require(utf8.size.toLong() <= MAX_EDITABLE_TEXT_BYTES) {
             "Text files larger than ${MAX_EDITABLE_TEXT_BYTES / (1024 * 1024)} MiB cannot be created in the app."
         }
+        val accountId = desktopFileCacheAccountId(session)
+        fun invalidateAffectedMetadata() = invalidateDesktopFileMetadata(accountId, path)
         val response = request(
             "PUT",
             buildNextcloudFileUrl(session.serverUrl, userId, path),
@@ -2131,13 +2144,14 @@ class DesktopNextcloudServices(
             rawBody = utf8,
             contentType = "text/plain; charset=utf-8",
             headers = mapOf("Accept" to "*/*", "If-None-Match" to "*"),
+            mutationExecutor = fileMutationHttpExecutor,
+            onAmbiguousMutationResult = ::invalidateAffectedMetadata,
         )
         if (response.status == 412) return@withContext SavedTextFile(etag = null, wasCreated = false)
         check(response.status in 200..299) { "Creating the text file failed (HTTP ${response.status})." }
         check(response.status == 201) { "The server did not confirm that a new text file was created." }
         runCatching {
-            val accountId = desktopFileCacheAccountId(session)
-            invalidateDesktopFileMetadata(accountId, path)
+            invalidateAffectedMetadata()
             response.etag?.let {
                 fileReadCache.storeContent(
                     accountId,
@@ -2154,19 +2168,21 @@ class DesktopNextcloudServices(
         userId: String,
         path: String,
     ): Boolean = withContext(Dispatchers.IO) {
+        val accountId = desktopFileCacheAccountId(session)
+        fun invalidateAffectedMetadata() = invalidateDesktopFileMetadata(accountId, path)
         val response = request(
             method = "MKCOL",
             url = buildNextcloudFileUrl(session.serverUrl, userId, path),
             session = session,
             headers = mapOf("Accept" to "*/*", "If-None-Match" to "*"),
             maxResponseBytes = 64 * 1024,
+            mutationExecutor = fileMutationHttpExecutor,
+            onAmbiguousMutationResult = ::invalidateAffectedMetadata,
         )
         if (response.status in setOf(405, 412)) return@withContext false
         if (response.status !in 200..299) throw fileOperationException(response.status)
         check(response.status == 201) { "The server did not confirm that a new folder was created." }
-        runCatching {
-            invalidateDesktopFileMetadata(desktopFileCacheAccountId(session), path)
-        }
+        runCatching(::invalidateAffectedMetadata)
         true
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -871,6 +871,9 @@ class DesktopNextcloudServices(
                 services = this@DesktopNextcloudServices,
                 rangeCache = virtualRangeCache,
                 writebacks = writebackStore,
+                onMutationCommitted = { path ->
+                    metadataBackendReference?.invalidateAfterExternalMutation(path)
+                },
                 onAmbiguousMutationResult = { path ->
                     metadataBackendReference?.invalidateAfterExternalMutation(path)
                 },

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -548,6 +548,7 @@ class DesktopNextcloudServices(
     private val virtualRangeCache = defaultDesktopVirtualRangeCache(fileReadCache::loadPolicy)
     private val virtualFileProviderLock = Any()
     private var linuxVirtualFileSystem: LinuxNextcloudVirtualFileSystem? = null
+    private var linuxVirtualMetadataBackend: CachingLinuxVirtualFileBackend? = null
     private var linuxVirtualFileMountIdentity: String? = null
     private var linuxVirtualFileFailure: String? = null
     private var windowsCloudFilesProvider: WindowsCloudFilesProvider? = null
@@ -839,6 +840,7 @@ class DesktopNextcloudServices(
             if (linuxVirtualFileSystem != null) {
                 runCatching { linuxVirtualFileSystem?.unmount() }
                 linuxVirtualFileSystem = null
+                linuxVirtualMetadataBackend = null
                 linuxVirtualFileMountIdentity = null
             }
             val mountPoint = desktopLinuxVirtualFileMountPoint().apply {
@@ -849,32 +851,37 @@ class DesktopNextcloudServices(
                 "The virtual-files mount folder must be empty before it can be activated."
             }
             val writebackStore = defaultDesktopLinuxWritebackStore(session)
+            val recoveredWritebackPaths = linkedSetOf<String>()
             writebackStore.recoverPending(
                 tree = DesktopFileSyncRemoteTree(session, userId, ""),
                 onCommitted = { path ->
                     runCatching { virtualRangeCache.invalidate(accountId, path) }
-                    runCatching { fileReadCache.invalidate(accountId, path) }
+                    recoveredWritebackPaths += path
                 },
             )
-            val fileSystem = LinuxNextcloudVirtualFileSystem(
-                CachingLinuxVirtualFileBackend(
-                    delegate = DesktopNextcloudVirtualFileBackend(
-                        session = session,
-                        userId = userId,
-                        services = this@DesktopNextcloudServices,
-                        rangeCache = virtualRangeCache,
-                        writebacks = writebackStore,
-                    ),
-                    store = DesktopLinuxVirtualMetadataStore(fileReadCache, accountId),
+            val metadataBackend = CachingLinuxVirtualFileBackend(
+                delegate = DesktopNextcloudVirtualFileBackend(
+                    session = session,
+                    userId = userId,
+                    services = this@DesktopNextcloudServices,
+                    rangeCache = virtualRangeCache,
+                    writebacks = writebackStore,
                 ),
+                store = DesktopLinuxVirtualMetadataStore(fileReadCache, accountId),
             )
+            recoveredWritebackPaths.forEach(metadataBackend::invalidateAfterExternalMutation)
+            val fileSystem = LinuxNextcloudVirtualFileSystem(metadataBackend)
             try {
                 fileSystem.mountAt(mountPoint.toPath())
                 linuxVirtualFileSystem = fileSystem
+                linuxVirtualMetadataBackend = metadataBackend
                 linuxVirtualFileMountIdentity = accountId
                 linuxVirtualFileFailure = null
                 preferences.putBoolean(virtualFileProviderPreferenceKey(accountId), true)
             } catch (failure: Throwable) {
+                runCatching(fileSystem::unmount).onFailure {
+                    runCatching(metadataBackend::close)
+                }
                 linuxVirtualFileFailure = failure.message ?: "Unknown FUSE mount failure"
                 throw failure
             }
@@ -891,6 +898,7 @@ class DesktopNextcloudServices(
         synchronized(virtualFileProviderLock) {
             linuxVirtualFileSystem?.unmount()
             linuxVirtualFileSystem = null
+            linuxVirtualMetadataBackend = null
             linuxVirtualFileMountIdentity = null
             linuxVirtualFileFailure = null
             windowsCloudFilesProvider?.close()
@@ -916,10 +924,23 @@ class DesktopNextcloudServices(
         synchronized(virtualFileProviderLock) {
             runCatching { linuxVirtualFileSystem?.unmount() }
             linuxVirtualFileSystem = null
+            linuxVirtualMetadataBackend = null
             linuxVirtualFileMountIdentity = null
             runCatching { windowsCloudFilesProvider?.close() }
             windowsCloudFilesProvider = null
             windowsCloudFilesIdentity = null
+        }
+    }
+
+    private fun invalidateDesktopFileMetadata(accountId: String, path: String) {
+        synchronized(virtualFileProviderLock) {
+            val mountedBackend = linuxVirtualMetadataBackend
+                ?.takeIf { linuxVirtualFileMountIdentity == accountId }
+            if (mountedBackend != null) {
+                mountedBackend.invalidateAfterExternalMutation(path)
+            } else {
+                fileReadCache.invalidate(accountId, path)
+            }
         }
     }
 
@@ -1444,6 +1465,7 @@ class DesktopNextcloudServices(
         synchronized(virtualFileProviderLock) {
             runCatching { linuxVirtualFileSystem?.unmount() }
             linuxVirtualFileSystem = null
+            linuxVirtualMetadataBackend = null
             linuxVirtualFileMountIdentity = null
             linuxVirtualFileFailure = null
             try {
@@ -1852,7 +1874,7 @@ class DesktopNextcloudServices(
                 response.status == 304 && cached != null ->
                     NextcloudFileContent(cached.bytes, cached.mimeType, cached.etag)
                 response.status == 404 -> {
-                    runCatching { fileReadCache.invalidate(accountId, path) }
+                    runCatching { invalidateDesktopFileMetadata(accountId, path) }
                     error("The file no longer exists on the server.")
                 }
                 response.status >= 500 && cached != null ->
@@ -2069,7 +2091,7 @@ class DesktopNextcloudServices(
         val etag = response.etag ?: runCatching { loadFileEtag(session, userId, path) }.getOrNull()
         val accountId = desktopFileCacheAccountId(session)
         runCatching {
-            fileReadCache.invalidate(accountId, path)
+            invalidateDesktopFileMetadata(accountId, path)
             etag?.let {
                 fileReadCache.storeContent(
                     accountId,
@@ -2104,7 +2126,7 @@ class DesktopNextcloudServices(
         check(response.status == 201) { "The server did not confirm that a new text file was created." }
         runCatching {
             val accountId = desktopFileCacheAccountId(session)
-            fileReadCache.invalidate(accountId, path)
+            invalidateDesktopFileMetadata(accountId, path)
             response.etag?.let {
                 fileReadCache.storeContent(
                     accountId,
@@ -2132,7 +2154,7 @@ class DesktopNextcloudServices(
         if (response.status !in 200..299) throw fileOperationException(response.status)
         check(response.status == 201) { "The server did not confirm that a new folder was created." }
         runCatching {
-            fileReadCache.invalidate(desktopFileCacheAccountId(session), path)
+            invalidateDesktopFileMetadata(desktopFileCacheAccountId(session), path)
         }
         true
     }
@@ -2161,8 +2183,8 @@ class DesktopNextcloudServices(
         if (response.status !in 200..299) throw fileOperationException(response.status)
         runCatching {
             val accountId = desktopFileCacheAccountId(session)
-            fileReadCache.invalidate(accountId, spec.sourcePath)
-            spec.destinationPath?.let { fileReadCache.invalidate(accountId, it) }
+            invalidateDesktopFileMetadata(accountId, spec.sourcePath)
+            spec.destinationPath?.let { invalidateDesktopFileMetadata(accountId, it) }
         }
         NextcloudFileMutationResult(spec.destinationPath, response.etag)
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -1625,6 +1625,7 @@ class DesktopNextcloudServices(
         path: String,
     ): NextcloudFileListing = withContext(Dispatchers.IO) {
         val accountId = desktopFileCacheAccountId(session)
+        val requestStartedAtEpochMillis = System.currentTimeMillis().coerceAtLeast(0L)
         try {
             val response = request(
                 "PROPFIND", buildNextcloudFileUrl(session.serverUrl, userId, path), session, DAV_PROPERTIES,
@@ -1633,7 +1634,14 @@ class DesktopNextcloudServices(
             if (response.status == 207) {
                 val files = parseDavFiles(response.body, userId).drop(1)
                     .sortedWith(compareByDescending<NextcloudFile> { it.isDirectory }.thenBy { it.name.lowercase() })
-                runCatching { fileReadCache.storeListing(accountId, path, files) }
+                runCatching {
+                    fileReadCache.storeListingUnlessNewer(
+                        accountId = accountId,
+                        path = path,
+                        files = files,
+                        fetchedAtEpochMillis = requestStartedAtEpochMillis,
+                    )
+                }
                 NextcloudFileListing(files, NextcloudFileListingSource.Network)
             } else {
                 if (response.status >= 500) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -852,8 +852,8 @@ class DesktopNextcloudServices(
             writebackStore.recoverPending(
                 tree = DesktopFileSyncRemoteTree(session, userId, ""),
                 onCommitted = { path ->
-                    virtualRangeCache.invalidate(accountId, path)
-                    fileReadCache.invalidate(accountId, path)
+                    runCatching { virtualRangeCache.invalidate(accountId, path) }
+                    runCatching { fileReadCache.invalidate(accountId, path) }
                 },
             )
             val fileSystem = LinuxNextcloudVirtualFileSystem(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -59,7 +59,13 @@ internal data class LinuxVirtualDirectorySnapshot(
     val nodes: List<LinuxVirtualFileNode>,
     val fetchedAtEpochMillis: Long,
     val generation: Long = 0L,
-)
+) {
+    val nodesByPath: Map<String, LinuxVirtualFileNode> = nodes.associateBy(LinuxVirtualFileNode::path)
+
+    init {
+        require(nodesByPath.size == nodes.size) { "A Linux directory snapshot contains duplicate paths." }
+    }
+}
 
 internal interface LinuxVirtualMetadataStore {
     fun load(path: String): LinuxVirtualDirectorySnapshot?
@@ -89,7 +95,7 @@ internal class DesktopLinuxVirtualMetadataStore(
     override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
         val previous = cache.cachedListing(accountId, path).orEmpty().associateBy(NextcloudFile::path)
         val files = snapshot.nodes.map { node ->
-            previous[node.path]?.copy(
+            previous[node.path]?.takeIf { file -> file.etag == node.remoteRevision }?.copy(
                 name = node.name,
                 isDirectory = node.directory,
                 size = node.size.takeUnless { node.directory },
@@ -124,35 +130,45 @@ internal class CachingLinuxVirtualFileBackend(
     private val store: LinuxVirtualMetadataStore,
     private val nowEpochMillis: () -> Long = System::currentTimeMillis,
     private val freshForMillis: Long = DEFAULT_FRESH_MILLIS,
+    private val refreshRetryBaseMillis: Long = DEFAULT_REFRESH_RETRY_BASE_MILLIS,
+    private val refreshRetryMaxMillis: Long = DEFAULT_REFRESH_RETRY_MAX_MILLIS,
     private val refreshExecutor: ExecutorService = defaultLinuxMetadataRefreshExecutor(),
 ) : LinuxVirtualFileBackend {
     private val snapshots = ConcurrentHashMap<String, LinuxVirtualDirectorySnapshot>()
-    private val refreshes = ConcurrentHashMap<String, CompletableFuture<LinuxVirtualDirectorySnapshot>>()
+    private val refreshes = ConcurrentHashMap<String, CompletableFuture<LinuxVirtualDirectorySnapshot?>>()
+    private val refreshFailures = ConcurrentHashMap<String, LinuxVirtualRefreshFailure>()
+    private val invalidationGenerations = mutableMapOf<String, Long>()
+    private val metadataLock = Any()
     private val nextGeneration = AtomicLong(1L)
     @Volatile
     private var closed = false
 
     init {
         require(freshForMillis >= 0L)
+        require(refreshRetryBaseMillis > 0L)
+        require(refreshRetryMaxMillis >= refreshRetryBaseMillis)
     }
 
     override fun resolve(path: String): LinuxVirtualFileNode? {
         val normalized = path.linuxVirtualPath()
         if (normalized.isEmpty()) return ROOT_NODE
         val parent = normalized.substringBeforeLast('/', "")
-        return list(parent).firstOrNull { node -> node.path == normalized }
+        return snapshot(parent).nodesByPath[normalized]
     }
 
-    override fun list(path: String): List<LinuxVirtualFileNode> {
-        val normalized = path.linuxVirtualPath()
-        val cached = snapshots[normalized] ?: store.load(normalized)?.also { restored ->
-            snapshots.putIfAbsent(normalized, restored)
+    override fun list(path: String): List<LinuxVirtualFileNode> = snapshot(path.linuxVirtualPath()).nodes
+
+    private fun snapshot(normalized: String): LinuxVirtualDirectorySnapshot {
+        val cached = snapshots[normalized] ?: synchronized(metadataLock) {
+            snapshots[normalized] ?: store.load(normalized)?.also { restored ->
+                snapshots[normalized] = restored
+            }
         }
         if (cached != null) {
             if (!cached.isFresh(nowEpochMillis(), freshForMillis)) refreshAsync(normalized)
-            return cached.nodes
+            return cached
         }
-        return refreshBlocking(normalized).nodes
+        return refreshBlocking(normalized)
     }
 
     override fun open(node: LinuxVirtualFileNode): LinuxVirtualFileReadHandle = delegate.open(node)
@@ -219,36 +235,60 @@ internal class CachingLinuxVirtualFileBackend(
     }
 
     private fun refreshBlocking(path: String): LinuxVirtualDirectorySnapshot {
-        val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot>()
-        val existing = refreshes.putIfAbsent(path, candidate)
-        if (existing != null) return existing.get()
-        refresh(path, candidate)
-        return candidate.get()
+        while (true) {
+            val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot?>()
+            val existing = refreshes.putIfAbsent(path, candidate)
+            val future = existing ?: candidate.also { refresh(path, it) }
+            val refreshed = future.get() ?: continue
+            val stillCurrent = synchronized(metadataLock) {
+                snapshots[path]?.generation == refreshed.generation
+            }
+            if (stillCurrent) return refreshed
+        }
     }
 
     private fun refreshAsync(path: String) {
         if (closed) return
-        val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot>()
+        val now = nowEpochMillis().coerceAtLeast(0L)
+        if (refreshFailures[path]?.retryAtEpochMillis?.let { retryAt -> now < retryAt } == true) return
+        val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot?>()
         if (refreshes.putIfAbsent(path, candidate) != null) return
         runCatching { refreshExecutor.execute { refresh(path, candidate) } }
             .onFailure { failure ->
+                recordRefreshFailure(path)
                 candidate.completeExceptionally(failure)
                 refreshes.remove(path, candidate)
             }
     }
 
-    private fun refresh(path: String, future: CompletableFuture<LinuxVirtualDirectorySnapshot>) {
+    private fun refresh(path: String, future: CompletableFuture<LinuxVirtualDirectorySnapshot?>) {
         try {
             check(!closed) { "The Linux metadata cache is closed." }
+            val invalidationGeneration = synchronized(metadataLock) {
+                invalidationGenerations.getOrDefault(path, 0L)
+            }
             val snapshot = LinuxVirtualDirectorySnapshot(
                 nodes = delegate.list(path),
                 fetchedAtEpochMillis = nowEpochMillis().coerceAtLeast(0L),
                 generation = nextGeneration.getAndIncrement(),
             )
-            snapshots[path] = snapshot
-            future.complete(snapshot)
-            persistAsync(path, snapshot)
+            val published = synchronized(metadataLock) {
+                if (!closed && invalidationGenerations.getOrDefault(path, 0L) == invalidationGeneration) {
+                    snapshots[path] = snapshot
+                    true
+                } else {
+                    false
+                }
+            }
+            if (published) {
+                refreshFailures.remove(path)
+                future.complete(snapshot)
+                persistAsync(path, snapshot)
+            } else {
+                future.complete(null)
+            }
         } catch (failure: Throwable) {
+            if (!closed) recordRefreshFailure(path)
             future.completeExceptionally(failure)
         } finally {
             refreshes.remove(path, future)
@@ -259,8 +299,10 @@ internal class CachingLinuxVirtualFileBackend(
         if (closed) return
         runCatching {
             refreshExecutor.execute {
-                if (!closed && snapshots[path]?.generation == snapshot.generation) {
-                    runCatching { store.store(path, snapshot) }
+                synchronized(metadataLock) {
+                    if (!closed && snapshots[path]?.generation == snapshot.generation) {
+                        runCatching { store.store(path, snapshot) }
+                    }
                 }
             }
         }
@@ -269,13 +311,46 @@ internal class CachingLinuxVirtualFileBackend(
     private fun invalidate(path: String) {
         val normalized = path.linuxVirtualPath()
         val parent = normalized.substringBeforeLast('/', "")
-        snapshots.keys.removeIf { cachedPath ->
-            normalized.isEmpty() ||
-                cachedPath == normalized ||
-                cachedPath.startsWith("$normalized/") ||
-                cachedPath == parent
+        synchronized(metadataLock) {
+            val knownPaths = buildSet {
+                add(normalized)
+                add(parent)
+                addAll(snapshots.keys)
+                addAll(refreshes.keys)
+                addAll(refreshFailures.keys)
+                addAll(invalidationGenerations.keys)
+            }
+            knownPaths.filterTo(mutableSetOf(), { cachedPath ->
+                normalized.isEmpty() ||
+                    cachedPath == normalized ||
+                    cachedPath.startsWith("$normalized/") ||
+                    cachedPath == parent
+            }).forEach { cachedPath ->
+                invalidationGenerations[cachedPath] =
+                    invalidationGenerations.getOrDefault(cachedPath, 0L) + 1L
+                snapshots.remove(cachedPath)
+                refreshFailures.remove(cachedPath)
+            }
+            store.invalidate(normalized)
         }
-        store.invalidate(normalized)
+    }
+
+    private fun recordRefreshFailure(path: String) {
+        val now = nowEpochMillis().coerceAtLeast(0L)
+        refreshFailures.compute(path) { _, previous ->
+            val failures = (previous?.consecutiveFailures ?: 0).plus(1).coerceAtMost(MAX_BACKOFF_EXPONENT + 1)
+            val exponent = (failures - 1).coerceAtMost(MAX_BACKOFF_EXPONENT)
+            val multiplier = 1L shl exponent
+            val delay = if (refreshRetryBaseMillis > refreshRetryMaxMillis / multiplier) {
+                refreshRetryMaxMillis
+            } else {
+                (refreshRetryBaseMillis * multiplier).coerceAtMost(refreshRetryMaxMillis)
+            }
+            LinuxVirtualRefreshFailure(
+                consecutiveFailures = failures,
+                retryAtEpochMillis = if (now > Long.MAX_VALUE - delay) Long.MAX_VALUE else now + delay,
+            )
+        }
     }
 
     private fun LinuxVirtualDirectorySnapshot.isFresh(now: Long, duration: Long): Boolean {
@@ -285,9 +360,17 @@ internal class CachingLinuxVirtualFileBackend(
 
     private companion object {
         const val DEFAULT_FRESH_MILLIS = 5_000L
+        const val DEFAULT_REFRESH_RETRY_BASE_MILLIS = 1_000L
+        const val DEFAULT_REFRESH_RETRY_MAX_MILLIS = 60_000L
+        const val MAX_BACKOFF_EXPONENT = 30
         val ROOT_NODE = LinuxVirtualFileNode("", "Nextcloud", true, 0L, "root")
     }
 }
+
+private data class LinuxVirtualRefreshFailure(
+    val consecutiveFailures: Int,
+    val retryAtEpochMillis: Long,
+)
 
 private fun defaultLinuxMetadataRefreshExecutor(): ExecutorService =
     Executors.newSingleThreadExecutor { task ->

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -146,6 +146,9 @@ internal class CachingLinuxVirtualFileBackend(
     private val failedPersistedInvalidations = mutableSetOf<String>()
     private val revalidatedPersistedListings = linkedSetOf<String>()
     private val activeMetadataOperations = mutableSetOf<LinuxVirtualMetadataOperation>()
+    private val pendingPersistenceLock = Any()
+    private var pendingPersistenceEntries = 0L
+    private var pendingPersistenceDirectories = 0
     private val nextGeneration = AtomicLong(1L)
     @Volatile
     private var closed = false
@@ -230,9 +233,8 @@ internal class CachingLinuxVirtualFileBackend(
 
             @Synchronized
             override fun truncate(size: Long) {
-                val previousSize = handle.size
                 handle.truncate(size)
-                if (size != previousSize) dirty = true
+                dirty = true
             }
 
             @Synchronized
@@ -370,8 +372,9 @@ internal class CachingLinuxVirtualFileBackend(
         snapshot: LinuxVirtualDirectorySnapshot,
         operation: LinuxVirtualMetadataOperation,
     ): Boolean {
-        if (closed) return false
-        return runCatching {
+        val entryWeight = snapshot.nodes.size.coerceAtLeast(1).toLong()
+        if (closed || !reservePendingPersistence(entryWeight)) return false
+        val scheduled = runCatching {
             refreshExecutor.execute {
                 try {
                     val current = synchronized(metadataLock) {
@@ -398,11 +401,30 @@ internal class CachingLinuxVirtualFileBackend(
                         }
                     }
                 } finally {
+                    releasePendingPersistence(entryWeight)
                     endMetadataOperation(operation)
                 }
             }
-            true
-        }.getOrDefault(false)
+        }.isSuccess
+        if (!scheduled) releasePendingPersistence(entryWeight)
+        return scheduled
+    }
+
+    private fun reservePendingPersistence(entryWeight: Long): Boolean = synchronized(pendingPersistenceLock) {
+        if (
+            pendingPersistenceDirectories >= maximumRetainedDirectories ||
+            entryWeight > maximumRetainedMetadataEntries.toLong() - pendingPersistenceEntries
+        ) {
+            return@synchronized false
+        }
+        pendingPersistenceDirectories += 1
+        pendingPersistenceEntries += entryWeight
+        true
+    }
+
+    private fun releasePendingPersistence(entryWeight: Long) = synchronized(pendingPersistenceLock) {
+        pendingPersistenceDirectories = (pendingPersistenceDirectories - 1).coerceAtLeast(0)
+        pendingPersistenceEntries = (pendingPersistenceEntries - entryWeight).coerceAtLeast(0L)
     }
 
     private fun invalidate(path: String) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -135,13 +135,16 @@ internal class CachingLinuxVirtualFileBackend(
     private val maximumRetainedMetadataEntries: Int = DEFAULT_MAX_RETAINED_METADATA_ENTRIES,
     private val maximumRetainedDirectories: Int = DEFAULT_MAX_RETAINED_DIRECTORIES,
     private val refreshExecutor: ExecutorService = defaultLinuxMetadataRefreshExecutor(),
+    private val afterPersistedInvalidationMarked: () -> Unit = {},
 ) : LinuxVirtualFileBackend {
     private val snapshots = LinkedHashMap<String, LinuxVirtualDirectorySnapshot>(16, 0.75f, true)
     private val refreshes = ConcurrentHashMap<String, CompletableFuture<LinuxVirtualDirectorySnapshot?>>()
     private val refreshFailures = ConcurrentHashMap<String, LinuxVirtualRefreshFailure>()
-    private val invalidationGenerations = mutableMapOf<String, Long>()
     private val metadataLock = Any()
+    private val persistedStoreLock = Any()
+    private val pendingPersistedInvalidations = mutableMapOf<String, Int>()
     private val nextGeneration = AtomicLong(1L)
+    private val invalidationEpoch = AtomicLong(0L)
     @Volatile
     private var closed = false
 
@@ -163,9 +166,24 @@ internal class CachingLinuxVirtualFileBackend(
     override fun list(path: String): List<LinuxVirtualFileNode> = snapshot(path.linuxVirtualPath()).nodes
 
     private fun snapshot(normalized: String): LinuxVirtualDirectorySnapshot {
-        val cached = synchronized(metadataLock) {
-            snapshots[normalized] ?: store.load(normalized)?.also { restored ->
-                retainSnapshot(normalized, restored)
+        synchronized(metadataLock) { snapshots[normalized] }?.let { cached ->
+            if (!cached.isFresh(nowEpochMillis(), freshForMillis)) refreshAsync(normalized)
+            return cached
+        }
+        val observedEpoch = invalidationEpoch.get()
+        val persisted = synchronized(persistedStoreLock) {
+            val invalidationPending = synchronized(metadataLock) {
+                pendingPersistedInvalidations.keys.any { mutation -> mutation.invalidatesListing(normalized) }
+            }
+            if (invalidationPending || invalidationEpoch.get() != observedEpoch) null else store.load(normalized)
+        }
+        val cached = persisted?.let { restored ->
+            synchronized(metadataLock) {
+                if (invalidationEpoch.get() == observedEpoch) {
+                    snapshots[normalized] ?: restored.also { retainSnapshot(normalized, it) }
+                } else {
+                    null
+                }
             }
         }
         if (cached != null) {
@@ -254,7 +272,13 @@ internal class CachingLinuxVirtualFileBackend(
     private fun refreshAsync(path: String) {
         if (closed) return
         val now = nowEpochMillis().coerceAtLeast(0L)
-        if (refreshFailures[path]?.retryAtEpochMillis?.let { retryAt -> now < retryAt } == true) return
+        refreshFailures[path]?.let { failure ->
+            if (now < failure.recordedAtEpochMillis) {
+                refreshFailures.remove(path, failure)
+            } else if (now < failure.retryAtEpochMillis) {
+                return
+            }
+        }
         val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot?>()
         if (refreshes.putIfAbsent(path, candidate) != null) return
         runCatching { refreshExecutor.execute { refresh(path, candidate) } }
@@ -268,16 +292,14 @@ internal class CachingLinuxVirtualFileBackend(
     private fun refresh(path: String, future: CompletableFuture<LinuxVirtualDirectorySnapshot?>) {
         try {
             check(!closed) { "The Linux metadata cache is closed." }
-            val invalidationGeneration = synchronized(metadataLock) {
-                invalidationGenerations.getOrDefault(path, 0L)
-            }
+            val observedEpoch = invalidationEpoch.get()
             val snapshot = LinuxVirtualDirectorySnapshot(
                 nodes = delegate.list(path),
                 fetchedAtEpochMillis = nowEpochMillis().coerceAtLeast(0L),
                 generation = nextGeneration.getAndIncrement(),
             )
             val published = synchronized(metadataLock) {
-                if (!closed && invalidationGenerations.getOrDefault(path, 0L) == invalidationGeneration) {
+                if (!closed && invalidationEpoch.get() == observedEpoch) {
                     retainSnapshot(path, snapshot)
                     true
                 } else {
@@ -287,7 +309,7 @@ internal class CachingLinuxVirtualFileBackend(
             if (published) {
                 refreshFailures.remove(path)
                 future.complete(snapshot)
-                persistAsync(path, snapshot)
+                persistAsync(path, snapshot, observedEpoch)
             } else {
                 future.complete(null)
             }
@@ -299,14 +321,22 @@ internal class CachingLinuxVirtualFileBackend(
         }
     }
 
-    private fun persistAsync(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+    private fun persistAsync(path: String, snapshot: LinuxVirtualDirectorySnapshot, observedEpoch: Long) {
         if (closed) return
         runCatching {
             refreshExecutor.execute {
-                synchronized(metadataLock) {
-                    if (!closed && snapshots[path]?.generation == snapshot.generation) {
-                        runCatching { store.store(path, snapshot) }
+                val current = synchronized(metadataLock) {
+                    !closed &&
+                        invalidationEpoch.get() == observedEpoch &&
+                        snapshots[path]?.generation == snapshot.generation
+                }
+                if (current) synchronized(persistedStoreLock) {
+                    val stillCurrent = synchronized(metadataLock) {
+                        !closed &&
+                            invalidationEpoch.get() == observedEpoch &&
+                            snapshots[path]?.generation == snapshot.generation
                     }
+                    if (stillCurrent) runCatching { store.store(path, snapshot) }
                 }
             }
         }
@@ -315,6 +345,7 @@ internal class CachingLinuxVirtualFileBackend(
     private fun invalidate(path: String) {
         val normalized = path.linuxVirtualPath()
         val parent = normalized.substringBeforeLast('/', "")
+        invalidationEpoch.incrementAndGet()
         synchronized(metadataLock) {
             val knownPaths = buildSet {
                 add(normalized)
@@ -322,7 +353,6 @@ internal class CachingLinuxVirtualFileBackend(
                 addAll(snapshots.keys)
                 addAll(refreshes.keys)
                 addAll(refreshFailures.keys)
-                addAll(invalidationGenerations.keys)
             }
             knownPaths.filterTo(mutableSetOf(), { cachedPath ->
                 normalized.isEmpty() ||
@@ -330,13 +360,22 @@ internal class CachingLinuxVirtualFileBackend(
                     cachedPath.startsWith("$normalized/") ||
                     cachedPath == parent
             }).forEach { cachedPath ->
-                invalidationGenerations[cachedPath] =
-                    invalidationGenerations.getOrDefault(cachedPath, 0L) + 1L
                 snapshots.remove(cachedPath)
                 refreshFailures.remove(cachedPath)
             }
+            pendingPersistedInvalidations[normalized] =
+                pendingPersistedInvalidations.getOrDefault(normalized, 0) + 1
         }
-        runCatching { store.invalidate(normalized) }
+        afterPersistedInvalidationMarked()
+        try {
+            synchronized(persistedStoreLock) { runCatching { store.invalidate(normalized) } }
+        } finally {
+            synchronized(metadataLock) {
+                val remaining = pendingPersistedInvalidations.getOrDefault(normalized, 1) - 1
+                if (remaining <= 0) pendingPersistedInvalidations.remove(normalized)
+                else pendingPersistedInvalidations[normalized] = remaining
+            }
+        }
     }
 
     private fun retainSnapshot(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
@@ -368,6 +407,7 @@ internal class CachingLinuxVirtualFileBackend(
             }
             LinuxVirtualRefreshFailure(
                 consecutiveFailures = failures,
+                recordedAtEpochMillis = now,
                 retryAtEpochMillis = if (now > Long.MAX_VALUE - delay) Long.MAX_VALUE else now + delay,
             )
         }
@@ -391,8 +431,14 @@ internal class CachingLinuxVirtualFileBackend(
 
 private data class LinuxVirtualRefreshFailure(
     val consecutiveFailures: Int,
+    val recordedAtEpochMillis: Long,
     val retryAtEpochMillis: Long,
 )
+
+private fun String.invalidatesListing(listingPath: String): Boolean {
+    val parent = substringBeforeLast('/', "")
+    return isEmpty() || listingPath == this || listingPath.startsWith("$this/") || listingPath == parent
+}
 
 private fun defaultLinuxMetadataRefreshExecutor(): ExecutorService =
     Executors.newSingleThreadExecutor { task ->

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -1,7 +1,10 @@
 package dev.obiente.nextcloudnative.app
 
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 import jnr.ffi.Pointer
 import jnr.ffi.Platform
@@ -35,7 +38,7 @@ internal interface LinuxVirtualFileWriteHandle : AutoCloseable {
     fun flush()
 }
 
-internal interface LinuxVirtualFileBackend {
+internal interface LinuxVirtualFileBackend : AutoCloseable {
     fun resolve(path: String): LinuxVirtualFileNode?
     fun list(path: String): List<LinuxVirtualFileNode>
     fun open(node: LinuxVirtualFileNode): LinuxVirtualFileReadHandle
@@ -48,7 +51,248 @@ internal interface LinuxVirtualFileBackend {
         destination: LinuxVirtualFileNode,
         destinationPath: String,
     )
+
+    override fun close() = Unit
 }
+
+internal data class LinuxVirtualDirectorySnapshot(
+    val nodes: List<LinuxVirtualFileNode>,
+    val fetchedAtEpochMillis: Long,
+    val generation: Long = 0L,
+)
+
+internal interface LinuxVirtualMetadataStore {
+    fun load(path: String): LinuxVirtualDirectorySnapshot?
+    fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot)
+    fun invalidate(path: String)
+}
+
+internal class DesktopLinuxVirtualMetadataStore(
+    private val cache: DesktopFileReadCache,
+    private val accountId: String,
+) : LinuxVirtualMetadataStore {
+    override fun load(path: String): LinuxVirtualDirectorySnapshot? {
+        val listing = cache.cachedListingSnapshot(accountId, path) ?: return null
+        val nodes = listing.files.mapNotNull { file ->
+            val revision = file.etag?.takeIf(String::isNotBlank) ?: return null
+            LinuxVirtualFileNode(
+                path = file.path,
+                name = file.name,
+                directory = file.isDirectory,
+                size = file.size ?: 0L,
+                remoteRevision = revision,
+            )
+        }
+        return LinuxVirtualDirectorySnapshot(nodes, listing.fetchedAtEpochMillis)
+    }
+
+    override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+        val previous = cache.cachedListing(accountId, path).orEmpty().associateBy(NextcloudFile::path)
+        val files = snapshot.nodes.map { node ->
+            previous[node.path]?.copy(
+                name = node.name,
+                isDirectory = node.directory,
+                size = node.size.takeUnless { node.directory },
+                etag = node.remoteRevision,
+            ) ?: NextcloudFile(
+                path = node.path,
+                name = node.name,
+                isDirectory = node.directory,
+                mimeType = null,
+                size = node.size.takeUnless { node.directory },
+                lastModified = null,
+                fileId = null,
+                hasPreview = false,
+                etag = node.remoteRevision,
+            )
+        }
+        cache.storeListing(accountId, path, files, snapshot.fetchedAtEpochMillis)
+    }
+
+    override fun invalidate(path: String) = cache.invalidate(accountId, path)
+}
+
+/**
+ * Coalesces directory reads and serves a persisted snapshot before refreshing stale metadata.
+ *
+ * File managers typically follow one readdir with a getattr for every visible child. Resolving a
+ * child from its cached parent snapshot prevents that access pattern from becoming one WebDAV
+ * PROPFIND per entry. A stale snapshot remains useful while one daemon refresh updates it.
+ */
+internal class CachingLinuxVirtualFileBackend(
+    private val delegate: LinuxVirtualFileBackend,
+    private val store: LinuxVirtualMetadataStore,
+    private val nowEpochMillis: () -> Long = System::currentTimeMillis,
+    private val freshForMillis: Long = DEFAULT_FRESH_MILLIS,
+    private val refreshExecutor: ExecutorService = defaultLinuxMetadataRefreshExecutor(),
+) : LinuxVirtualFileBackend {
+    private val snapshots = ConcurrentHashMap<String, LinuxVirtualDirectorySnapshot>()
+    private val refreshes = ConcurrentHashMap<String, CompletableFuture<LinuxVirtualDirectorySnapshot>>()
+    private val nextGeneration = AtomicLong(1L)
+    @Volatile
+    private var closed = false
+
+    init {
+        require(freshForMillis >= 0L)
+    }
+
+    override fun resolve(path: String): LinuxVirtualFileNode? {
+        val normalized = path.linuxVirtualPath()
+        if (normalized.isEmpty()) return ROOT_NODE
+        val parent = normalized.substringBeforeLast('/', "")
+        return list(parent).firstOrNull { node -> node.path == normalized }
+    }
+
+    override fun list(path: String): List<LinuxVirtualFileNode> {
+        val normalized = path.linuxVirtualPath()
+        val cached = snapshots[normalized] ?: store.load(normalized)?.also { restored ->
+            snapshots.putIfAbsent(normalized, restored)
+        }
+        if (cached != null) {
+            if (!cached.isFresh(nowEpochMillis(), freshForMillis)) refreshAsync(normalized)
+            return cached.nodes
+        }
+        return refreshBlocking(normalized).nodes
+    }
+
+    override fun open(node: LinuxVirtualFileNode): LinuxVirtualFileReadHandle = delegate.open(node)
+
+    override fun openWrite(
+        path: String,
+        existing: LinuxVirtualFileNode?,
+        truncate: Boolean,
+    ): LinuxVirtualFileWriteHandle {
+        val normalized = path.linuxVirtualPath()
+        val handle = delegate.openWrite(normalized, existing, truncate)
+        return object : LinuxVirtualFileWriteHandle {
+            override val size: Long get() = handle.size
+            override fun read(offset: Long, length: Int): ByteArray = handle.read(offset, length)
+            override fun write(offset: Long, bytes: ByteArray): Int = handle.write(offset, bytes)
+            override fun truncate(size: Long) = handle.truncate(size)
+            override fun flush() {
+                handle.flush()
+                invalidate(normalized)
+            }
+
+            override fun close() {
+                handle.close()
+                invalidate(normalized)
+            }
+        }
+    }
+
+    override fun createDirectory(path: String) {
+        val normalized = path.linuxVirtualPath()
+        delegate.createDirectory(normalized)
+        invalidate(normalized)
+    }
+
+    override fun delete(node: LinuxVirtualFileNode) {
+        delegate.delete(node)
+        invalidate(node.path)
+    }
+
+    override fun move(node: LinuxVirtualFileNode, destinationPath: String) {
+        val destination = destinationPath.linuxVirtualPath()
+        delegate.move(node, destination)
+        invalidate(node.path)
+        invalidate(destination)
+    }
+
+    override fun moveReplacing(
+        node: LinuxVirtualFileNode,
+        destination: LinuxVirtualFileNode,
+        destinationPath: String,
+    ) {
+        val normalized = destinationPath.linuxVirtualPath()
+        delegate.moveReplacing(node, destination, normalized)
+        invalidate(node.path)
+        invalidate(normalized)
+    }
+
+    @Synchronized
+    override fun close() {
+        if (closed) return
+        closed = true
+        refreshExecutor.shutdownNow()
+        delegate.close()
+    }
+
+    private fun refreshBlocking(path: String): LinuxVirtualDirectorySnapshot {
+        val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot>()
+        val existing = refreshes.putIfAbsent(path, candidate)
+        if (existing != null) return existing.get()
+        refresh(path, candidate)
+        return candidate.get()
+    }
+
+    private fun refreshAsync(path: String) {
+        if (closed) return
+        val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot>()
+        if (refreshes.putIfAbsent(path, candidate) != null) return
+        runCatching { refreshExecutor.execute { refresh(path, candidate) } }
+            .onFailure { failure ->
+                candidate.completeExceptionally(failure)
+                refreshes.remove(path, candidate)
+            }
+    }
+
+    private fun refresh(path: String, future: CompletableFuture<LinuxVirtualDirectorySnapshot>) {
+        try {
+            check(!closed) { "The Linux metadata cache is closed." }
+            val snapshot = LinuxVirtualDirectorySnapshot(
+                nodes = delegate.list(path),
+                fetchedAtEpochMillis = nowEpochMillis().coerceAtLeast(0L),
+                generation = nextGeneration.getAndIncrement(),
+            )
+            snapshots[path] = snapshot
+            future.complete(snapshot)
+            persistAsync(path, snapshot)
+        } catch (failure: Throwable) {
+            future.completeExceptionally(failure)
+        } finally {
+            refreshes.remove(path, future)
+        }
+    }
+
+    private fun persistAsync(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+        if (closed) return
+        runCatching {
+            refreshExecutor.execute {
+                if (!closed && snapshots[path]?.generation == snapshot.generation) {
+                    runCatching { store.store(path, snapshot) }
+                }
+            }
+        }
+    }
+
+    private fun invalidate(path: String) {
+        val normalized = path.linuxVirtualPath()
+        val parent = normalized.substringBeforeLast('/', "")
+        snapshots.keys.removeIf { cachedPath ->
+            normalized.isEmpty() ||
+                cachedPath == normalized ||
+                cachedPath.startsWith("$normalized/") ||
+                cachedPath == parent
+        }
+        store.invalidate(normalized)
+    }
+
+    private fun LinuxVirtualDirectorySnapshot.isFresh(now: Long, duration: Long): Boolean {
+        val age = now - fetchedAtEpochMillis
+        return age >= 0L && age <= duration
+    }
+
+    private companion object {
+        const val DEFAULT_FRESH_MILLIS = 5_000L
+        val ROOT_NODE = LinuxVirtualFileNode("", "Nextcloud", true, 0L, "root")
+    }
+}
+
+private fun defaultLinuxMetadataRefreshExecutor(): ExecutorService =
+    Executors.newSingleThreadExecutor { task ->
+        Thread(task, "nextcloud-linux-metadata-refresh").apply { isDaemon = true }
+    }
 
 /** Generation-pinned WebDAV backend shared by the Linux FUSE adapter and its unit tests. */
 internal class DesktopNextcloudVirtualFileBackend(
@@ -229,6 +473,7 @@ internal class LinuxNextcloudVirtualFileSystem(
     private val readHandles = ConcurrentHashMap<Long, LinuxVirtualFileReadHandle>()
     private val readHandlePaths = ConcurrentHashMap<Long, String>()
     private val writeHandles = ConcurrentHashMap<Long, LinuxOpenWriteReference>()
+    private val directoryHandles = ConcurrentHashMap<Long, LinuxOpenDirectorySnapshot>()
     private val pendingCreatedFiles = ConcurrentHashMap<String, LinuxSharedWriteHandle>()
     private val namespaceLock = Any()
 
@@ -238,14 +483,15 @@ internal class LinuxNextcloudVirtualFileSystem(
         val node = visibleNode(normalized)
             ?: pending?.let { LinuxVirtualFileNode(normalized, normalized.substringAfterLast('/'), false, it.size, "pending") }
             ?: return -ErrorCodes.ENOENT()
-        stat.st_mode.set(
-            if (node.directory) FileStat.S_IFDIR or DIRECTORY_PERMISSIONS
-            else FileStat.S_IFREG or FILE_PERMISSIONS,
-        )
-        stat.st_nlink.set(if (node.directory) 2 else 1)
-        stat.st_size.set(node.size)
-        stat.st_uid.set(context.uid.get())
-        stat.st_gid.set(context.gid.get())
+        fillStat(node, stat)
+        0
+    }
+
+    override fun opendir(path: String, fileInfo: FuseFileInfo): Int = fuseResult {
+        val snapshot = openDirectorySnapshot(path)
+        val id = nextHandle.getAndIncrement()
+        directoryHandles[id] = snapshot
+        fileInfo.fh.set(id)
         0
     }
 
@@ -257,22 +503,30 @@ internal class LinuxNextcloudVirtualFileSystem(
         fileInfo: FuseFileInfo,
     ): Int = fuseResult {
         val normalized = path.linuxVirtualPath()
-        val directory = visibleNode(normalized) ?: return -ErrorCodes.ENOENT()
-        if (!directory.directory) return -ErrorCodes.ENOTDIR()
-        val visibleNames = LinkedHashSet<String>()
-        backend.list(normalized)
-            .forEach { node -> visibleNames += node.name }
-        pendingCreatedFiles.keys
-            .asSequence()
-            .filter { pending -> pending.substringBeforeLast('/', "") == normalized }
-            .map { pending -> pending.substringAfterLast('/') }
-            .filter(visibleNames::add)
-            .toList()
-        val entries = listOf(".", "..") + visibleNames.sorted()
+        val handleId = fileInfo.fh.get()
+        val existingHandle = directoryHandles[handleId]?.takeIf { it.path == normalized }
+        if (handleId != 0L && existingHandle == null) return -ErrorCodes.EBADF()
+        val snapshot = existingHandle ?: openDirectorySnapshot(path).also { opened ->
+            val id = nextHandle.getAndIncrement()
+            directoryHandles[id] = opened
+            fileInfo.fh.set(id)
+        }
+        val entries = snapshot.entries
         if (offset < 0L || offset > entries.size.toLong()) return -ErrorCodes.EINVAL()
         for (index in offset.toInt() until entries.size) {
-            if (filler.apply(buffer, entries[index], null, index.toLong() + 1L) != 0) break
+            val entry = entries[index]
+            val stat = entry.node?.let { node -> FileStat(jnr.ffi.Runtime.getSystemRuntime()).also { fillStat(node, it) } }
+            if (filler.apply(buffer, entry.name, stat, index.toLong() + 1L) != 0) break
         }
+        0
+    }
+
+    override fun releasedir(path: String, fileInfo: FuseFileInfo): Int = fuseResult {
+        val id = fileInfo.fh.get()
+        val handle = directoryHandles[id] ?: return -ErrorCodes.EBADF()
+        if (handle.path != path.linuxVirtualPath()) return -ErrorCodes.EBADF()
+        if (!directoryHandles.remove(id, handle)) return -ErrorCodes.EBADF()
+        fileInfo.fh.set(0L)
         0
     }
 
@@ -451,7 +705,19 @@ internal class LinuxNextcloudVirtualFileSystem(
         require(mountPoint.toFile().let { it.isDirectory && it.canWrite() }) {
             "The Linux virtual filesystem mount point must be a writable directory."
         }
-        mount(mountPoint, blocking, debug, arrayOf("-o", "fsname=nextcloud-native", "-o", "default_permissions"))
+        mount(
+            mountPoint,
+            blocking,
+            debug,
+            arrayOf(
+                "-o", "fsname=nextcloud-native",
+                "-o", "default_permissions",
+                "-o", "attr_timeout=5",
+                "-o", "entry_timeout=5",
+                "-o", "negative_timeout=1",
+                "-o", "big_writes",
+            ),
+        )
     }
 
     fun unmount() {
@@ -462,8 +728,50 @@ internal class LinuxNextcloudVirtualFileSystem(
         readHandles.clear()
         readHandlePaths.clear()
         writeHandles.clear()
+        directoryHandles.clear()
         pendingCreatedFiles.clear()
-        umount()
+        try {
+            umount()
+        } finally {
+            backend.close()
+        }
+    }
+
+    private fun openDirectorySnapshot(path: String): LinuxOpenDirectorySnapshot {
+        val normalized = path.linuxVirtualPath()
+        val directory = visibleNode(normalized) ?: throw LinuxVirtualFileSystemException(ErrorCodes.ENOENT())
+        if (!directory.directory) throw LinuxVirtualFileSystemException(ErrorCodes.ENOTDIR())
+        val byName = linkedMapOf<String, LinuxVirtualFileNode>()
+        backend.list(normalized).forEach { node -> byName[node.name] = node }
+        pendingCreatedFiles.entries
+            .asSequence()
+            .filter { (pending, _) -> pending.substringBeforeLast('/', "") == normalized }
+            .forEach { (pending, shared) ->
+                val name = pending.substringAfterLast('/')
+                byName.putIfAbsent(
+                    name,
+                    LinuxVirtualFileNode(pending, name, false, shared.delegate.size, "pending"),
+                )
+            }
+        val entries = buildList {
+            add(LinuxOpenDirectoryEntry(".", directory))
+            add(LinuxOpenDirectoryEntry("..", null))
+            byName.values.sortedBy(LinuxVirtualFileNode::name).forEach { node ->
+                add(LinuxOpenDirectoryEntry(node.name, node))
+            }
+        }
+        return LinuxOpenDirectorySnapshot(normalized, entries)
+    }
+
+    private fun fillStat(node: LinuxVirtualFileNode, stat: FileStat) {
+        stat.st_mode.set(
+            if (node.directory) FileStat.S_IFDIR or DIRECTORY_PERMISSIONS
+            else FileStat.S_IFREG or FILE_PERMISSIONS,
+        )
+        stat.st_nlink.set(if (node.directory) 2 else 1)
+        stat.st_size.set(node.size)
+        stat.st_uid.set(context.uid.get())
+        stat.st_gid.set(context.gid.get())
     }
 
     private fun registerWriteHandle(shared: LinuxSharedWriteHandle, writable: Boolean): Long {
@@ -549,6 +857,8 @@ internal class LinuxNextcloudVirtualFileSystem(
 
     private inline fun fuseResult(operation: () -> Int): Int = try {
         operation()
+    } catch (failure: LinuxVirtualFileSystemException) {
+        -failure.errorCode
     } catch (_: IllegalArgumentException) {
         -ErrorCodes.EINVAL()
     } catch (_: Throwable) {
@@ -564,6 +874,18 @@ internal class LinuxNextcloudVirtualFileSystem(
         const val OPEN_TRUNCATE = 0x200
     }
 }
+
+private data class LinuxOpenDirectorySnapshot(
+    val path: String,
+    val entries: List<LinuxOpenDirectoryEntry>,
+)
+
+private data class LinuxOpenDirectoryEntry(
+    val name: String,
+    val node: LinuxVirtualFileNode?,
+)
+
+private class LinuxVirtualFileSystemException(val errorCode: Int) : RuntimeException()
 
 private class LinuxSharedWriteHandle(
     val delegate: LinuxVirtualFileWriteHandle,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -98,7 +98,11 @@ internal class DesktopLinuxVirtualMetadataStore(
 ) : LinuxVirtualMetadataStore {
     override fun load(path: String): LinuxVirtualDirectorySnapshot? {
         val listing = cache.cachedVirtualListingSnapshot(accountId, path) ?: return null
-        return LinuxVirtualDirectorySnapshot(listing.nodes, listing.fetchedAtEpochMillis)
+        return LinuxVirtualDirectorySnapshot(
+            nodes = listing.nodes,
+            fetchedAtEpochMillis = listing.fetchedAtEpochMillis,
+            freshAtEpochMillis = listing.freshAtEpochMillis,
+        )
     }
 
     override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean =
@@ -107,6 +111,7 @@ internal class DesktopLinuxVirtualMetadataStore(
             path = path,
             nodes = snapshot.nodes,
             fetchedAtEpochMillis = snapshot.fetchedAtEpochMillis,
+            freshAtEpochMillis = snapshot.freshAtEpochMillis,
         )
 
     override fun invalidate(path: String) = cache.invalidate(accountId, path)
@@ -492,6 +497,7 @@ internal class CachingLinuxVirtualFileBackend(
     private fun invalidate(path: String) {
         val normalized = path.linuxVirtualPath()
         val parent = normalized.substringBeforeLast('/', "")
+        var quarantinePersisted = false
         synchronized(metadataLock) {
             val knownPaths = buildSet {
                 add(normalized)
@@ -515,13 +521,23 @@ internal class CachingLinuxVirtualFileBackend(
             // Persist the fail-closed quarantine before touching the main cache index. If the
             // process stops during invalidation, the next process must not restore stale data.
             rememberFailedPersistedInvalidation(normalized)
-            store.replaceFailedInvalidations(failedPersistedInvalidations)
+            quarantinePersisted = persistFailedInvalidationsBestEffort()
         }
-        afterPersistedInvalidationMarked()
         var persistedInvalidated = false
-        try {
+        if (!quarantinePersisted) {
+            // Preferences can be unavailable even while the cache volume is writable. In that
+            // case remove the affected index before exposing the mutation as complete so a
+            // restart cannot resurrect the stale listing.
             synchronized(persistedStoreLock) {
                 persistedInvalidated = runCatching { store.invalidate(normalized) }.isSuccess
+            }
+        }
+        afterPersistedInvalidationMarked()
+        try {
+            if (!persistedInvalidated) {
+                synchronized(persistedStoreLock) {
+                    persistedInvalidated = runCatching { store.invalidate(normalized) }.isSuccess
+                }
             }
         } finally {
             synchronized(metadataLock) {
@@ -531,7 +547,7 @@ internal class CachingLinuxVirtualFileBackend(
                     }
                     pruneUnpairedRevalidatedListings()
                 }
-                store.replaceFailedInvalidations(failedPersistedInvalidations)
+                persistFailedInvalidationsBestEffort()
                 val remaining = pendingPersistedInvalidations.getOrDefault(normalized, 1) - 1
                 if (remaining <= 0) pendingPersistedInvalidations.remove(normalized)
                 else pendingPersistedInvalidations[normalized] = remaining
@@ -583,7 +599,12 @@ internal class CachingLinuxVirtualFileBackend(
             }
         }
         pruneUnpairedRevalidatedListings()
-        store.replaceFailedInvalidations(failedPersistedInvalidations)
+        persistFailedInvalidationsBestEffort()
+    }
+
+    private fun persistFailedInvalidationsBestEffort(): Boolean {
+        check(Thread.holdsLock(metadataLock))
+        return runCatching { store.replaceFailedInvalidations(failedPersistedInvalidations) }.isSuccess
     }
 
     private fun retainSnapshot(path: String, snapshot: LinuxVirtualDirectorySnapshot) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -73,6 +73,7 @@ internal interface LinuxVirtualFileBackend : AutoCloseable {
 internal data class LinuxVirtualDirectorySnapshot(
     val nodes: List<LinuxVirtualFileNode>,
     val fetchedAtEpochMillis: Long,
+    val freshAtEpochMillis: Long = fetchedAtEpochMillis,
     val generation: Long = 0L,
 ) {
     val nodesByPath: Map<String, LinuxVirtualFileNode> = nodes.associateBy(LinuxVirtualFileNode::path)
@@ -395,9 +396,11 @@ internal class CachingLinuxVirtualFileBackend(
         try {
             check(!closed) { "The Linux metadata cache is closed." }
             val requestStartedAtEpochMillis = nowEpochMillis().coerceAtLeast(0L)
+            val nodes = delegate.list(path)
             val snapshot = LinuxVirtualDirectorySnapshot(
-                nodes = delegate.list(path),
+                nodes = nodes,
                 fetchedAtEpochMillis = requestStartedAtEpochMillis,
+                freshAtEpochMillis = nowEpochMillis().coerceAtLeast(requestStartedAtEpochMillis),
                 generation = nextGeneration.getAndIncrement(),
             )
             val published = synchronized(metadataLock) {
@@ -509,6 +512,10 @@ internal class CachingLinuxVirtualFileBackend(
             revalidatedPersistedListings.removeIf { listing -> normalized.invalidatesListing(listing) }
             pendingPersistedInvalidations[normalized] =
                 pendingPersistedInvalidations.getOrDefault(normalized, 0) + 1
+            // Persist the fail-closed quarantine before touching the main cache index. If the
+            // process stops during invalidation, the next process must not restore stale data.
+            rememberFailedPersistedInvalidation(normalized)
+            store.replaceFailedInvalidations(failedPersistedInvalidations)
         }
         afterPersistedInvalidationMarked()
         var persistedInvalidated = false
@@ -523,8 +530,6 @@ internal class CachingLinuxVirtualFileBackend(
                         normalized.isEmpty() || failed == normalized || failed.startsWith("$normalized/")
                     }
                     pruneUnpairedRevalidatedListings()
-                } else {
-                    rememberFailedPersistedInvalidation(normalized)
                 }
                 store.replaceFailedInvalidations(failedPersistedInvalidations)
                 val remaining = pendingPersistedInvalidations.getOrDefault(normalized, 1) - 1
@@ -630,7 +635,7 @@ internal class CachingLinuxVirtualFileBackend(
     }
 
     private fun LinuxVirtualDirectorySnapshot.isFresh(now: Long, duration: Long): Boolean {
-        val age = now - fetchedAtEpochMillis
+        val age = now - freshAtEpochMillis
         return age >= 0L && age <= duration
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -665,11 +665,13 @@ internal class DesktopNextcloudVirtualFileBackend(
     private val services: NextcloudPlatformServices,
     private val rangeCache: DesktopVirtualRangeCache,
     private val writebacks: DesktopLinuxVirtualFileWritebackStore,
+    onMutationCommitted: (relativePath: String) -> Unit = {},
     onAmbiguousMutationResult: (relativePath: String) -> Unit = {},
     private val tree: DesktopFileSyncRemoteTree = DesktopFileSyncRemoteTree(
         session = session,
         userId = userId,
         remoteRootPath = "",
+        onMutationCommitted = onMutationCommitted,
         onAmbiguousMutationResult = onAmbiguousMutationResult,
     ),
 ) : LinuxVirtualFileBackend {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -112,7 +112,7 @@ internal class DesktopLinuxVirtualMetadataStore(
                 etag = node.remoteRevision,
             )
         }
-        cache.storeListing(accountId, path, files, snapshot.fetchedAtEpochMillis)
+        cache.storeListingUnlessNewer(accountId, path, files, snapshot.fetchedAtEpochMillis)
     }
 
     override fun invalidate(path: String) = cache.invalidate(accountId, path)
@@ -132,9 +132,11 @@ internal class CachingLinuxVirtualFileBackend(
     private val freshForMillis: Long = DEFAULT_FRESH_MILLIS,
     private val refreshRetryBaseMillis: Long = DEFAULT_REFRESH_RETRY_BASE_MILLIS,
     private val refreshRetryMaxMillis: Long = DEFAULT_REFRESH_RETRY_MAX_MILLIS,
+    private val maximumRetainedMetadataEntries: Int = DEFAULT_MAX_RETAINED_METADATA_ENTRIES,
+    private val maximumRetainedDirectories: Int = DEFAULT_MAX_RETAINED_DIRECTORIES,
     private val refreshExecutor: ExecutorService = defaultLinuxMetadataRefreshExecutor(),
 ) : LinuxVirtualFileBackend {
-    private val snapshots = ConcurrentHashMap<String, LinuxVirtualDirectorySnapshot>()
+    private val snapshots = LinkedHashMap<String, LinuxVirtualDirectorySnapshot>(16, 0.75f, true)
     private val refreshes = ConcurrentHashMap<String, CompletableFuture<LinuxVirtualDirectorySnapshot?>>()
     private val refreshFailures = ConcurrentHashMap<String, LinuxVirtualRefreshFailure>()
     private val invalidationGenerations = mutableMapOf<String, Long>()
@@ -147,6 +149,8 @@ internal class CachingLinuxVirtualFileBackend(
         require(freshForMillis >= 0L)
         require(refreshRetryBaseMillis > 0L)
         require(refreshRetryMaxMillis >= refreshRetryBaseMillis)
+        require(maximumRetainedMetadataEntries > 0)
+        require(maximumRetainedDirectories > 0)
     }
 
     override fun resolve(path: String): LinuxVirtualFileNode? {
@@ -159,9 +163,9 @@ internal class CachingLinuxVirtualFileBackend(
     override fun list(path: String): List<LinuxVirtualFileNode> = snapshot(path.linuxVirtualPath()).nodes
 
     private fun snapshot(normalized: String): LinuxVirtualDirectorySnapshot {
-        val cached = snapshots[normalized] ?: synchronized(metadataLock) {
+        val cached = synchronized(metadataLock) {
             snapshots[normalized] ?: store.load(normalized)?.also { restored ->
-                snapshots[normalized] = restored
+                retainSnapshot(normalized, restored)
             }
         }
         if (cached != null) {
@@ -274,7 +278,7 @@ internal class CachingLinuxVirtualFileBackend(
             )
             val published = synchronized(metadataLock) {
                 if (!closed && invalidationGenerations.getOrDefault(path, 0L) == invalidationGeneration) {
-                    snapshots[path] = snapshot
+                    retainSnapshot(path, snapshot)
                     true
                 } else {
                     false
@@ -331,7 +335,23 @@ internal class CachingLinuxVirtualFileBackend(
                 snapshots.remove(cachedPath)
                 refreshFailures.remove(cachedPath)
             }
-            store.invalidate(normalized)
+        }
+        runCatching { store.invalidate(normalized) }
+    }
+
+    private fun retainSnapshot(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+        check(Thread.holdsLock(metadataLock))
+        snapshots[path] = snapshot
+        var retainedEntries = snapshots.values.sumOf { retained -> retained.nodes.size }
+        val iterator = snapshots.entries.iterator()
+        while (
+            (retainedEntries > maximumRetainedMetadataEntries || snapshots.size > maximumRetainedDirectories) &&
+            snapshots.size > 1 &&
+            iterator.hasNext()
+        ) {
+            val evicted = iterator.next()
+            retainedEntries -= evicted.value.nodes.size
+            iterator.remove()
         }
     }
 
@@ -362,6 +382,8 @@ internal class CachingLinuxVirtualFileBackend(
         const val DEFAULT_FRESH_MILLIS = 5_000L
         const val DEFAULT_REFRESH_RETRY_BASE_MILLIS = 1_000L
         const val DEFAULT_REFRESH_RETRY_MAX_MILLIS = 60_000L
+        const val DEFAULT_MAX_RETAINED_METADATA_ENTRIES = 100_000
+        const val DEFAULT_MAX_RETAINED_DIRECTORIES = 512
         const val MAX_BACKOFF_EXPONENT = 30
         val ROOT_NODE = LinuxVirtualFileNode("", "Nextcloud", true, 0L, "root")
     }
@@ -745,6 +767,7 @@ internal class LinuxNextcloudVirtualFileSystem(
                 backend.move(source, destination)
             }
             readdressReadHandles(sourcePath, destination)
+            readdressDirectoryHandles(sourcePath, destination)
             0
         }
     }
@@ -899,6 +922,19 @@ internal class LinuxNextcloudVirtualFileSystem(
             readHandles[id]?.readdress(movedPath)
             readHandlePaths.replace(id, openPath, movedPath)
         }
+    }
+
+    private fun readdressDirectoryHandles(sourcePath: String, destinationPath: String) {
+        directoryHandles.entries.toList().forEach { (id, snapshot) ->
+            val movedPath = snapshot.path.readdressWithin(sourcePath, destinationPath) ?: return@forEach
+            directoryHandles.replace(id, snapshot, snapshot.copy(path = movedPath))
+        }
+    }
+
+    private fun String.readdressWithin(sourcePath: String, destinationPath: String): String? = when {
+        this == sourcePath -> destinationPath
+        startsWith("$sourcePath/") -> destinationPath + removePrefix(sourcePath)
+        else -> null
     }
 
     private fun hasOpenWriteHandleWithin(path: String): Boolean =

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicLong
 import jnr.ffi.Pointer
 import jnr.ffi.Platform
@@ -79,46 +80,22 @@ internal class DesktopLinuxVirtualMetadataStore(
     private val accountId: String,
 ) : LinuxVirtualMetadataStore {
     override fun load(path: String): LinuxVirtualDirectorySnapshot? {
-        val listing = cache.cachedListingSnapshot(accountId, path) ?: return null
-        val nodes = listing.files.mapNotNull { file ->
-            val revision = file.etag?.takeIf(String::isNotBlank) ?: return null
-            LinuxVirtualFileNode(
-                path = file.path,
-                name = file.name,
-                directory = file.isDirectory,
-                size = file.size ?: 0L,
-                remoteRevision = revision,
-            )
-        }
-        return LinuxVirtualDirectorySnapshot(nodes, listing.fetchedAtEpochMillis)
+        val listing = cache.cachedVirtualListingSnapshot(accountId, path) ?: return null
+        return LinuxVirtualDirectorySnapshot(listing.nodes, listing.fetchedAtEpochMillis)
     }
 
     override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
-        val previous = cache.cachedListing(accountId, path).orEmpty().associateBy(NextcloudFile::path)
-        val files = snapshot.nodes.map { node ->
-            previous[node.path]?.takeIf { file -> file.etag == node.remoteRevision }?.copy(
-                name = node.name,
-                isDirectory = node.directory,
-                size = node.size.takeUnless { node.directory },
-                etag = node.remoteRevision,
-            ) ?: NextcloudFile(
-                path = node.path,
-                name = node.name,
-                isDirectory = node.directory,
-                mimeType = null,
-                size = node.size.takeUnless { node.directory },
-                lastModified = null,
-                fileId = null,
-                hasPreview = false,
-                etag = node.remoteRevision,
-            )
-        }
-        cache.storeListingUnlessNewer(accountId, path, files, snapshot.fetchedAtEpochMillis)
+        cache.storeVirtualListingUnlessNewer(
+            accountId = accountId,
+            path = path,
+            nodes = snapshot.nodes,
+            fetchedAtEpochMillis = snapshot.fetchedAtEpochMillis,
+        )
     }
 
     override fun invalidate(path: String) = cache.invalidate(accountId, path)
 
-    override fun retainedPaths(): Set<String> = cache.cachedListingPaths(accountId)
+    override fun retainedPaths(): Set<String> = cache.cachedVirtualListingPaths(accountId)
 }
 
 /**
@@ -142,6 +119,7 @@ internal class CachingLinuxVirtualFileBackend(
 ) : LinuxVirtualFileBackend {
     private val snapshots = LinkedHashMap<String, LinuxVirtualDirectorySnapshot>(16, 0.75f, true)
     private val refreshes = ConcurrentHashMap<String, CompletableFuture<LinuxVirtualDirectorySnapshot?>>()
+    private val blockingRefreshPermits = Semaphore(MAX_CONCURRENT_BLOCKING_REFRESHES, true)
     private val refreshFailures = LinkedHashMap<String, LinuxVirtualRefreshFailure>(16, 0.75f, true)
     private val metadataLock = Any()
     private val persistedStoreLock = Any()
@@ -314,7 +292,20 @@ internal class CachingLinuxVirtualFileBackend(
         while (true) {
             val candidate = CompletableFuture<LinuxVirtualDirectorySnapshot?>()
             val existing = refreshes.putIfAbsent(path, candidate)
-            val future = existing ?: candidate.also { refresh(path, it) }
+            val future = existing ?: candidate.also {
+                var acquired = false
+                try {
+                    blockingRefreshPermits.acquire()
+                    acquired = true
+                    refresh(path, it)
+                } catch (failure: Throwable) {
+                    it.completeExceptionally(failure)
+                    refreshes.remove(path, it)
+                    throw failure
+                } finally {
+                    if (acquired) blockingRefreshPermits.release()
+                }
+            }
             val refreshed = future.get() ?: continue
             val stillCurrent = synchronized(metadataLock) {
                 snapshots[path]?.generation == refreshed.generation
@@ -593,6 +584,7 @@ internal class CachingLinuxVirtualFileBackend(
         const val DEFAULT_MAX_RETAINED_METADATA_ENTRIES = 100_000
         const val DEFAULT_MAX_RETAINED_DIRECTORIES = 512
         const val MAX_FAILED_PERSISTED_INVALIDATIONS = 1_024
+        const val MAX_CONCURRENT_BLOCKING_REFRESHES = 2
         const val MAX_BACKOFF_EXPONENT = 30
         val ROOT_NODE = LinuxVirtualFileNode("", "Nextcloud", true, 0L, "root")
     }
@@ -740,25 +732,25 @@ internal class DesktopNextcloudVirtualFileBackend(
         existing = existing,
         truncate = truncate,
         tree = tree,
-        onCommitted = { committedPath -> rangeCache.invalidate(accountId, committedPath) },
+        onCommitted = { committedPath -> runCatching { rangeCache.invalidate(accountId, committedPath) } },
     )
 
     override fun createDirectory(path: String) {
         val normalized = path.linuxVirtualPath()
         tree.createDirectory(normalized, expectedRemoteEtag = null)
-        rangeCache.invalidate(accountId, normalized)
+        runCatching { rangeCache.invalidate(accountId, normalized) }
     }
 
     override fun delete(node: LinuxVirtualFileNode) {
         tree.delete(node.path, node.remoteRevision)
-        rangeCache.invalidate(accountId, node.path)
+        runCatching { rangeCache.invalidate(accountId, node.path) }
     }
 
     override fun move(node: LinuxVirtualFileNode, destinationPath: String) {
         val normalized = destinationPath.linuxVirtualPath()
         tree.move(node.path, normalized, node.remoteRevision)
-        rangeCache.invalidate(accountId, node.path)
-        rangeCache.invalidate(accountId, normalized)
+        runCatching { rangeCache.invalidate(accountId, node.path) }
+        runCatching { rangeCache.invalidate(accountId, normalized) }
     }
 
     override fun moveReplacing(
@@ -768,8 +760,8 @@ internal class DesktopNextcloudVirtualFileBackend(
     ) {
         val normalized = destinationPath.linuxVirtualPath()
         tree.moveReplacing(node.path, normalized, node.remoteRevision, destination.remoteRevision)
-        rangeCache.invalidate(accountId, node.path)
-        rangeCache.invalidate(accountId, normalized)
+        runCatching { rangeCache.invalidate(accountId, node.path) }
+        runCatching { rangeCache.invalidate(accountId, normalized) }
     }
 
     private fun DesktopRemoteSyncDocument.toLinuxNode(): LinuxVirtualFileNode = LinuxVirtualFileNode(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -144,6 +144,7 @@ internal class CachingLinuxVirtualFileBackend(
     private val persistedStoreLock = Any()
     private val pendingPersistedInvalidations = mutableMapOf<String, Int>()
     private val failedPersistedInvalidations = mutableSetOf<String>()
+    private val revalidatedPersistedListings = linkedSetOf<String>()
     private val activeMetadataOperations = mutableSetOf<LinuxVirtualMetadataOperation>()
     private val nextGeneration = AtomicLong(1L)
     @Volatile
@@ -179,6 +180,7 @@ internal class CachingLinuxVirtualFileBackend(
             synchronized(persistedStoreLock) {
                 val invalidationPending = synchronized(metadataLock) {
                     pendingPersistedInvalidations.keys.any { mutation -> mutation.invalidatesListing(normalized) } ||
+                        normalized !in revalidatedPersistedListings &&
                         failedPersistedInvalidations.any { mutation -> mutation.invalidatesListing(normalized) }
                 }
                 if (invalidationPending) null else store.load(normalized)
@@ -291,6 +293,7 @@ internal class CachingLinuxVirtualFileBackend(
             activeMetadataOperations.clear()
             pendingPersistedInvalidations.clear()
             failedPersistedInvalidations.clear()
+            revalidatedPersistedListings.clear()
         }
         delegate.close()
     }
@@ -382,7 +385,17 @@ internal class CachingLinuxVirtualFileBackend(
                                 !operation.invalidated &&
                                 snapshots[path]?.generation == snapshot.generation
                         }
-                        if (stillCurrent) runCatching { store.store(path, snapshot) }
+                        if (stillCurrent && runCatching { store.store(path, snapshot) }.isSuccess) {
+                            synchronized(metadataLock) {
+                                if (
+                                    !closed &&
+                                    !operation.invalidated &&
+                                    snapshots[path]?.generation == snapshot.generation
+                                ) {
+                                    rememberRevalidatedPersistedListing(path)
+                                }
+                            }
+                        }
                     }
                 } finally {
                     endMetadataOperation(operation)
@@ -412,6 +425,7 @@ internal class CachingLinuxVirtualFileBackend(
             activeMetadataOperations
                 .filter { operation -> normalized.invalidatesListing(operation.path) }
                 .forEach { operation -> operation.invalidated = true }
+            revalidatedPersistedListings.removeIf { listing -> normalized.invalidatesListing(listing) }
             pendingPersistedInvalidations[normalized] =
                 pendingPersistedInvalidations.getOrDefault(normalized, 0) + 1
         }
@@ -450,6 +464,15 @@ internal class CachingLinuxVirtualFileBackend(
         if (failedPersistedInvalidations.size > MAX_FAILED_PERSISTED_INVALIDATIONS) {
             failedPersistedInvalidations.clear()
             failedPersistedInvalidations += ""
+        }
+    }
+
+    private fun rememberRevalidatedPersistedListing(path: String) {
+        check(Thread.holdsLock(metadataLock))
+        revalidatedPersistedListings.remove(path)
+        revalidatedPersistedListings += path
+        while (revalidatedPersistedListings.size > MAX_REVALIDATED_PERSISTED_LISTINGS) {
+            revalidatedPersistedListings.remove(revalidatedPersistedListings.first())
         }
     }
 
@@ -509,6 +532,7 @@ internal class CachingLinuxVirtualFileBackend(
         const val DEFAULT_MAX_RETAINED_METADATA_ENTRIES = 100_000
         const val DEFAULT_MAX_RETAINED_DIRECTORIES = 512
         const val MAX_FAILED_PERSISTED_INVALIDATIONS = 1_024
+        const val MAX_REVALIDATED_PERSISTED_LISTINGS = 1_024
         const val MAX_BACKOFF_EXPONENT = 30
         val ROOT_NODE = LinuxVirtualFileNode("", "Nextcloud", true, 0L, "root")
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -338,9 +338,10 @@ internal class CachingLinuxVirtualFileBackend(
         var persistenceScheduled = false
         try {
             check(!closed) { "The Linux metadata cache is closed." }
+            val requestStartedAtEpochMillis = nowEpochMillis().coerceAtLeast(0L)
             val snapshot = LinuxVirtualDirectorySnapshot(
                 nodes = delegate.list(path),
-                fetchedAtEpochMillis = nowEpochMillis().coerceAtLeast(0L),
+                fetchedAtEpochMillis = requestStartedAtEpochMillis,
                 generation = nextGeneration.getAndIncrement(),
             )
             val published = synchronized(metadataLock) {
@@ -757,14 +758,22 @@ internal class DesktopNextcloudVirtualFileBackend(
  */
 internal class LinuxNextcloudVirtualFileSystem(
     private val backend: LinuxVirtualFileBackend,
+    private val maximumOpenDirectoryEntries: Int = DEFAULT_MAX_OPEN_DIRECTORY_ENTRIES,
 ) : FuseStubFS() {
     private val nextHandle = AtomicLong(1L)
     private val readHandles = ConcurrentHashMap<Long, LinuxVirtualFileReadHandle>()
     private val readHandlePaths = ConcurrentHashMap<Long, String>()
     private val writeHandles = ConcurrentHashMap<Long, LinuxOpenWriteReference>()
     private val directoryHandles = ConcurrentHashMap<Long, LinuxOpenDirectorySnapshot>()
+    private val directoryHandleLock = Any()
+    private val directorySnapshotCreationLock = Any()
+    private var openDirectoryEntries = 0L
     private val pendingCreatedFiles = ConcurrentHashMap<String, LinuxSharedWriteHandle>()
     private val namespaceLock = Any()
+
+    init {
+        require(maximumOpenDirectoryEntries > 0)
+    }
 
     override fun getattr(path: String, stat: FileStat): Int = fuseResult {
         val normalized = path.linuxVirtualPath()
@@ -777,9 +786,7 @@ internal class LinuxNextcloudVirtualFileSystem(
     }
 
     override fun opendir(path: String, fileInfo: FuseFileInfo): Int = fuseResult {
-        val snapshot = openDirectorySnapshot(path)
-        val id = nextHandle.getAndIncrement()
-        directoryHandles[id] = snapshot
+        val id = openAndRegisterDirectorySnapshot(path)
         fileInfo.fh.set(id)
         0
     }
@@ -795,10 +802,9 @@ internal class LinuxNextcloudVirtualFileSystem(
         val handleId = fileInfo.fh.get()
         val existingHandle = directoryHandles[handleId]?.takeIf { it.path == normalized }
         if (handleId != 0L && existingHandle == null) return -ErrorCodes.EBADF()
-        val snapshot = existingHandle ?: openDirectorySnapshot(path).also { opened ->
-            val id = nextHandle.getAndIncrement()
-            directoryHandles[id] = opened
+        val snapshot = existingHandle ?: openAndRegisterDirectorySnapshot(path).let { id ->
             fileInfo.fh.set(id)
+            checkNotNull(directoryHandles[id])
         }
         val entries = snapshot.entries
         if (offset < 0L || offset > entries.size.toLong()) return -ErrorCodes.EINVAL()
@@ -812,9 +818,13 @@ internal class LinuxNextcloudVirtualFileSystem(
 
     override fun releasedir(path: String, fileInfo: FuseFileInfo): Int = fuseResult {
         val id = fileInfo.fh.get()
-        val handle = directoryHandles[id] ?: return -ErrorCodes.EBADF()
-        if (handle.path != path.linuxVirtualPath()) return -ErrorCodes.EBADF()
-        if (!directoryHandles.remove(id, handle)) return -ErrorCodes.EBADF()
+        val normalized = path.linuxVirtualPath()
+        val removed = synchronized(directoryHandleLock) {
+            val handle = directoryHandles[id] ?: return@synchronized null
+            if (handle.path != normalized || !directoryHandles.remove(id, handle)) return@synchronized null
+            openDirectoryEntries = (openDirectoryEntries - handle.entries.size).coerceAtLeast(0L)
+            handle
+        } ?: return -ErrorCodes.EBADF()
         fileInfo.fh.set(0L)
         0
     }
@@ -1019,7 +1029,10 @@ internal class LinuxNextcloudVirtualFileSystem(
         readHandles.clear()
         readHandlePaths.clear()
         writeHandles.clear()
-        directoryHandles.clear()
+        synchronized(directoryHandleLock) {
+            directoryHandles.clear()
+            openDirectoryEntries = 0L
+        }
         pendingCreatedFiles.clear()
         backend.close()
     }
@@ -1049,6 +1062,23 @@ internal class LinuxNextcloudVirtualFileSystem(
         }
         return LinuxOpenDirectorySnapshot(normalized, entries)
     }
+
+    private fun openAndRegisterDirectorySnapshot(path: String): Long =
+        synchronized(directorySnapshotCreationLock) {
+            registerDirectorySnapshot(openDirectorySnapshot(path))
+        }
+
+    private fun registerDirectorySnapshot(snapshot: LinuxOpenDirectorySnapshot): Long =
+        synchronized(directoryHandleLock) {
+            val entryCount = snapshot.entries.size.toLong()
+            if (entryCount > maximumOpenDirectoryEntries.toLong() - openDirectoryEntries) {
+                throw LinuxVirtualFileSystemException(ErrorCodes.ENOMEM())
+            }
+            val id = nextHandle.getAndIncrement()
+            directoryHandles[id] = snapshot
+            openDirectoryEntries += entryCount
+            id
+        }
 
     private fun fillStat(node: LinuxVirtualFileNode, stat: FileStat) {
         stat.st_mode.set(
@@ -1172,6 +1202,7 @@ internal class LinuxNextcloudVirtualFileSystem(
         const val OPEN_ACCESS_MASK = 0x3
         const val OPEN_READ_ONLY = 0x0
         const val OPEN_TRUNCATE = 0x200
+        const val DEFAULT_MAX_OPEN_DIRECTORY_ENTRIES = 100_000
     }
 }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -172,6 +172,15 @@ internal class CachingLinuxVirtualFileBackend(
     internal fun failedPersistedInvalidationCount(): Int =
         synchronized(metadataLock) { failedPersistedInvalidations.size }
 
+    /**
+     * Invalidates metadata after a mutation committed outside this backend, such as an in-app
+     * Files action or recovery of a durable writeback. This must use the same generation and
+     * persisted-store guards as FUSE mutations so an older refresh cannot republish stale paths.
+     */
+    internal fun invalidateAfterExternalMutation(path: String) {
+        invalidate(path)
+    }
+
     private fun snapshot(normalized: String): LinuxVirtualDirectorySnapshot {
         synchronized(metadataLock) { snapshots[normalized] }?.let { cached ->
             if (!cached.isFresh(nowEpochMillis(), freshForMillis)) refreshAsync(normalized)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -143,8 +143,8 @@ internal class CachingLinuxVirtualFileBackend(
     private val metadataLock = Any()
     private val persistedStoreLock = Any()
     private val pendingPersistedInvalidations = mutableMapOf<String, Int>()
+    private val activeMetadataOperations = mutableSetOf<LinuxVirtualMetadataOperation>()
     private val nextGeneration = AtomicLong(1L)
-    private val invalidationEpoch = AtomicLong(0L)
     @Volatile
     private var closed = false
 
@@ -170,21 +170,30 @@ internal class CachingLinuxVirtualFileBackend(
             if (!cached.isFresh(nowEpochMillis(), freshForMillis)) refreshAsync(normalized)
             return cached
         }
-        val observedEpoch = invalidationEpoch.get()
-        val persisted = synchronized(persistedStoreLock) {
-            val invalidationPending = synchronized(metadataLock) {
-                pendingPersistedInvalidations.keys.any { mutation -> mutation.invalidatesListing(normalized) }
+        val operation = beginMetadataOperation(normalized)
+        val persisted = try {
+            synchronized(persistedStoreLock) {
+                val invalidationPending = synchronized(metadataLock) {
+                    pendingPersistedInvalidations.keys.any { mutation -> mutation.invalidatesListing(normalized) }
+                }
+                if (invalidationPending) null else store.load(normalized)
             }
-            if (invalidationPending || invalidationEpoch.get() != observedEpoch) null else store.load(normalized)
+        } catch (failure: Throwable) {
+            endMetadataOperation(operation)
+            throw failure
         }
-        val cached = persisted?.let { restored ->
-            synchronized(metadataLock) {
-                if (invalidationEpoch.get() == observedEpoch) {
-                    snapshots[normalized] ?: restored.also { retainSnapshot(normalized, it) }
-                } else {
-                    null
+        val cached = try {
+            persisted?.let { restored ->
+                synchronized(metadataLock) {
+                    if (!operation.invalidated) {
+                        snapshots[normalized] ?: restored.also { retainSnapshot(normalized, it) }
+                    } else {
+                        null
+                    }
                 }
             }
+        } finally {
+            endMetadataOperation(operation)
         }
         if (cached != null) {
             if (!cached.isFresh(nowEpochMillis(), freshForMillis)) refreshAsync(normalized)
@@ -253,6 +262,10 @@ internal class CachingLinuxVirtualFileBackend(
         if (closed) return
         closed = true
         refreshExecutor.shutdownNow()
+        synchronized(metadataLock) {
+            activeMetadataOperations.clear()
+            pendingPersistedInvalidations.clear()
+        }
         delegate.close()
     }
 
@@ -290,16 +303,17 @@ internal class CachingLinuxVirtualFileBackend(
     }
 
     private fun refresh(path: String, future: CompletableFuture<LinuxVirtualDirectorySnapshot?>) {
+        val operation = beginMetadataOperation(path)
+        var persistenceScheduled = false
         try {
             check(!closed) { "The Linux metadata cache is closed." }
-            val observedEpoch = invalidationEpoch.get()
             val snapshot = LinuxVirtualDirectorySnapshot(
                 nodes = delegate.list(path),
                 fetchedAtEpochMillis = nowEpochMillis().coerceAtLeast(0L),
                 generation = nextGeneration.getAndIncrement(),
             )
             val published = synchronized(metadataLock) {
-                if (!closed && invalidationEpoch.get() == observedEpoch) {
+                if (!closed && !operation.invalidated) {
                     retainSnapshot(path, snapshot)
                     true
                 } else {
@@ -309,7 +323,7 @@ internal class CachingLinuxVirtualFileBackend(
             if (published) {
                 refreshFailures.remove(path)
                 future.complete(snapshot)
-                persistAsync(path, snapshot, observedEpoch)
+                persistenceScheduled = persistAsync(path, snapshot, operation)
             } else {
                 future.complete(null)
             }
@@ -317,35 +331,44 @@ internal class CachingLinuxVirtualFileBackend(
             if (!closed) recordRefreshFailure(path)
             future.completeExceptionally(failure)
         } finally {
+            if (!persistenceScheduled) endMetadataOperation(operation)
             refreshes.remove(path, future)
         }
     }
 
-    private fun persistAsync(path: String, snapshot: LinuxVirtualDirectorySnapshot, observedEpoch: Long) {
-        if (closed) return
-        runCatching {
+    private fun persistAsync(
+        path: String,
+        snapshot: LinuxVirtualDirectorySnapshot,
+        operation: LinuxVirtualMetadataOperation,
+    ): Boolean {
+        if (closed) return false
+        return runCatching {
             refreshExecutor.execute {
-                val current = synchronized(metadataLock) {
-                    !closed &&
-                        invalidationEpoch.get() == observedEpoch &&
-                        snapshots[path]?.generation == snapshot.generation
-                }
-                if (current) synchronized(persistedStoreLock) {
-                    val stillCurrent = synchronized(metadataLock) {
+                try {
+                    val current = synchronized(metadataLock) {
                         !closed &&
-                            invalidationEpoch.get() == observedEpoch &&
+                            !operation.invalidated &&
                             snapshots[path]?.generation == snapshot.generation
                     }
-                    if (stillCurrent) runCatching { store.store(path, snapshot) }
+                    if (current) synchronized(persistedStoreLock) {
+                        val stillCurrent = synchronized(metadataLock) {
+                            !closed &&
+                                !operation.invalidated &&
+                                snapshots[path]?.generation == snapshot.generation
+                        }
+                        if (stillCurrent) runCatching { store.store(path, snapshot) }
+                    }
+                } finally {
+                    endMetadataOperation(operation)
                 }
             }
-        }
+            true
+        }.getOrDefault(false)
     }
 
     private fun invalidate(path: String) {
         val normalized = path.linuxVirtualPath()
         val parent = normalized.substringBeforeLast('/', "")
-        invalidationEpoch.incrementAndGet()
         synchronized(metadataLock) {
             val knownPaths = buildSet {
                 add(normalized)
@@ -354,15 +377,15 @@ internal class CachingLinuxVirtualFileBackend(
                 addAll(refreshes.keys)
                 addAll(refreshFailures.keys)
             }
-            knownPaths.filterTo(mutableSetOf(), { cachedPath ->
-                normalized.isEmpty() ||
-                    cachedPath == normalized ||
-                    cachedPath.startsWith("$normalized/") ||
-                    cachedPath == parent
-            }).forEach { cachedPath ->
+            knownPaths.filterTo(mutableSetOf()) { cachedPath ->
+                normalized.invalidatesListing(cachedPath)
+            }.forEach { cachedPath ->
                 snapshots.remove(cachedPath)
                 refreshFailures.remove(cachedPath)
             }
+            activeMetadataOperations
+                .filter { operation -> normalized.invalidatesListing(operation.path) }
+                .forEach { operation -> operation.invalidated = true }
             pendingPersistedInvalidations[normalized] =
                 pendingPersistedInvalidations.getOrDefault(normalized, 0) + 1
         }
@@ -392,6 +415,15 @@ internal class CachingLinuxVirtualFileBackend(
             retainedEntries -= evicted.value.nodes.size
             iterator.remove()
         }
+    }
+
+    private fun beginMetadataOperation(path: String): LinuxVirtualMetadataOperation =
+        synchronized(metadataLock) {
+            LinuxVirtualMetadataOperation(path).also(activeMetadataOperations::add)
+        }
+
+    private fun endMetadataOperation(operation: LinuxVirtualMetadataOperation) {
+        synchronized(metadataLock) { activeMetadataOperations.remove(operation) }
     }
 
     private fun recordRefreshFailure(path: String) {
@@ -435,9 +467,16 @@ private data class LinuxVirtualRefreshFailure(
     val retryAtEpochMillis: Long,
 )
 
+private class LinuxVirtualMetadataOperation(val path: String) {
+    var invalidated: Boolean = false
+}
+
 private fun String.invalidatesListing(listingPath: String): Boolean {
-    val parent = substringBeforeLast('/', "")
-    return isEmpty() || listingPath == this || listingPath.startsWith("$this/") || listingPath == parent
+    return isEmpty() ||
+        listingPath.isEmpty() ||
+        listingPath == this ||
+        listingPath.startsWith("$this/") ||
+        startsWith("$listingPath/")
 }
 
 private fun defaultLinuxMetadataRefreshExecutor(): ExecutorService =
@@ -882,11 +921,8 @@ internal class LinuxNextcloudVirtualFileSystem(
         writeHandles.clear()
         directoryHandles.clear()
         pendingCreatedFiles.clear()
-        try {
-            umount()
-        } finally {
-            backend.close()
-        }
+        umount()
+        backend.close()
     }
 
     private fun openDirectorySnapshot(path: String): LinuxOpenDirectorySnapshot {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -165,6 +165,9 @@ internal class CachingLinuxVirtualFileBackend(
 
     override fun list(path: String): List<LinuxVirtualFileNode> = snapshot(path.linuxVirtualPath()).nodes
 
+    internal fun hasRecordedRefreshFailure(path: String): Boolean =
+        refreshFailures.containsKey(path.linuxVirtualPath())
+
     private fun snapshot(normalized: String): LinuxVirtualDirectorySnapshot {
         synchronized(metadataLock) { snapshots[normalized] }?.let { cached ->
             if (!cached.isFresh(nowEpochMillis(), freshForMillis)) refreshAsync(normalized)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -71,6 +71,7 @@ internal interface LinuxVirtualMetadataStore {
     fun load(path: String): LinuxVirtualDirectorySnapshot?
     fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot)
     fun invalidate(path: String)
+    fun retainedPaths(): Set<String>? = null
 }
 
 internal class DesktopLinuxVirtualMetadataStore(
@@ -116,6 +117,8 @@ internal class DesktopLinuxVirtualMetadataStore(
     }
 
     override fun invalidate(path: String) = cache.invalidate(accountId, path)
+
+    override fun retainedPaths(): Set<String> = cache.cachedListingPaths(accountId)
 }
 
 /**
@@ -172,6 +175,12 @@ internal class CachingLinuxVirtualFileBackend(
 
     internal fun hasRecordedRefreshFailure(path: String): Boolean =
         synchronized(metadataLock) { refreshFailures.containsKey(path.linuxVirtualPath()) }
+
+    internal fun revalidatedPersistedListingCount(): Int =
+        synchronized(metadataLock) { revalidatedPersistedListings.size }
+
+    internal fun failedPersistedInvalidationCount(): Int =
+        synchronized(metadataLock) { failedPersistedInvalidations.size }
 
     private fun snapshot(normalized: String): LinuxVirtualDirectorySnapshot {
         synchronized(metadataLock) { snapshots[normalized] }?.let { cached ->
@@ -467,6 +476,7 @@ internal class CachingLinuxVirtualFileBackend(
                     failedPersistedInvalidations.removeIf { failed ->
                         normalized.isEmpty() || failed == normalized || failed.startsWith("$normalized/")
                     }
+                    pruneUnpairedRevalidatedListings()
                 } else {
                     rememberFailedPersistedInvalidation(normalized)
                 }
@@ -495,11 +505,32 @@ internal class CachingLinuxVirtualFileBackend(
 
     private fun rememberRevalidatedPersistedListing(path: String) {
         check(Thread.holdsLock(metadataLock))
+        if (failedPersistedInvalidations.none { failed -> failed.invalidatesListing(path) }) {
+            revalidatedPersistedListings.remove(path)
+            return
+        }
         revalidatedPersistedListings.remove(path)
         revalidatedPersistedListings += path
-        while (revalidatedPersistedListings.size > MAX_REVALIDATED_PERSISTED_LISTINGS) {
-            revalidatedPersistedListings.remove(revalidatedPersistedListings.first())
+        reconcileRevalidatedListingsWithStore()
+    }
+
+    private fun pruneUnpairedRevalidatedListings() {
+        check(Thread.holdsLock(metadataLock))
+        revalidatedPersistedListings.removeIf { listing ->
+            failedPersistedInvalidations.none { failed -> failed.invalidatesListing(listing) }
         }
+    }
+
+    private fun reconcileRevalidatedListingsWithStore() {
+        check(Thread.holdsLock(metadataLock))
+        val retainedPaths = store.retainedPaths() ?: return
+        revalidatedPersistedListings.retainAll(retainedPaths)
+        failedPersistedInvalidations.removeIf { failed ->
+            retainedPaths.none { listing ->
+                failed.invalidatesListing(listing) && listing !in revalidatedPersistedListings
+            }
+        }
+        pruneUnpairedRevalidatedListings()
     }
 
     private fun retainSnapshot(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
@@ -562,7 +593,6 @@ internal class CachingLinuxVirtualFileBackend(
         const val DEFAULT_MAX_RETAINED_METADATA_ENTRIES = 100_000
         const val DEFAULT_MAX_RETAINED_DIRECTORIES = 512
         const val MAX_FAILED_PERSISTED_INVALIDATIONS = 1_024
-        const val MAX_REVALIDATED_PERSISTED_LISTINGS = 1_024
         const val MAX_BACKOFF_EXPONENT = 30
         val ROOT_NODE = LinuxVirtualFileNode("", "Nextcloud", true, 0L, "root")
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -143,6 +143,7 @@ internal class CachingLinuxVirtualFileBackend(
     private val metadataLock = Any()
     private val persistedStoreLock = Any()
     private val pendingPersistedInvalidations = mutableMapOf<String, Int>()
+    private val failedPersistedInvalidations = mutableSetOf<String>()
     private val activeMetadataOperations = mutableSetOf<LinuxVirtualMetadataOperation>()
     private val nextGeneration = AtomicLong(1L)
     @Volatile
@@ -177,7 +178,8 @@ internal class CachingLinuxVirtualFileBackend(
         val persisted = try {
             synchronized(persistedStoreLock) {
                 val invalidationPending = synchronized(metadataLock) {
-                    pendingPersistedInvalidations.keys.any { mutation -> mutation.invalidatesListing(normalized) }
+                    pendingPersistedInvalidations.keys.any { mutation -> mutation.invalidatesListing(normalized) } ||
+                        failedPersistedInvalidations.any { mutation -> mutation.invalidatesListing(normalized) }
                 }
                 if (invalidationPending) null else store.load(normalized)
             }
@@ -215,18 +217,38 @@ internal class CachingLinuxVirtualFileBackend(
         val normalized = path.linuxVirtualPath()
         val handle = delegate.openWrite(normalized, existing, truncate)
         return object : LinuxVirtualFileWriteHandle {
+            private var dirty = truncate
+
             override val size: Long get() = handle.size
             override fun read(offset: Long, length: Int): ByteArray = handle.read(offset, length)
-            override fun write(offset: Long, bytes: ByteArray): Int = handle.write(offset, bytes)
-            override fun truncate(size: Long) = handle.truncate(size)
-            override fun flush() {
-                handle.flush()
-                invalidate(normalized)
+            @Synchronized
+            override fun write(offset: Long, bytes: ByteArray): Int = handle.write(offset, bytes).also { written ->
+                if (written > 0) dirty = true
             }
 
+            @Synchronized
+            override fun truncate(size: Long) {
+                val previousSize = handle.size
+                handle.truncate(size)
+                if (size != previousSize) dirty = true
+            }
+
+            @Synchronized
+            override fun flush() {
+                handle.flush()
+                if (dirty) {
+                    invalidate(normalized)
+                    dirty = false
+                }
+            }
+
+            @Synchronized
             override fun close() {
                 handle.close()
-                invalidate(normalized)
+                if (dirty) {
+                    invalidate(normalized)
+                    dirty = false
+                }
             }
         }
     }
@@ -268,6 +290,7 @@ internal class CachingLinuxVirtualFileBackend(
         synchronized(metadataLock) {
             activeMetadataOperations.clear()
             pendingPersistedInvalidations.clear()
+            failedPersistedInvalidations.clear()
         }
         delegate.close()
     }
@@ -393,14 +416,40 @@ internal class CachingLinuxVirtualFileBackend(
                 pendingPersistedInvalidations.getOrDefault(normalized, 0) + 1
         }
         afterPersistedInvalidationMarked()
+        var persistedInvalidated = false
         try {
-            synchronized(persistedStoreLock) { runCatching { store.invalidate(normalized) } }
+            synchronized(persistedStoreLock) {
+                persistedInvalidated = runCatching { store.invalidate(normalized) }.isSuccess
+            }
         } finally {
             synchronized(metadataLock) {
+                if (persistedInvalidated) {
+                    failedPersistedInvalidations.removeIf { failed ->
+                        normalized.isEmpty() || failed == normalized || failed.startsWith("$normalized/")
+                    }
+                } else {
+                    rememberFailedPersistedInvalidation(normalized)
+                }
                 val remaining = pendingPersistedInvalidations.getOrDefault(normalized, 1) - 1
                 if (remaining <= 0) pendingPersistedInvalidations.remove(normalized)
                 else pendingPersistedInvalidations[normalized] = remaining
             }
+        }
+    }
+
+    private fun rememberFailedPersistedInvalidation(path: String) {
+        check(Thread.holdsLock(metadataLock))
+        if (failedPersistedInvalidations.any { failed ->
+                failed.isEmpty() || failed == path || path.startsWith("$failed/")
+            }
+        ) {
+            return
+        }
+        failedPersistedInvalidations.removeIf { failed -> path.isEmpty() || failed.startsWith("$path/") }
+        failedPersistedInvalidations += path
+        if (failedPersistedInvalidations.size > MAX_FAILED_PERSISTED_INVALIDATIONS) {
+            failedPersistedInvalidations.clear()
+            failedPersistedInvalidations += ""
         }
     }
 
@@ -459,6 +508,7 @@ internal class CachingLinuxVirtualFileBackend(
         const val DEFAULT_REFRESH_RETRY_MAX_MILLIS = 60_000L
         const val DEFAULT_MAX_RETAINED_METADATA_ENTRIES = 100_000
         const val DEFAULT_MAX_RETAINED_DIRECTORIES = 512
+        const val MAX_FAILED_PERSISTED_INVALIDATIONS = 1_024
         const val MAX_BACKOFF_EXPONENT = 30
         val ROOT_NODE = LinuxVirtualFileNode("", "Nextcloud", true, 0L, "root")
     }
@@ -915,6 +965,7 @@ internal class LinuxNextcloudVirtualFileSystem(
     }
 
     fun unmount() {
+        umount()
         readHandles.values.forEach { runCatching(it::close) }
         writeHandles.values.map(LinuxOpenWriteReference::shared).distinct().forEach { shared ->
             runCatching(shared.delegate::close)
@@ -924,7 +975,6 @@ internal class LinuxNextcloudVirtualFileSystem(
         writeHandles.clear()
         directoryHandles.clear()
         pendingCreatedFiles.clear()
-        umount()
         backend.close()
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -139,7 +139,7 @@ internal class CachingLinuxVirtualFileBackend(
 ) : LinuxVirtualFileBackend {
     private val snapshots = LinkedHashMap<String, LinuxVirtualDirectorySnapshot>(16, 0.75f, true)
     private val refreshes = ConcurrentHashMap<String, CompletableFuture<LinuxVirtualDirectorySnapshot?>>()
-    private val refreshFailures = ConcurrentHashMap<String, LinuxVirtualRefreshFailure>()
+    private val refreshFailures = LinkedHashMap<String, LinuxVirtualRefreshFailure>(16, 0.75f, true)
     private val metadataLock = Any()
     private val persistedStoreLock = Any()
     private val pendingPersistedInvalidations = mutableMapOf<String, Int>()
@@ -171,7 +171,7 @@ internal class CachingLinuxVirtualFileBackend(
     override fun list(path: String): List<LinuxVirtualFileNode> = snapshot(path.linuxVirtualPath()).nodes
 
     internal fun hasRecordedRefreshFailure(path: String): Boolean =
-        refreshFailures.containsKey(path.linuxVirtualPath())
+        synchronized(metadataLock) { refreshFailures.containsKey(path.linuxVirtualPath()) }
 
     private fun snapshot(normalized: String): LinuxVirtualDirectorySnapshot {
         synchronized(metadataLock) { snapshots[normalized] }?.let { cached ->
@@ -296,6 +296,7 @@ internal class CachingLinuxVirtualFileBackend(
             pendingPersistedInvalidations.clear()
             failedPersistedInvalidations.clear()
             revalidatedPersistedListings.clear()
+            refreshFailures.clear()
         }
         delegate.close()
     }
@@ -316,9 +317,11 @@ internal class CachingLinuxVirtualFileBackend(
     private fun refreshAsync(path: String) {
         if (closed) return
         val now = nowEpochMillis().coerceAtLeast(0L)
-        refreshFailures[path]?.let { failure ->
+        synchronized(metadataLock) { refreshFailures[path] }?.let { failure ->
             if (now < failure.recordedAtEpochMillis) {
-                refreshFailures.remove(path, failure)
+                synchronized(metadataLock) {
+                    if (refreshFailures[path] == failure) refreshFailures.remove(path)
+                }
             } else if (now < failure.retryAtEpochMillis) {
                 return
             }
@@ -353,7 +356,7 @@ internal class CachingLinuxVirtualFileBackend(
                 }
             }
             if (published) {
-                refreshFailures.remove(path)
+                synchronized(metadataLock) { refreshFailures.remove(path) }
                 future.complete(snapshot)
                 persistenceScheduled = persistAsync(path, snapshot, operation)
             } else {
@@ -526,7 +529,8 @@ internal class CachingLinuxVirtualFileBackend(
 
     private fun recordRefreshFailure(path: String) {
         val now = nowEpochMillis().coerceAtLeast(0L)
-        refreshFailures.compute(path) { _, previous ->
+        synchronized(metadataLock) {
+            val previous = refreshFailures[path]
             val failures = (previous?.consecutiveFailures ?: 0).plus(1).coerceAtMost(MAX_BACKOFF_EXPONENT + 1)
             val exponent = (failures - 1).coerceAtMost(MAX_BACKOFF_EXPONENT)
             val multiplier = 1L shl exponent
@@ -535,11 +539,14 @@ internal class CachingLinuxVirtualFileBackend(
             } else {
                 (refreshRetryBaseMillis * multiplier).coerceAtMost(refreshRetryMaxMillis)
             }
-            LinuxVirtualRefreshFailure(
+            refreshFailures[path] = LinuxVirtualRefreshFailure(
                 consecutiveFailures = failures,
                 recordedAtEpochMillis = now,
                 retryAtEpochMillis = if (now > Long.MAX_VALUE - delay) Long.MAX_VALUE else now + delay,
             )
+            while (refreshFailures.size > maximumRetainedDirectories) {
+                refreshFailures.remove(refreshFailures.keys.first())
+            }
         }
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -42,6 +42,7 @@ internal interface LinuxVirtualFileWriteHandle : AutoCloseable {
 internal interface LinuxVirtualFileBackend : AutoCloseable {
     fun resolve(path: String): LinuxVirtualFileNode?
     fun list(path: String): List<LinuxVirtualFileNode>
+    fun isDirectoryEmpty(node: LinuxVirtualFileNode): Boolean = list(node.path).isEmpty()
     fun open(node: LinuxVirtualFileNode): LinuxVirtualFileReadHandle
     fun openWrite(path: String, existing: LinuxVirtualFileNode?, truncate: Boolean): LinuxVirtualFileWriteHandle
     fun createDirectory(path: String)
@@ -86,6 +87,8 @@ internal interface LinuxVirtualMetadataStore {
     fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean
     fun invalidate(path: String)
     fun retainedPaths(): Set<String>? = null
+    fun failedInvalidations(): Set<String> = emptySet()
+    fun replaceFailedInvalidations(paths: Set<String>) = Unit
 }
 
 internal class DesktopLinuxVirtualMetadataStore(
@@ -108,6 +111,11 @@ internal class DesktopLinuxVirtualMetadataStore(
     override fun invalidate(path: String) = cache.invalidate(accountId, path)
 
     override fun retainedPaths(): Set<String> = cache.cachedVirtualListingPaths(accountId)
+
+    override fun failedInvalidations(): Set<String> = cache.failedVirtualListingInvalidations(accountId)
+
+    override fun replaceFailedInvalidations(paths: Set<String>) =
+        cache.replaceFailedVirtualListingInvalidations(accountId, paths)
 }
 
 /**
@@ -152,6 +160,7 @@ internal class CachingLinuxVirtualFileBackend(
         require(refreshRetryMaxMillis >= refreshRetryBaseMillis)
         require(maximumRetainedMetadataEntries > 0)
         require(maximumRetainedDirectories > 0)
+        failedPersistedInvalidations += store.failedInvalidations()
     }
 
     override fun resolve(path: String): LinuxVirtualFileNode? {
@@ -162,6 +171,8 @@ internal class CachingLinuxVirtualFileBackend(
     }
 
     override fun list(path: String): List<LinuxVirtualFileNode> = snapshot(path.linuxVirtualPath()).nodes
+
+    override fun isDirectoryEmpty(node: LinuxVirtualFileNode): Boolean = delegate.isDirectoryEmpty(node)
 
     internal fun hasRecordedRefreshFailure(path: String): Boolean =
         synchronized(metadataLock) { refreshFailures.containsKey(path.linuxVirtualPath()) }
@@ -324,7 +335,6 @@ internal class CachingLinuxVirtualFileBackend(
         synchronized(metadataLock) {
             activeMetadataOperations.clear()
             pendingPersistedInvalidations.clear()
-            failedPersistedInvalidations.clear()
             revalidatedPersistedListings.clear()
             refreshFailures.clear()
         }
@@ -516,6 +526,7 @@ internal class CachingLinuxVirtualFileBackend(
                 } else {
                     rememberFailedPersistedInvalidation(normalized)
                 }
+                store.replaceFailedInvalidations(failedPersistedInvalidations)
                 val remaining = pendingPersistedInvalidations.getOrDefault(normalized, 1) - 1
                 if (remaining <= 0) pendingPersistedInvalidations.remove(normalized)
                 else pendingPersistedInvalidations[normalized] = remaining
@@ -567,6 +578,7 @@ internal class CachingLinuxVirtualFileBackend(
             }
         }
         pruneUnpairedRevalidatedListings()
+        store.replaceFailedInvalidations(failedPersistedInvalidations)
     }
 
     private fun retainSnapshot(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
@@ -685,6 +697,11 @@ internal class DesktopNextcloudVirtualFileBackend(
 
     override fun list(path: String): List<LinuxVirtualFileNode> =
         tree.list(path.linuxVirtualPath()).map { document -> document.toLinuxNode() }
+
+    override fun isDirectoryEmpty(node: LinuxVirtualFileNode): Boolean {
+        require(node.directory)
+        return tree.isDirectoryEmpty(node.path, node.remoteRevision)
+    }
 
     override fun open(node: LinuxVirtualFileNode): LinuxVirtualFileReadHandle {
         require(!node.directory)
@@ -1057,7 +1074,7 @@ internal class LinuxNextcloudVirtualFileSystem(
             if (existingDestination != null) {
                 if (source.directory && !existingDestination.directory) return -ErrorCodes.ENOTDIR()
                 if (!source.directory && existingDestination.directory) return -ErrorCodes.EISDIR()
-                if (existingDestination.directory && backend.list(destination).isNotEmpty()) {
+                if (existingDestination.directory && !backend.isDirectoryEmpty(existingDestination)) {
                     return -ErrorCodes.ENOTEMPTY()
                 }
                 if (hasOpenReadHandleWithin(destination)) return -ErrorCodes.EBUSY()
@@ -1325,7 +1342,7 @@ internal class LinuxNextcloudVirtualFileSystem(
                 return if (expectDirectory) -ErrorCodes.ENOTDIR() else -ErrorCodes.EISDIR()
             }
             if (expectDirectory) {
-                val hasRemoteChildren = backend.list(normalized).isNotEmpty()
+                val hasRemoteChildren = !backend.isDirectoryEmpty(node)
                 val hasPendingChildren = pendingCreatedFiles.keys.any { pending ->
                     pending.substringBeforeLast('/', "") == normalized
                 }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -315,6 +315,11 @@ internal class CachingLinuxVirtualFileBackend(
     override fun close() {
         if (closed) return
         closed = true
+        refreshExecutor.shutdown()
+        // A persistence task that entered store.store() before close must finish before a new
+        // backend can replace this one. Tasks that were only waiting for the store lock observe
+        // `closed` in their second guarded check and skip publication.
+        synchronized(persistedStoreLock) { }
         refreshExecutor.shutdownNow()
         synchronized(metadataLock) {
             activeMetadataOperations.clear()
@@ -660,7 +665,13 @@ internal class DesktopNextcloudVirtualFileBackend(
     private val services: NextcloudPlatformServices,
     private val rangeCache: DesktopVirtualRangeCache,
     private val writebacks: DesktopLinuxVirtualFileWritebackStore,
-    private val tree: DesktopFileSyncRemoteTree = DesktopFileSyncRemoteTree(session, userId, ""),
+    onAmbiguousMutationResult: (relativePath: String) -> Unit = {},
+    private val tree: DesktopFileSyncRemoteTree = DesktopFileSyncRemoteTree(
+        session = session,
+        userId = userId,
+        remoteRootPath = "",
+        onAmbiguousMutationResult = onAmbiguousMutationResult,
+    ),
 ) : LinuxVirtualFileBackend {
     private val accountId = desktopFileCacheAccountId(session)
 
@@ -848,6 +859,7 @@ internal class LinuxNextcloudVirtualFileSystem(
     private val backend: LinuxVirtualFileBackend,
     private val maximumOpenDirectoryEntries: Int = DEFAULT_MAX_OPEN_DIRECTORY_ENTRIES,
     private val beforeDirectoryHandleRemoval: () -> Unit = {},
+    private val unmountOperation: (LinuxNextcloudVirtualFileSystem) -> Unit = { fileSystem -> fileSystem.umount() },
 ) : FuseStubFS() {
     private val nextHandle = AtomicLong(1L)
     private val readHandles = ConcurrentHashMap<Long, LinuxVirtualFileReadHandle>()
@@ -1114,20 +1126,25 @@ internal class LinuxNextcloudVirtualFileSystem(
     }
 
     fun unmount() {
-        umount()
-        readHandles.values.forEach { runCatching(it::close) }
-        writeHandles.values.map(LinuxOpenWriteReference::shared).distinct().forEach { shared ->
-            runCatching(shared.delegate::close)
+        var detached = false
+        try {
+            unmountOperation(this)
+            detached = true
+        } finally {
+            readHandles.values.forEach { runCatching(it::close) }
+            writeHandles.values.map(LinuxOpenWriteReference::shared).distinct().forEach { shared ->
+                runCatching(shared.delegate::close)
+            }
+            readHandles.clear()
+            readHandlePaths.clear()
+            writeHandles.clear()
+            synchronized(directoryHandleLock) {
+                directoryHandles.clear()
+                openDirectoryEntries = 0L
+            }
+            pendingCreatedFiles.clear()
+            if (detached) backend.close()
         }
-        readHandles.clear()
-        readHandlePaths.clear()
-        writeHandles.clear()
-        synchronized(directoryHandleLock) {
-            directoryHandles.clear()
-            openDirectoryEntries = 0L
-        }
-        pendingCreatedFiles.clear()
-        backend.close()
     }
 
     private fun openDirectorySnapshot(path: String): LinuxOpenDirectorySnapshot {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -47,11 +47,24 @@ internal interface LinuxVirtualFileBackend : AutoCloseable {
     fun createDirectory(path: String)
     fun delete(node: LinuxVirtualFileNode)
     fun move(node: LinuxVirtualFileNode, destinationPath: String)
+    fun move(node: LinuxVirtualFileNode, destinationPath: String, afterRemoteCommit: () -> Unit) {
+        move(node, destinationPath)
+        afterRemoteCommit()
+    }
     fun moveReplacing(
         node: LinuxVirtualFileNode,
         destination: LinuxVirtualFileNode,
         destinationPath: String,
     )
+    fun moveReplacing(
+        node: LinuxVirtualFileNode,
+        destination: LinuxVirtualFileNode,
+        destinationPath: String,
+        afterRemoteCommit: () -> Unit,
+    ) {
+        moveReplacing(node, destination, destinationPath)
+        afterRemoteCommit()
+    }
 
     override fun close() = Unit
 }
@@ -255,8 +268,16 @@ internal class CachingLinuxVirtualFileBackend(
     }
 
     override fun move(node: LinuxVirtualFileNode, destinationPath: String) {
+        move(node, destinationPath) {}
+    }
+
+    override fun move(
+        node: LinuxVirtualFileNode,
+        destinationPath: String,
+        afterRemoteCommit: () -> Unit,
+    ) {
         val destination = destinationPath.linuxVirtualPath()
-        delegate.move(node, destination)
+        delegate.move(node, destination, afterRemoteCommit)
         invalidate(node.path)
         invalidate(destination)
     }
@@ -266,8 +287,17 @@ internal class CachingLinuxVirtualFileBackend(
         destination: LinuxVirtualFileNode,
         destinationPath: String,
     ) {
+        moveReplacing(node, destination, destinationPath) {}
+    }
+
+    override fun moveReplacing(
+        node: LinuxVirtualFileNode,
+        destination: LinuxVirtualFileNode,
+        destinationPath: String,
+        afterRemoteCommit: () -> Unit,
+    ) {
         val normalized = destinationPath.linuxVirtualPath()
-        delegate.moveReplacing(node, destination, normalized)
+        delegate.moveReplacing(node, destination, normalized, afterRemoteCommit)
         invalidate(node.path)
         invalidate(normalized)
     }
@@ -748,8 +778,17 @@ internal class DesktopNextcloudVirtualFileBackend(
     }
 
     override fun move(node: LinuxVirtualFileNode, destinationPath: String) {
+        move(node, destinationPath) {}
+    }
+
+    override fun move(
+        node: LinuxVirtualFileNode,
+        destinationPath: String,
+        afterRemoteCommit: () -> Unit,
+    ) {
         val normalized = destinationPath.linuxVirtualPath()
         tree.move(node.path, normalized, node.remoteRevision)
+        afterRemoteCommit()
         runCatching { rangeCache.invalidate(accountId, node.path) }
         runCatching { rangeCache.invalidate(accountId, normalized) }
     }
@@ -759,8 +798,18 @@ internal class DesktopNextcloudVirtualFileBackend(
         destination: LinuxVirtualFileNode,
         destinationPath: String,
     ) {
+        moveReplacing(node, destination, destinationPath) {}
+    }
+
+    override fun moveReplacing(
+        node: LinuxVirtualFileNode,
+        destination: LinuxVirtualFileNode,
+        destinationPath: String,
+        afterRemoteCommit: () -> Unit,
+    ) {
         val normalized = destinationPath.linuxVirtualPath()
         tree.moveReplacing(node.path, normalized, node.remoteRevision, destination.remoteRevision)
+        afterRemoteCommit()
         runCatching { rangeCache.invalidate(accountId, node.path) }
         runCatching { rangeCache.invalidate(accountId, normalized) }
     }
@@ -798,6 +847,7 @@ internal class LinuxNextcloudVirtualFileSystem(
     private val directoryHandles = ConcurrentHashMap<Long, LinuxOpenDirectorySnapshot>()
     private val directoryHandleLock = Any()
     private val directorySnapshotCreationPermits = Semaphore(MAX_CONCURRENT_DIRECTORY_SNAPSHOT_CREATIONS, true)
+    private val pendingDirectorySnapshots = mutableSetOf<LinuxPendingDirectorySnapshot>()
     private var openDirectoryEntries = 0L
     private val pendingCreatedFiles = ConcurrentHashMap<String, LinuxSharedWriteHandle>()
     private val namespaceLock = Any()
@@ -988,12 +1038,14 @@ internal class LinuxNextcloudVirtualFileSystem(
                     return -ErrorCodes.ENOTEMPTY()
                 }
                 if (hasOpenReadHandleWithin(destination)) return -ErrorCodes.EBUSY()
-                backend.moveReplacing(source, existingDestination, destination)
+                backend.moveReplacing(source, existingDestination, destination) {
+                    readdressOpenNamespace(sourcePath, destination)
+                }
             } else {
-                backend.move(source, destination)
+                backend.move(source, destination) {
+                    readdressOpenNamespace(sourcePath, destination)
+                }
             }
-            readdressReadHandles(sourcePath, destination)
-            readdressDirectoryHandles(sourcePath, destination)
             0
         }
     }
@@ -1097,14 +1149,36 @@ internal class LinuxNextcloudVirtualFileSystem(
 
     private fun openAndRegisterDirectorySnapshot(path: String): Long {
         var acquired = false
+        var pending: LinuxPendingDirectorySnapshot? = null
         try {
             directorySnapshotCreationPermits.acquire()
             acquired = true
-            return registerDirectorySnapshot(openDirectorySnapshot(path))
+            val registration = synchronized(namespaceLock) {
+                LinuxPendingDirectorySnapshot(path.linuxVirtualPath()).also(pendingDirectorySnapshots::add)
+            }
+            pending = registration
+            while (true) {
+                val requestedPath = synchronized(namespaceLock) { registration.path }
+                val snapshot = try {
+                    openDirectorySnapshot(requestedPath)
+                } catch (failure: Throwable) {
+                    if (synchronized(namespaceLock) { registration.path != requestedPath }) continue
+                    throw failure
+                }
+                val registered = synchronized(namespaceLock) {
+                    if (registration.path == requestedPath) {
+                        registerDirectorySnapshot(snapshot.copy(path = requestedPath))
+                    } else {
+                        null
+                    }
+                }
+                if (registered != null) return registered
+            }
         } catch (_: InterruptedException) {
             Thread.currentThread().interrupt()
             throw LinuxVirtualFileSystemException(ErrorCodes.EINTR())
         } finally {
+            pending?.let { snapshot -> synchronized(namespaceLock) { pendingDirectorySnapshots.remove(snapshot) } }
             if (acquired) directorySnapshotCreationPermits.release()
         }
     }
@@ -1185,6 +1259,17 @@ internal class LinuxNextcloudVirtualFileSystem(
         }
     }
 
+    private fun readdressOpenNamespace(sourcePath: String, destinationPath: String) {
+        check(Thread.holdsLock(namespaceLock))
+        readdressReadHandles(sourcePath, destinationPath)
+        readdressDirectoryHandles(sourcePath, destinationPath)
+        pendingDirectorySnapshots.forEach { pending ->
+            pending.path.readdressWithin(sourcePath, destinationPath)?.let { movedPath ->
+                pending.path = movedPath
+            }
+        }
+    }
+
     private fun String.readdressWithin(sourcePath: String, destinationPath: String): String? = when {
         this == sourcePath -> destinationPath
         startsWith("$sourcePath/") -> destinationPath + removePrefix(sourcePath)
@@ -1254,6 +1339,8 @@ private data class LinuxOpenDirectorySnapshot(
     val path: String,
     val entries: List<LinuxOpenDirectoryEntry>,
 )
+
+private class LinuxPendingDirectorySnapshot(var path: String)
 
 private data class LinuxOpenDirectoryEntry(
     val name: String,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -70,7 +70,7 @@ internal data class LinuxVirtualDirectorySnapshot(
 
 internal interface LinuxVirtualMetadataStore {
     fun load(path: String): LinuxVirtualDirectorySnapshot?
-    fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot)
+    fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean
     fun invalidate(path: String)
     fun retainedPaths(): Set<String>? = null
 }
@@ -84,14 +84,13 @@ internal class DesktopLinuxVirtualMetadataStore(
         return LinuxVirtualDirectorySnapshot(listing.nodes, listing.fetchedAtEpochMillis)
     }
 
-    override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+    override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean =
         cache.storeVirtualListingUnlessNewer(
             accountId = accountId,
             path = path,
             nodes = snapshot.nodes,
             fetchedAtEpochMillis = snapshot.fetchedAtEpochMillis,
         )
-    }
 
     override fun invalidate(path: String) = cache.invalidate(accountId, path)
 
@@ -392,7 +391,9 @@ internal class CachingLinuxVirtualFileBackend(
                                 !operation.invalidated &&
                                 snapshots[path]?.generation == snapshot.generation
                         }
-                        if (stillCurrent && runCatching { store.store(path, snapshot) }.isSuccess) {
+                        val persisted = stillCurrent &&
+                            runCatching { store.store(path, snapshot) }.getOrDefault(false)
+                        if (persisted) {
                             synchronized(metadataLock) {
                                 if (
                                     !closed &&
@@ -788,6 +789,7 @@ internal class DesktopNextcloudVirtualFileBackend(
 internal class LinuxNextcloudVirtualFileSystem(
     private val backend: LinuxVirtualFileBackend,
     private val maximumOpenDirectoryEntries: Int = DEFAULT_MAX_OPEN_DIRECTORY_ENTRIES,
+    private val beforeDirectoryHandleRemoval: () -> Unit = {},
 ) : FuseStubFS() {
     private val nextHandle = AtomicLong(1L)
     private val readHandles = ConcurrentHashMap<Long, LinuxVirtualFileReadHandle>()
@@ -795,7 +797,7 @@ internal class LinuxNextcloudVirtualFileSystem(
     private val writeHandles = ConcurrentHashMap<Long, LinuxOpenWriteReference>()
     private val directoryHandles = ConcurrentHashMap<Long, LinuxOpenDirectorySnapshot>()
     private val directoryHandleLock = Any()
-    private val directorySnapshotCreationLock = Any()
+    private val directorySnapshotCreationPermits = Semaphore(MAX_CONCURRENT_DIRECTORY_SNAPSHOT_CREATIONS, true)
     private var openDirectoryEntries = 0L
     private val pendingCreatedFiles = ConcurrentHashMap<String, LinuxSharedWriteHandle>()
     private val namespaceLock = Any()
@@ -850,6 +852,7 @@ internal class LinuxNextcloudVirtualFileSystem(
         val normalized = path.linuxVirtualPath()
         val removed = synchronized(directoryHandleLock) {
             val handle = directoryHandles[id] ?: return@synchronized null
+            beforeDirectoryHandleRemoval()
             if (handle.path != normalized || !directoryHandles.remove(id, handle)) return@synchronized null
             openDirectoryEntries = (openDirectoryEntries - handle.entries.size).coerceAtLeast(0L)
             handle
@@ -1092,10 +1095,19 @@ internal class LinuxNextcloudVirtualFileSystem(
         return LinuxOpenDirectorySnapshot(normalized, entries)
     }
 
-    private fun openAndRegisterDirectorySnapshot(path: String): Long =
-        synchronized(directorySnapshotCreationLock) {
-            registerDirectorySnapshot(openDirectorySnapshot(path))
+    private fun openAndRegisterDirectorySnapshot(path: String): Long {
+        var acquired = false
+        try {
+            directorySnapshotCreationPermits.acquire()
+            acquired = true
+            return registerDirectorySnapshot(openDirectorySnapshot(path))
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw LinuxVirtualFileSystemException(ErrorCodes.EINTR())
+        } finally {
+            if (acquired) directorySnapshotCreationPermits.release()
         }
+    }
 
     private fun registerDirectorySnapshot(snapshot: LinuxOpenDirectorySnapshot): Long =
         synchronized(directoryHandleLock) {
@@ -1165,9 +1177,11 @@ internal class LinuxNextcloudVirtualFileSystem(
     }
 
     private fun readdressDirectoryHandles(sourcePath: String, destinationPath: String) {
-        directoryHandles.entries.toList().forEach { (id, snapshot) ->
-            val movedPath = snapshot.path.readdressWithin(sourcePath, destinationPath) ?: return@forEach
-            directoryHandles.replace(id, snapshot, snapshot.copy(path = movedPath))
+        synchronized(directoryHandleLock) {
+            directoryHandles.entries.toList().forEach { (id, snapshot) ->
+                val movedPath = snapshot.path.readdressWithin(sourcePath, destinationPath) ?: return@forEach
+                directoryHandles.replace(id, snapshot, snapshot.copy(path = movedPath))
+            }
         }
     }
 
@@ -1232,6 +1246,7 @@ internal class LinuxNextcloudVirtualFileSystem(
         const val OPEN_READ_ONLY = 0x0
         const val OPEN_TRUNCATE = 0x200
         const val DEFAULT_MAX_OPEN_DIRECTORY_ENTRIES = 100_000
+        const val MAX_CONCURRENT_DIRECTORY_SNAPSHOT_CREATIONS = 4
     }
 }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -40,6 +40,24 @@ class DesktopFileReadCacheTest {
     }
 
     @Test
+    fun `failed virtual metadata invalidation quarantines persisted listings after restart`() =
+        withCache { root, cache ->
+            val accountId = desktopFileCacheAccountId(session())
+            val preferences = testPreferences(root)
+            cache.replaceFailedVirtualListingInvalidations(accountId, setOf("Photos/Changed"))
+
+            val restarted = DesktopFileReadCache(root, preferences = preferences)
+            assertEquals(setOf(""), restarted.failedVirtualListingInvalidations(accountId))
+
+            restarted.replaceFailedVirtualListingInvalidations(accountId, emptySet())
+            assertEquals(
+                emptySet(),
+                DesktopFileReadCache(root, preferences = preferences)
+                    .failedVirtualListingInvalidations(accountId),
+            )
+        }
+
+    @Test
     fun `folder refresh invalidates only removed or changed ETag generations`() = withCache { _, cache ->
         val accountId = desktopFileCacheAccountId(session())
         val stable = file("Notes/stable.md", "\"same\"")

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -175,6 +175,53 @@ class DesktopFileReadCacheTest {
     }
 
     @Test
+    fun `large listings are sharded beneath the bounded account index`() {
+        val root = Files.createTempDirectory("ncn-files-cache-shards-").toFile()
+        val preferences = testPreferences(root)
+        val maximumIndexBytes = 64L * 1024L
+        try {
+            val accountId = "a".repeat(64)
+            val files = List(200) { index ->
+                val name = "${index.toString().padStart(3, '0')}-${"x".repeat(900)}.jpg"
+                file("Library/$name", "\"etag-${"y".repeat(500)}-$index\"")
+            }
+            DesktopFileReadCache(
+                root = root,
+                preferences = preferences,
+                maximumIndexBytes = maximumIndexBytes,
+            ).storeListing(accountId, "Library", files, nowEpochMillis = 123_456L)
+
+            val accountDirectory = root.resolve(accountId)
+            assertTrue(accountDirectory.resolve("index-v1.json").length() <= maximumIndexBytes)
+            assertTrue(accountDirectory.listFiles().orEmpty().count { it.extension == "metadata" } > 1)
+
+            val restored = DesktopFileReadCache(
+                root = root,
+                preferences = preferences,
+                maximumIndexBytes = maximumIndexBytes,
+            ).cachedListingSnapshot(accountId, "Library")
+            assertEquals(files, restored?.files)
+            assertEquals(123_456L, restored?.fetchedAtEpochMillis)
+        } finally {
+            runCatching { preferences.removeNode() }
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `one corrupt metadata shard does not discard unrelated listings`() = withCache { root, cache ->
+        val accountId = desktopFileCacheAccountId(session())
+        cache.storeListing(accountId, "Photos", listOf(file("Photos/photo.jpg", "photos")), 10L)
+        cache.storeListing(accountId, "Notes", listOf(file("Notes/note.txt", "notes")), 20L)
+        val shards = root.resolve(accountId).listFiles().orEmpty().filter { it.extension == "metadata" }
+        assertEquals(2, shards.size)
+        shards.first().writeText("corrupt")
+
+        val restored = DesktopFileReadCache(root, preferences = testPreferences(root))
+        assertEquals(1, restored.cachedListingPaths(accountId).size)
+    }
+
+    @Test
     fun `authoritative listing replaces a future timestamp after clock rollback`() = withCache { _, cache ->
         val accountId = desktopFileCacheAccountId(session())
         cache.storeListing(accountId, "Photos", listOf(file("Photos/old.jpg", "old")), 10_000L)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -251,7 +251,8 @@ class DesktopFileReadCacheTest {
     @Test
     fun `startup preserves over-budget metadata references for demand loading`() = withCache { root, cache ->
         val accountId = desktopFileCacheAccountId(session())
-        cache.storeListing(accountId, "First", listOf(file("First/one.jpg", "first")), 10L)
+        val largeListing = List(65) { index -> file("First/$index.jpg", "first-$index") }
+        cache.storeListing(accountId, "First", largeListing, 10L)
         cache.storeListing(accountId, "Second", listOf(file("Second/two.jpg", "second")), 20L)
         val shardBytes = root.resolve(accountId).listFiles().orEmpty()
             .filter { file -> file.extension == "metadata" }
@@ -276,9 +277,9 @@ class DesktopFileReadCacheTest {
             ),
         )
         assertEquals(1, shardReads.get())
-        assertEquals(listOf(file("First/one.jpg", "first")), restored.cachedListing(accountId, "First"))
+        assertEquals(largeListing, restored.cachedListing(accountId, "First"))
         assertEquals(listOf(file("Second/two.jpg", "second")), restored.cachedListing(accountId, "Second"))
-        assertEquals(3, shardReads.get())
+        assertEquals(4, shardReads.get())
 
         val restarted = DesktopFileReadCache(
             root = root,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -156,6 +156,30 @@ class DesktopFileReadCacheTest {
         assertEquals(123_456, listing?.fetchedAtEpochMillis)
     }
 
+    @Test
+    fun `decoded account indexes are retained within an LRU bound`() {
+        val root = Files.createTempDirectory("ncn-files-cache-accounts-").toFile()
+        val preferences = testPreferences(root)
+        try {
+            val cache = DesktopFileReadCache(
+                root = root,
+                preferences = preferences,
+                maximumLoadedAccountIndexes = 1,
+            )
+            val firstAccount = "1".repeat(64)
+            val secondAccount = "2".repeat(64)
+            cache.storeListing(firstAccount, "Notes", listOf(file("Notes/first.txt", "e1")), 1L)
+            cache.storeListing(secondAccount, "Notes", listOf(file("Notes/second.txt", "e2")), 2L)
+
+            assertTrue(root.resolve(firstAccount).resolve("index-v1.json").delete())
+            assertNull(cache.cachedListing(firstAccount, "Notes"))
+            assertEquals("Notes/second.txt", cache.cachedListing(secondAccount, "Notes")?.single()?.path)
+        } finally {
+            runCatching { preferences.removeNode() }
+            root.deleteRecursively()
+        }
+    }
+
     private fun session(password: String = "secret") = NextcloudSession(
         serverUrl = "https://cloud.example.test",
         loginName = "alice",

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -1,6 +1,7 @@
 package dev.obiente.nextcloudnative.app
 
 import java.nio.file.Files
+import java.util.prefs.Preferences
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -24,7 +25,7 @@ class DesktopFileReadCacheTest {
             ),
         )
 
-        val restored = DesktopFileReadCache(root)
+        val restored = DesktopFileReadCache(root, preferences = testPreferences(root))
 
         assertEquals(listOf(file), restored.cachedListing(accountId, "Notes"))
         assertContentEquals(
@@ -135,9 +136,24 @@ class DesktopFileReadCacheTest {
         val index = root.resolve(accountId).resolve("index-v1.json")
         index.writeText("{not-json")
 
-        val restored = DesktopFileReadCache(root)
+        val restored = DesktopFileReadCache(root, preferences = testPreferences(root))
 
         assertNull(restored.cachedContent(accountId, "safe.txt", 10))
+    }
+
+    @Test
+    fun `large folder metadata and refresh timestamp survive restart`() = withCache { root, cache ->
+        val accountId = desktopFileCacheAccountId(session())
+        val files = List(6_001) { index ->
+            file("Library/photo-${index.toString().padStart(5, '0')}.jpg", "\"etag-$index\"")
+        }
+
+        cache.storeListing(accountId, "Library", files, nowEpochMillis = 123_456)
+        val restored = DesktopFileReadCache(root, preferences = testPreferences(root))
+        val listing = restored.cachedListingSnapshot(accountId, "Library")
+
+        assertEquals(6_001, listing?.files?.size)
+        assertEquals(123_456, listing?.fetchedAtEpochMillis)
     }
 
     private fun session(password: String = "secret") = NextcloudSession(
@@ -176,10 +192,20 @@ class DesktopFileReadCacheTest {
         block: (java.io.File, DesktopFileReadCache) -> Unit,
     ) {
         val root = Files.createTempDirectory("ncn-files-cache-").toFile()
+        val preferences = testPreferences(root)
         try {
-            block(root, DesktopFileReadCache(root, maximumContentBytes, maximumEntryBytes))
+            preferences.clear()
+            preferences.putBoolean("automatic-cleanup", false)
+            block(
+                root,
+                DesktopFileReadCache(root, maximumContentBytes, maximumEntryBytes, preferences),
+            )
         } finally {
+            preferences.removeNode()
             root.deleteRecursively()
         }
     }
+
+    private fun testPreferences(root: java.io.File): Preferences = Preferences.userRoot()
+        .node("dev/obiente/nextcloudnative/tests/file-cache/${root.name}")
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -125,6 +125,24 @@ class DesktopFileReadCacheTest {
     }
 
     @Test
+    fun `nested invalidation removes every persisted ancestor listing`() = withCache { _, cache ->
+        val accountId = desktopFileCacheAccountId(session())
+        cache.storeListing(accountId, "", listOf(directory("Photos"), directory("Archive")), 10)
+        cache.storeListing(accountId, "Photos", listOf(directory("Photos/Album")), 20)
+        cache.storeListing(accountId, "Photos/Album", listOf(directory("Photos/Album/Day")), 30)
+        cache.storeListing(accountId, "Photos/Album/Day", listOf(file("Photos/Album/Day/photo.raf", "e1")), 40)
+        cache.storeListing(accountId, "Archive", emptyList(), 50)
+
+        cache.invalidate(accountId, "Photos/Album/Day/photo.raf")
+
+        assertNull(cache.cachedListing(accountId, ""))
+        assertNull(cache.cachedListing(accountId, "Photos"))
+        assertNull(cache.cachedListing(accountId, "Photos/Album"))
+        assertNull(cache.cachedListing(accountId, "Photos/Album/Day"))
+        assertEquals(emptyList(), cache.cachedListing(accountId, "Archive"))
+    }
+
+    @Test
     fun `corrupt disposable index never exposes orphaned content`() = withCache { root, cache ->
         val accountId = desktopFileCacheAccountId(session())
         cache.storeContent(

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -194,6 +194,24 @@ class DesktopFileReadCacheTest {
     }
 
     @Test
+    fun `delayed listing cannot replace a request that started later`() = withCache { _, cache ->
+        val accountId = desktopFileCacheAccountId(session())
+        cache.storeListing(accountId, "Photos", listOf(file("Photos/current.jpg", "current")), 200L)
+
+        assertFalse(
+            cache.storeListingUnlessNewer(
+                accountId = accountId,
+                path = "Photos",
+                files = listOf(file("Photos/stale.jpg", "stale")),
+                fetchedAtEpochMillis = 100L,
+                nowEpochMillis = 300L,
+            ),
+        )
+
+        assertEquals("Photos/current.jpg", cache.cachedListing(accountId, "Photos")?.single()?.path)
+    }
+
+    @Test
     fun `decoded account indexes are retained within an LRU bound`() {
         val root = Files.createTempDirectory("ncn-files-cache-accounts-").toFile()
         val preferences = testPreferences(root)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -1,6 +1,7 @@
 package dev.obiente.nextcloudnative.app
 
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.prefs.Preferences
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -218,6 +219,50 @@ class DesktopFileReadCacheTest {
         shards.first().writeText("corrupt")
 
         val restored = DesktopFileReadCache(root, preferences = testPreferences(root))
+        assertEquals(1, restored.cachedListingPaths(accountId).size)
+    }
+
+    @Test
+    fun `content-only saves reuse verified metadata shards without reading them again`() = withCache { root, cache ->
+        val accountId = desktopFileCacheAccountId(session())
+        val files = List(200) { index -> file("Library/photo-$index.jpg", "etag-$index") }
+        cache.storeListing(accountId, "Library", files, 10L)
+        val shardReads = AtomicInteger()
+        val restored = DesktopFileReadCache(
+            root = root,
+            preferences = testPreferences(root),
+            metadataShardReadObserver = { shardReads.incrementAndGet() },
+        )
+        assertEquals(files, restored.cachedListing(accountId, "Library"))
+        val readsAfterHydration = shardReads.get()
+
+        assertTrue(
+            restored.storeContent(
+                accountId,
+                "unrelated.bin",
+                NextcloudFileContent(byteArrayOf(1), "application/octet-stream", "unrelated-etag"),
+                20L,
+            ),
+        )
+
+        assertEquals(readsAfterHydration, shardReads.get())
+    }
+
+    @Test
+    fun `startup bounds cumulative metadata shard hydration bytes`() = withCache { root, cache ->
+        val accountId = desktopFileCacheAccountId(session())
+        cache.storeListing(accountId, "First", listOf(file("First/one.jpg", "first")), 10L)
+        cache.storeListing(accountId, "Second", listOf(file("Second/two.jpg", "second")), 20L)
+        val shardBytes = root.resolve(accountId).listFiles().orEmpty()
+            .filter { file -> file.extension == "metadata" }
+            .maxOf { file -> file.length() }
+
+        val restored = DesktopFileReadCache(
+            root = root,
+            preferences = testPreferences(root),
+            maximumHydratedMetadataBytes = shardBytes,
+        )
+
         assertEquals(1, restored.cachedListingPaths(accountId).size)
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -235,6 +235,45 @@ class DesktopFileReadCacheTest {
         }
     }
 
+    @Test
+    fun `Files metadata cannot consume the reserved virtual listing capacity`() {
+        val root = Files.createTempDirectory("ncn-files-cache-reserve-").toFile()
+        val preferences = testPreferences(root)
+        try {
+            val accountId = "0".repeat(64)
+            val cache = DesktopFileReadCache(
+                root = root,
+                preferences = preferences,
+                maximumTotalMetadataEntries = 10,
+            )
+            repeat(3) { listing ->
+                cache.storeListing(
+                    accountId,
+                    "Folder-$listing",
+                    List(4) { index -> file("Folder-$listing/file-$index.txt", "e-$listing-$index") },
+                    nowEpochMillis = listing.toLong(),
+                )
+            }
+            cache.storeVirtualListingUnlessNewer(
+                accountId = accountId,
+                path = "Virtual",
+                nodes = listOf(LinuxVirtualFileNode("Virtual/photo.raf", "photo.raf", false, 4L, "virtual-e1")),
+                fetchedAtEpochMillis = 10L,
+            )
+
+            val restarted = DesktopFileReadCache(
+                root = root,
+                preferences = preferences,
+                maximumTotalMetadataEntries = 10,
+            )
+            assertEquals("virtual-e1", restarted.cachedVirtualListingSnapshot(accountId, "Virtual")
+                ?.nodes?.single()?.remoteRevision)
+        } finally {
+            runCatching { preferences.removeNode() }
+            root.deleteRecursively()
+        }
+    }
+
     private fun session(password: String = "secret") = NextcloudSession(
         serverUrl = "https://cloud.example.test",
         loginName = "alice",

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -157,6 +157,25 @@ class DesktopFileReadCacheTest {
     }
 
     @Test
+    fun `authoritative listing replaces a future timestamp after clock rollback`() = withCache { _, cache ->
+        val accountId = desktopFileCacheAccountId(session())
+        cache.storeListing(accountId, "Photos", listOf(file("Photos/old.jpg", "old")), 10_000L)
+
+        assertTrue(
+            cache.storeListingUnlessNewer(
+                accountId = accountId,
+                path = "Photos",
+                files = listOf(file("Photos/current.jpg", "current")),
+                fetchedAtEpochMillis = 5_000L,
+                nowEpochMillis = 5_000L,
+            ),
+        )
+
+        assertEquals("Photos/current.jpg", cache.cachedListing(accountId, "Photos")?.single()?.path)
+        assertEquals(5_000L, cache.cachedListingSnapshot(accountId, "Photos")?.fetchedAtEpochMillis)
+    }
+
+    @Test
     fun `decoded account indexes are retained within an LRU bound`() {
         val root = Files.createTempDirectory("ncn-files-cache-accounts-").toFile()
         val preferences = testPreferences(root)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -58,6 +58,25 @@ class DesktopFileReadCacheTest {
         }
 
     @Test
+    fun `virtual metadata preserves response completion freshness after restart`() =
+        withCache { root, cache ->
+            val accountId = desktopFileCacheAccountId(session())
+            cache.storeVirtualListingUnlessNewer(
+                accountId = accountId,
+                path = "Photos",
+                nodes = listOf(LinuxVirtualFileNode("Photos/a.jpg", "a.jpg", false, 4L, "etag-a")),
+                fetchedAtEpochMillis = 10L,
+                freshAtEpochMillis = 6_010L,
+            )
+
+            val restored = DesktopFileReadCache(root, preferences = testPreferences(root))
+            val snapshot = restored.cachedVirtualListingSnapshot(accountId, "Photos")
+
+            assertEquals(10L, snapshot?.fetchedAtEpochMillis)
+            assertEquals(6_010L, snapshot?.freshAtEpochMillis)
+        }
+
+    @Test
     fun `folder refresh invalidates only removed or changed ETag generations`() = withCache { _, cache ->
         val accountId = desktopFileCacheAccountId(session())
         val stable = file("Notes/stable.md", "\"same\"")

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileReadCacheTest.kt
@@ -249,7 +249,7 @@ class DesktopFileReadCacheTest {
     }
 
     @Test
-    fun `startup bounds cumulative metadata shard hydration bytes`() = withCache { root, cache ->
+    fun `startup preserves over-budget metadata references for demand loading`() = withCache { root, cache ->
         val accountId = desktopFileCacheAccountId(session())
         cache.storeListing(accountId, "First", listOf(file("First/one.jpg", "first")), 10L)
         cache.storeListing(accountId, "Second", listOf(file("Second/two.jpg", "second")), 20L)
@@ -257,13 +257,35 @@ class DesktopFileReadCacheTest {
             .filter { file -> file.extension == "metadata" }
             .maxOf { file -> file.length() }
 
+        val shardReads = AtomicInteger()
         val restored = DesktopFileReadCache(
             root = root,
             preferences = testPreferences(root),
             maximumHydratedMetadataBytes = shardBytes,
+            metadataShardReadObserver = { shardReads.incrementAndGet() },
         )
 
-        assertEquals(1, restored.cachedListingPaths(accountId).size)
+        assertEquals(setOf("First", "Second"), restored.cachedListingPaths(accountId))
+        assertEquals(1, shardReads.get())
+        assertTrue(
+            restored.storeContent(
+                accountId,
+                "unrelated.bin",
+                NextcloudFileContent(byteArrayOf(1), "application/octet-stream", "unrelated"),
+                30L,
+            ),
+        )
+        assertEquals(1, shardReads.get())
+        assertEquals(listOf(file("First/one.jpg", "first")), restored.cachedListing(accountId, "First"))
+        assertEquals(listOf(file("Second/two.jpg", "second")), restored.cachedListing(accountId, "Second"))
+        assertEquals(3, shardReads.get())
+
+        val restarted = DesktopFileReadCache(
+            root = root,
+            preferences = testPreferences(root),
+            maximumHydratedMetadataBytes = shardBytes,
+        )
+        assertEquals(setOf("First", "Second"), restarted.cachedListingPaths(accountId))
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncEngineTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncEngineTest.kt
@@ -9,6 +9,18 @@ import kotlin.test.assertTrue
 
 class DesktopFileSyncEngineTest {
     @Test
+    fun `remote mutation paths include the configured pair root`() {
+        assertEquals(
+            "Photography/Albums/2026/cover.jpg",
+            desktopFileSyncRemoteMutationPath(
+                remoteRootPath = "/Photography/Albums/",
+                relativePath = "/2026/cover.jpg/",
+            ),
+        )
+        assertEquals("cover.jpg", desktopFileSyncRemoteMutationPath("", "cover.jpg"))
+    }
+
+    @Test
     fun `stale owned stages are reclaimed without touching lookalikes`() {
         val root = Files.createTempDirectory("desktop-sync-stage-recovery-").toFile()
         try {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -350,6 +350,19 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `dav parser counts unusable responses against its streaming limit`() {
+        val responses = "<d:response/>".repeat(3)
+
+        assertFails {
+            parseDesktopSyncDav(
+                "<d:multistatus xmlns:d=\"DAV:\">$responses</d:multistatus>".encodeToByteArray(),
+                userId = "alice",
+                maximumDocuments = 2,
+            )
+        }
+    }
+
+    @Test
     fun `dav parser rejects an oversized property without coalescing text`() {
         val oversizedHref = "a".repeat(20_000)
         val response = (

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -1,10 +1,94 @@
 package dev.obiente.nextcloudnative.app
 
+import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 
 class DesktopFileSyncRemoteTreeTest {
+    @Test
+    fun `definitive mutation rejection preserves cached metadata`() {
+        val invalidated = mutableListOf<String>()
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            when (chain.request().method) {
+                "PROPFIND" -> response(
+                    chain.request(),
+                    207,
+                    "<d:multistatus xmlns:d=\"DAV:\"></d:multistatus>",
+                )
+                "MKCOL" -> response(chain.request(), 412)
+                else -> error("Unexpected ${chain.request().method} request")
+            }
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            session = NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            userId = "alice",
+            remoteRootPath = "",
+            client = client,
+            onMutationCommitted = invalidated::add,
+        )
+
+        assertFails { tree.createDirectory("Photos", expectedRemoteEtag = null) }
+        assertEquals(emptyList(), invalidated)
+    }
+
+    @Test
+    fun `confirmed mutation invalidates cached metadata once`() {
+        val invalidated = mutableListOf<String>()
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            when (chain.request().method) {
+                "PROPFIND" -> response(
+                    chain.request(),
+                    207,
+                    "<d:multistatus xmlns:d=\"DAV:\"></d:multistatus>",
+                )
+                "MKCOL" -> response(chain.request(), 201)
+                else -> error("Unexpected ${chain.request().method} request")
+            }
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            session = NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            userId = "alice",
+            remoteRootPath = "",
+            client = client,
+            onMutationCommitted = invalidated::add,
+        )
+
+        tree.createDirectory("Photos", expectedRemoteEtag = null)
+        assertEquals(listOf("Photos"), invalidated)
+    }
+
+    @Test
+    fun `only started mutation exchanges have ambiguous io results`() {
+        val failure = IOException("connection closed")
+
+        assertEquals(false, desktopMutationResultIsAmbiguous(networkExchangeStarted = false, failure))
+        assertEquals(true, desktopMutationResultIsAmbiguous(networkExchangeStarted = true, failure))
+        assertEquals(false, desktopMutationResultIsAmbiguous(networkExchangeStarted = true, IllegalStateException()))
+    }
+
+    @Test
+    fun `pre-network io failure does not invoke ambiguous recovery`() {
+        val executor = DesktopHttpMutationExecutor(
+            OkHttpClient.Builder().addInterceptor { throw IOException("offline") }.build(),
+        )
+        var recovered = false
+
+        assertFails {
+            executor.execute(
+                Request.Builder().url("https://cloud.example.test/remote.php/dav/files/alice/Photos").build(),
+                onAmbiguousNetworkResult = { recovered = true },
+            ) { response -> response.code }
+        }
+        assertFalse(recovered)
+    }
+
     @Test
     fun `dav parser preserves plus signs and reads guarded revisions`() {
         val documents = parseDesktopSyncDav(
@@ -42,6 +126,14 @@ class DesktopFileSyncRemoteTreeTest {
         assertEquals("\"file-etag\"", documents.last().entry.etag)
         assertEquals(1_785_587_696_000L, documents.last().lastModifiedEpochMillis)
     }
+
+    private fun response(request: Request, code: Int, body: String = ""): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message("test")
+        .body(body.toResponseBody())
+        .build()
 
     @Test
     fun `dav parser rejects external entities`() {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -108,6 +108,17 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `dav parser rejects non utf8 xml before decoded events`() {
+        val utf16 = (
+            "<?xml version=\"1.0\" encoding=\"UTF-16\"?>" +
+                "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>Photos/a.jpg</d:href>" +
+                "</d:response></d:multistatus>"
+            ).toByteArray(Charsets.UTF_16)
+
+        assertFails { parseDesktopSyncDav(utf16, userId = "alice") }
+    }
+
+    @Test
     fun `only exact provider owned upload stages are suppressed`() {
         assertEquals(
             true,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -72,6 +72,62 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `accepted mutation invalidates metadata before an oversized response fails`() {
+        val invalidated = mutableListOf<String>()
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            when (chain.request().method) {
+                "PROPFIND" -> response(
+                    chain.request(),
+                    207,
+                    "<d:multistatus xmlns:d=\"DAV:\"></d:multistatus>",
+                )
+                "MKCOL" -> response(chain.request(), 201, "x".repeat(65 * 1024))
+                else -> error("Unexpected ${chain.request().method} request")
+            }
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            session = NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            userId = "alice",
+            remoteRootPath = "",
+            client = client,
+            onMutationCommitted = invalidated::add,
+        )
+
+        assertFails { tree.createDirectory("Photos", expectedRemoteEtag = null) }
+        assertEquals(listOf("Photos"), invalidated)
+    }
+
+    @Test
+    fun `directory emptiness is bound to the revision in one authoritative listing`() {
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            response(
+                chain.request(),
+                207,
+                """
+                <d:multistatus xmlns:d="DAV:">
+                  <d:response><d:href>/remote.php/dav/files/alice/Photos/Trips/</d:href>
+                    <d:propstat><d:prop><d:getetag>current-directory</d:getetag>
+                      <d:resourcetype><d:collection/></d:resourcetype>
+                    </d:prop></d:propstat></d:response>
+                  <d:response><d:href>/remote.php/dav/files/alice/Photos/Trips/new.raf</d:href>
+                    <d:propstat><d:prop><d:getetag>new-file</d:getetag><d:getcontentlength>1</d:getcontentlength>
+                      <d:resourcetype/></d:prop></d:propstat></d:response>
+                </d:multistatus>
+                """.trimIndent(),
+            )
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            session = NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            userId = "alice",
+            remoteRootPath = "",
+            client = client,
+        )
+
+        assertFails { tree.isDirectoryEmpty("Photos/Trips", "stale-directory") }
+        assertFalse(tree.isDirectoryEmpty("Photos/Trips", "current-directory"))
+    }
+
+    @Test
     fun `confirmed replacement backup move invalidates metadata when later moves fail`() {
         val confirmed = mutableListOf<String>()
         var backupPath: String? = null

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -119,6 +119,20 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `dav parser bounds markup and rejects unsupported token forms before stax`() {
+        val oversizedAttribute = (
+            "<d:multistatus xmlns:d=\"DAV:\" data-value=\"" + "a".repeat(20_000) +
+                "\"></d:multistatus>"
+            ).encodeToByteArray()
+        val comment = "<d:multistatus xmlns:d=\"DAV:\"><!-- comment --></d:multistatus>".encodeToByteArray()
+        val instruction = "<d:multistatus xmlns:d=\"DAV:\"><?unsafe value?></d:multistatus>".encodeToByteArray()
+
+        listOf(oversizedAttribute, comment, instruction).forEach { response ->
+            assertFails { parseDesktopSyncDav(response, userId = "alice") }
+        }
+    }
+
+    @Test
     fun `only exact provider owned upload stages are suppressed`() {
         assertEquals(
             true,
@@ -155,6 +169,13 @@ class DesktopFileSyncRemoteTreeTest {
         assertEquals(
             emptyList(),
             desktopOwnedBackupRecoveryPlan(listOf(first, "Photos/one.jpg"), maximumRecoveryItems = 1),
+        )
+        assertEquals(
+            emptyList(),
+            desktopOwnedBackupRecoveryPlan(
+                listOf(first, second, "Photos/one.jpg", "Photos/two.jpg"),
+                maximumRecoveryItems = 0,
+            ),
         )
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -94,6 +94,20 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `dav parser rejects cdata before materializing property text`() {
+        assertFails {
+            parseDesktopSyncDav(
+                (
+                    "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href><![CDATA[" +
+                        "a".repeat(20_000) +
+                        "]]></d:href></d:response></d:multistatus>"
+                    ).encodeToByteArray(),
+                userId = "alice",
+            )
+        }
+    }
+
+    @Test
     fun `only exact provider owned upload stages are suppressed`() {
         assertEquals(
             true,
@@ -113,6 +127,24 @@ class DesktopFileSyncRemoteTreeTest {
         )
         assertEquals(null, desktopOwnedBackupDestination("Photos/.today.md.nextcloud-native-backup-not-a-uuid"))
         assertEquals(null, desktopOwnedBackupDestination("Photos/user-backup"))
+    }
+
+    @Test
+    fun `backup recovery is bounded before orphan processing`() {
+        val first = "Photos/.one.jpg.nextcloud-native-backup-123e4567-e89b-12d3-a456-426614174000"
+        val second = "Photos/.two.jpg.nextcloud-native-backup-123e4567-e89b-12d3-a456-426614174001"
+
+        assertFails {
+            desktopOwnedBackupRecoveryPlan(listOf(first, second), maximumRecoveryItems = 1)
+        }
+        assertEquals(
+            listOf(first to "Photos/one.jpg"),
+            desktopOwnedBackupRecoveryPlan(listOf(first), maximumRecoveryItems = 1),
+        )
+        assertEquals(
+            emptyList(),
+            desktopOwnedBackupRecoveryPlan(listOf(first, "Photos/one.jpg"), maximumRecoveryItems = 1),
+        )
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -72,6 +72,62 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `confirmed replacement backup move invalidates metadata when later moves fail`() {
+        val confirmed = mutableListOf<String>()
+        var backupPath: String? = null
+        var propfindCount = 0
+        var moveCount = 0
+        fun listing(vararg entries: Pair<String, String>): String = entries.joinToString(
+            prefix = "<d:multistatus xmlns:d=\"DAV:\">",
+            postfix = "</d:multistatus>",
+            separator = "",
+        ) { (path, etag) ->
+            "<d:response><d:href>/remote.php/dav/files/alice/$path</d:href>" +
+                "<d:propstat><d:prop><d:getetag>$etag</d:getetag><d:getcontentlength>4</d:getcontentlength>" +
+                "<d:resourcetype/></d:prop></d:propstat></d:response>"
+        }
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            when (chain.request().method) {
+                "PROPFIND" -> {
+                    propfindCount += 1
+                    val body = if (propfindCount <= 2) {
+                        listing("source.txt" to "source-etag", "destination.txt" to "destination-etag")
+                    } else {
+                        listing("source.txt" to "source-etag", requireNotNull(backupPath) to "destination-etag")
+                    }
+                    response(chain.request(), 207, body)
+                }
+                "MOVE" -> {
+                    moveCount += 1
+                    when (moveCount) {
+                        1 -> {
+                            backupPath = requireNotNull(chain.request().header("Destination"))
+                                .substringAfter("/remote.php/dav/files/alice/")
+                            response(chain.request(), 201)
+                        }
+                        2 -> response(chain.request(), 412)
+                        else -> response(chain.request(), 500)
+                    }
+                }
+                else -> error("Unexpected ${chain.request().method} request")
+            }
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            session = NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            userId = "alice",
+            remoteRootPath = "",
+            client = client,
+            onMutationCommitted = confirmed::add,
+        )
+
+        assertFails {
+            tree.moveReplacing("source.txt", "destination.txt", "source-etag", "destination-etag")
+        }
+        assertEquals(listOf("destination.txt"), confirmed)
+        assertEquals(3, moveCount)
+    }
+
+    @Test
     fun `only started mutation exchanges have ambiguous io results`() {
         val failure = IOException("connection closed")
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -1,10 +1,14 @@
 package dev.obiente.nextcloudnative.app
 
 import java.io.IOException
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.util.concurrent.Executors
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
@@ -41,6 +45,7 @@ class DesktopFileSyncRemoteTreeTest {
     @Test
     fun `confirmed mutation invalidates cached metadata once`() {
         val invalidated = mutableListOf<String>()
+        val ambiguous = mutableListOf<String>()
         val client = OkHttpClient.Builder().addInterceptor { chain ->
             when (chain.request().method) {
                 "PROPFIND" -> response(
@@ -58,10 +63,12 @@ class DesktopFileSyncRemoteTreeTest {
             remoteRootPath = "",
             client = client,
             onMutationCommitted = invalidated::add,
+            onAmbiguousMutationResult = ambiguous::add,
         )
 
         tree.createDirectory("Photos", expectedRemoteEtag = null)
         assertEquals(listOf("Photos"), invalidated)
+        assertEquals(emptyList(), ambiguous)
     }
 
     @Test
@@ -71,6 +78,47 @@ class DesktopFileSyncRemoteTreeTest {
         assertEquals(false, desktopMutationResultIsAmbiguous(networkExchangeStarted = false, failure))
         assertEquals(true, desktopMutationResultIsAmbiguous(networkExchangeStarted = true, failure))
         assertEquals(false, desktopMutationResultIsAmbiguous(networkExchangeStarted = true, IllegalStateException()))
+    }
+
+    @Test
+    fun `lost mutation response invokes only ambiguous metadata recovery`() {
+        val server = ServerSocket(0, 1, InetAddress.getLoopbackAddress())
+        val worker = Executors.newSingleThreadExecutor()
+        val confirmed = mutableListOf<String>()
+        val ambiguous = mutableListOf<String>()
+        val served = worker.submit {
+            server.accept().use { socket ->
+                val input = socket.getInputStream().buffered()
+                assertTrue(readRequestHeaders(input).startsWith("PROPFIND "))
+                val body = "<d:multistatus xmlns:d=\"DAV:\"></d:multistatus>"
+                socket.getOutputStream().write(
+                    (
+                        "HTTP/1.1 207 Multi-Status\r\n" +
+                            "Content-Length: ${body.encodeToByteArray().size}\r\n" +
+                            "Connection: keep-alive\r\n\r\n" + body
+                        ).encodeToByteArray(),
+                )
+                socket.getOutputStream().flush()
+                assertTrue(readRequestHeaders(input).startsWith("MKCOL "))
+            }
+        }
+        try {
+            val tree = DesktopFileSyncRemoteTree(
+                session = NextcloudSession("http://127.0.0.1:${server.localPort}", "alice", "secret"),
+                userId = "alice",
+                remoteRootPath = "",
+                onMutationCommitted = confirmed::add,
+                onAmbiguousMutationResult = ambiguous::add,
+            )
+
+            assertFails { tree.createDirectory("Photos", expectedRemoteEtag = null) }
+            served.get()
+            assertEquals(emptyList(), confirmed)
+            assertEquals(listOf("Photos"), ambiguous)
+        } finally {
+            runCatching(server::close)
+            worker.shutdownNow()
+        }
     }
 
     @Test
@@ -134,6 +182,26 @@ class DesktopFileSyncRemoteTreeTest {
         .message("test")
         .body(body.toResponseBody())
         .build()
+
+    private fun readRequestHeaders(input: java.io.InputStream): String {
+        val bytes = ArrayList<Byte>()
+        var matched = 0
+        val terminator = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte(), '\r'.code.toByte(), '\n'.code.toByte())
+        while (matched < terminator.size) {
+            val next = input.read()
+            check(next >= 0) { "The test client closed before sending complete HTTP headers." }
+            val byte = next.toByte()
+            bytes += byte
+            matched = if (byte == terminator[matched]) matched + 1 else if (byte == terminator[0]) 1 else 0
+        }
+        val headers = bytes.toByteArray().decodeToString()
+        val contentLength = Regex("(?im)^Content-Length:\\s*(\\d+)\\s*$")
+            .find(headers)?.groupValues?.get(1)?.toInt() ?: 0
+        repeat(contentLength) {
+            check(input.read() >= 0) { "The test client closed before sending its HTTP body." }
+        }
+        return headers
+    }
 
     @Test
     fun `dav parser rejects external entities`() {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -58,6 +58,26 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `dav parser rejects excess documents while streaming`() {
+        val responses = (1..3).joinToString("") { index ->
+            """
+            <d:response>
+              <d:href>/remote.php/dav/files/alice/Photos/$index.jpg</d:href>
+              <d:propstat><d:prop><d:getetag>etag-$index</d:getetag></d:prop></d:propstat>
+            </d:response>
+            """.trimIndent()
+        }
+
+        assertFails {
+            parseDesktopSyncDav(
+                "<d:multistatus xmlns:d=\"DAV:\">$responses</d:multistatus>".encodeToByteArray(),
+                userId = "alice",
+                maximumDocuments = 2,
+            )
+        }
+    }
+
+    @Test
     fun `only exact provider owned upload stages are suppressed`() {
         assertEquals(
             true,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -78,6 +78,22 @@ class DesktopFileSyncRemoteTreeTest {
     }
 
     @Test
+    fun `dav parser rejects an oversized property without coalescing text`() {
+        val oversizedHref = "a".repeat(20_000)
+        val response = (
+            "<d:multistatus xmlns:d=\"DAV:\"><d:response><d:href>$oversizedHref</d:href>" +
+                "</d:response></d:multistatus>"
+            ).encodeToByteArray()
+
+        assertFails {
+            parseDesktopSyncDav(
+                response,
+                userId = "alice",
+            )
+        }
+    }
+
+    @Test
     fun `only exact provider owned upload stages are suppressed`() {
         assertEquals(
             true,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -287,6 +287,24 @@ class DesktopFileSyncRemoteTreeTest {
         assertEquals(1_785_587_696_000L, documents.last().lastModifiedEpochMillis)
     }
 
+    @Test
+    fun `dav parser accepts bounded cdata properties`() {
+        val documents = parseDesktopSyncDav(
+            (
+                "<d:multistatus xmlns:d=\"DAV:\"><d:response>" +
+                    "<d:href><![CDATA[/remote.php/dav/files/alice/Photos/a%20b.jpg]]></d:href>" +
+                    "<d:propstat><d:prop><d:getetag><![CDATA[\"etag-a\"]]></d:getetag>" +
+                    "<d:getcontentlength><![CDATA[4]]></d:getcontentlength>" +
+                    "</d:prop></d:propstat></d:response></d:multistatus>"
+                ).encodeToByteArray(),
+            userId = "alice",
+        )
+
+        assertEquals(listOf("Photos/a b.jpg"), documents.map { it.entry.relativePath })
+        assertEquals("\"etag-a\"", documents.single().entry.etag)
+        assertEquals(4L, documents.single().entry.size)
+    }
+
     private fun response(request: Request, code: Int, body: String = ""): Response = Response.Builder()
         .request(request)
         .protocol(Protocol.HTTP_1_1)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStoreTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStoreTest.kt
@@ -62,6 +62,8 @@ class DesktopLinuxVirtualFileWritebackStoreTest {
             assertFails { handle.write(0L, "after!".encodeToByteArray()) }
 
             assertTrue(store.pendingWritebacks().single().dirty)
+            val manifest = directory.listFiles().orEmpty().single { it.name.endsWith(".stage.json") }
+            assertFalse("\"committed\"" in manifest.readText())
             val stage = directory.listFiles().orEmpty().single { it.name.endsWith(".stage") }
             assertContentEquals("before".encodeToByteArray(), stage.readBytes())
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStoreTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStoreTest.kt
@@ -161,6 +161,31 @@ class DesktopLinuxVirtualFileWritebackStoreTest {
         }
     }
 
+    @Test
+    fun `recovery discards an untouched write stage without invalidating caches`() {
+        val directory = Files.createTempDirectory("linux-writeback-untouched-recovery-").toFile()
+        try {
+            val remote = FakeWritebackRemote("before".encodeToByteArray(), "etag-1")
+            val store = DesktopLinuxVirtualFileWritebackStore(directory, minimumFreeSpaceBytes = { 0L })
+            val node = LinuxVirtualFileNode("Notes/today.txt", "today.txt", false, 6L, "etag-1")
+            val interrupted = store.open("Notes/today.txt", node, truncate = false, tree = remote) {}
+
+            val invalidated = mutableListOf<String>()
+            assertEquals(
+                DesktopLinuxWritebackRecoveryResult(recoveredCount = 1, retainedCount = 0),
+                DesktopLinuxVirtualFileWritebackStore(directory, minimumFreeSpaceBytes = { 0L })
+                    .recoverPending(remote, invalidated::add),
+            )
+
+            assertEquals(emptyList(), invalidated)
+            assertEquals(emptyList(), store.pendingWritebacks())
+            assertContentEquals("before".encodeToByteArray(), remote.content)
+            interrupted.close()
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
     private class FakeWritebackRemote(
         var content: ByteArray,
         var etag: String,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStoreTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopLinuxVirtualFileWritebackStoreTest.kt
@@ -138,6 +138,29 @@ class DesktopLinuxVirtualFileWritebackStoreTest {
         }
     }
 
+    @Test
+    fun `clean interrupted recovery still invalidates committed metadata`() {
+        val directory = Files.createTempDirectory("linux-writeback-clean-recovery-").toFile()
+        try {
+            val remote = FakeWritebackRemote("before".encodeToByteArray(), "etag-1")
+            val store = DesktopLinuxVirtualFileWritebackStore(directory, minimumFreeSpaceBytes = { 0L })
+            val node = LinuxVirtualFileNode("Notes/today.txt", "today.txt", false, 6L, "etag-1")
+            val interrupted = store.open("Notes/today.txt", node, truncate = false, tree = remote) {}
+            interrupted.write(0L, "saved!".encodeToByteArray())
+            interrupted.flush()
+
+            val invalidated = mutableListOf<String>()
+            assertEquals(
+                DesktopLinuxWritebackRecoveryResult(recoveredCount = 1, retainedCount = 0),
+                DesktopLinuxVirtualFileWritebackStore(directory, minimumFreeSpaceBytes = { 0L })
+                    .recoverPending(remote, invalidated::add),
+            )
+            assertEquals(listOf("Notes/today.txt"), invalidated)
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
     private class FakeWritebackRemote(
         var content: ByteArray,
         var etag: String,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualRangeCacheTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualRangeCacheTest.kt
@@ -29,10 +29,10 @@ class DesktopVirtualRangeCacheTest {
     fun `exact revision blocks survive cache restart`() {
         val directory = Files.createTempDirectory("virtual-range-cache-").toFile()
         try {
-            val cache = DesktopVirtualRangeCache(directory) { VirtualFileCachePolicy() }
+            val cache = DesktopVirtualRangeCache(directory) { nonEvictingTestPolicy() }
             cache.storeBlock(ACCOUNT_ID, "Photos/example.raf", "etag-1", 8L, 0L, "abcd".encodeToByteArray())
 
-            val restarted = DesktopVirtualRangeCache(directory) { VirtualFileCachePolicy() }
+            val restarted = DesktopVirtualRangeCache(directory) { nonEvictingTestPolicy() }
             assertContentEquals(
                 "abcd".encodeToByteArray(),
                 restarted.readBlock(ACCOUNT_ID, "Photos/example.raf", "etag-1", 8L, 0L, 4),
@@ -71,7 +71,7 @@ class DesktopVirtualRangeCacheTest {
         try {
             val cache = DesktopVirtualRangeCache(
                 root = directory,
-                policy = { VirtualFileCachePolicy() },
+                policy = { nonEvictingTestPolicy() },
                 maximumIndexBytes = 1_024L,
             )
             cache.storeBlock(ACCOUNT_ID, "Photos/kept.raf", "etag-1", 4L, 0L, "kept".encodeToByteArray())
@@ -102,5 +102,11 @@ class DesktopVirtualRangeCacheTest {
 
     private companion object {
         const val ACCOUNT_ID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+        fun nonEvictingTestPolicy() = VirtualFileCachePolicy(
+            automaticCleanup = false,
+            minimumFreeSpaceBytes = 0L,
+            unusedFileAgeMillis = null,
+        )
     }
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -472,7 +472,7 @@ class LinuxVirtualFileSystemTest {
         )
 
         assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
-        assertTrue(waitUntil { attempts.get() == 1 })
+        assertTrue(waitUntil { attempts.get() == 1 && cached.hasRecordedRefreshFailure("Photos") })
         repeat(10_000) {
             assertNotNull(cached.resolve("Photos/cached.dat"))
         }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -5,11 +5,19 @@ import jnr.ffi.Pointer
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import java.nio.ByteBuffer
+import java.nio.file.Files
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.prefs.Preferences
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import ru.serce.jnrfuse.ErrorCodes
 import ru.serce.jnrfuse.struct.FileStat
@@ -348,6 +356,19 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `directory snapshot indexes large child sets by canonical path`() {
+        val nodes = List(50_000) { index ->
+            val name = "item-${index.toString().padStart(5, '0')}.dat"
+            LinuxVirtualFileNode("Photos/$name", name, false, 1L, "etag-$index")
+        }
+        val snapshot = LinuxVirtualDirectorySnapshot(nodes, fetchedAtEpochMillis = 1L)
+
+        assertEquals(nodes.size, snapshot.nodesByPath.size)
+        assertEquals(nodes.first(), snapshot.nodesByPath[nodes.first().path])
+        assertEquals(nodes.last(), snapshot.nodesByPath[nodes.last().path])
+    }
+
+    @Test
     fun `stale persisted listing is returned while one background refresh replaces it`() {
         val delegate = MutableFixtureBackend().apply {
             addFile("Photos/new-a.dat", byteArrayOf(1))
@@ -378,6 +399,149 @@ class LinuxVirtualFileSystemTest {
         assertEquals(listOf("new-a.dat", "new-b.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
         assertEquals(1, delegate.listCallCount("Photos"))
         cached.close()
+    }
+
+    @Test
+    fun `mutation invalidation discards an older in flight directory refresh`() {
+        val delegate = MutableFixtureBackend().apply {
+            addFile("Photos/existing.dat", byteArrayOf(1))
+        }
+        val blocking = BlockingListBackend(delegate, "Photos")
+        val store = MemoryLinuxVirtualMetadataStore().apply {
+            seed(
+                "Photos",
+                LinuxVirtualDirectorySnapshot(
+                    listOf(LinuxVirtualFileNode("Photos/cached.dat", "cached.dat", false, 1L, "cached-etag")),
+                    fetchedAtEpochMillis = 1L,
+                ),
+            )
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = blocking,
+            store = store,
+            nowEpochMillis = { 10_000L },
+            freshForMillis = 1_000L,
+        )
+
+        assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertTrue(blocking.started.await(2L, TimeUnit.SECONDS))
+        cached.createDirectory("Photos/New")
+        blocking.release.countDown()
+
+        assertEquals(
+            setOf("existing.dat", "New"),
+            cached.list("Photos").mapTo(mutableSetOf(), LinuxVirtualFileNode::name),
+        )
+        assertTrue(
+            waitUntil {
+                store.snapshot("Photos")?.nodes?.mapTo(mutableSetOf(), LinuxVirtualFileNode::name) ==
+                    setOf("existing.dat", "New")
+            },
+        )
+        assertEquals(2, delegate.listCallCount("Photos"))
+        cached.close()
+    }
+
+    @Test
+    fun `failed stale refresh backs off during cached directory enumeration`() {
+        val attempts = AtomicInteger(0)
+        val delegate = object : LinuxVirtualFileBackend by MutableFixtureBackend() {
+            override fun list(path: String): List<LinuxVirtualFileNode> {
+                attempts.incrementAndGet()
+                error("Simulated offline listing failure")
+            }
+        }
+        val store = MemoryLinuxVirtualMetadataStore().apply {
+            seed(
+                "Photos",
+                LinuxVirtualDirectorySnapshot(
+                    listOf(LinuxVirtualFileNode("Photos/cached.dat", "cached.dat", false, 1L, "cached-etag")),
+                    fetchedAtEpochMillis = 1L,
+                ),
+            )
+        }
+        val clock = AtomicLong(10_000L)
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            nowEpochMillis = clock::get,
+            freshForMillis = 1_000L,
+            refreshRetryBaseMillis = 1_000L,
+            refreshRetryMaxMillis = 8_000L,
+        )
+
+        assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertTrue(waitUntil { attempts.get() == 1 })
+        repeat(10_000) {
+            assertNotNull(cached.resolve("Photos/cached.dat"))
+        }
+        assertEquals(1, attempts.get())
+
+        clock.addAndGet(1_000L)
+        assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertTrue(waitUntil { attempts.get() == 2 })
+        repeat(1_000) { cached.list("Photos") }
+        assertEquals(2, attempts.get())
+        cached.close()
+    }
+
+    @Test
+    fun `persisted metadata is reused only for the same remote revision`() {
+        val root = Files.createTempDirectory("linux-virtual-metadata-")
+        val preferences = Preferences.userRoot().node(
+            "dev/obiente/nextcloudnative/tests/linux-virtual-metadata/${UUID.randomUUID()}",
+        )
+        try {
+            val cache = DesktopFileReadCache(root.toFile(), preferences = preferences)
+            val accountId = "0".repeat(64)
+            val previous = NextcloudFile(
+                path = "Photos/example.raf",
+                name = "example.raf",
+                isDirectory = false,
+                mimeType = "image/x-raw",
+                size = 5L,
+                lastModified = "2026-08-02T12:00:00Z",
+                fileId = 42L,
+                hasPreview = true,
+                etag = "revision-1",
+                permissions = "RGDNVW",
+                checksums = listOf("SHA256:abc"),
+            )
+            cache.storeListing(accountId, "Photos", listOf(previous), nowEpochMillis = 1L)
+            val store = DesktopLinuxVirtualMetadataStore(cache, accountId)
+
+            store.store(
+                "Photos",
+                LinuxVirtualDirectorySnapshot(
+                    listOf(LinuxVirtualFileNode(previous.path, previous.name, false, 5L, "revision-1")),
+                    fetchedAtEpochMillis = 2L,
+                ),
+            )
+            val unchanged = cache.cachedListing(accountId, "Photos").orEmpty().single()
+            assertEquals("image/x-raw", unchanged.mimeType)
+            assertEquals("RGDNVW", unchanged.permissions)
+            assertEquals(listOf("SHA256:abc"), unchanged.checksums)
+
+            store.store(
+                "Photos",
+                LinuxVirtualDirectorySnapshot(
+                    listOf(LinuxVirtualFileNode(previous.path, previous.name, false, 8L, "revision-2")),
+                    fetchedAtEpochMillis = 3L,
+                ),
+            )
+            val replaced = cache.cachedListing(accountId, "Photos").orEmpty().single()
+            assertEquals("revision-2", replaced.etag)
+            assertEquals(8L, replaced.size)
+            assertNull(replaced.mimeType)
+            assertNull(replaced.lastModified)
+            assertNull(replaced.fileId)
+            assertTrue(!replaced.hasPreview)
+            assertNull(replaced.permissions)
+            assertTrue(replaced.checksums.isEmpty())
+        } finally {
+            runCatching { preferences.removeNode() }
+            root.toFile().deleteRecursively()
+        }
     }
 
     @Test
@@ -609,6 +773,26 @@ class LinuxVirtualFileSystemTest {
 
         fun seed(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
             snapshots[path] = snapshot
+        }
+
+        fun snapshot(path: String): LinuxVirtualDirectorySnapshot? = snapshots[path]
+    }
+
+    private class BlockingListBackend(
+        private val delegate: LinuxVirtualFileBackend,
+        private val blockedPath: String,
+    ) : LinuxVirtualFileBackend by delegate {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        private val blockNext = AtomicBoolean(true)
+
+        override fun list(path: String): List<LinuxVirtualFileNode> {
+            val snapshot = delegate.list(path)
+            if (path.trim('/') == blockedPath && blockNext.compareAndSet(true, false)) {
+                started.countDown()
+                check(release.await(2L, TimeUnit.SECONDS)) { "Timed out waiting to release the directory listing." }
+            }
+            return snapshot
         }
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -482,7 +483,83 @@ class LinuxVirtualFileSystemTest {
         assertTrue(waitUntil { attempts.get() == 2 })
         repeat(1_000) { cached.list("Photos") }
         assertEquals(2, attempts.get())
+
+        clock.set(5_000L)
+        assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertTrue(waitUntil { attempts.get() == 3 })
         cached.close()
+    }
+
+    @Test
+    fun `persisting a large snapshot does not block cached metadata reads`() {
+        val delegate = MutableFixtureBackend().apply { addFile("Photos/cached.dat", byteArrayOf(1)) }
+        val persistenceStarted = CountDownLatch(1)
+        val releasePersistence = CountDownLatch(1)
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+                persistenceStarted.countDown()
+                check(releasePersistence.await(2L, TimeUnit.SECONDS))
+            }
+            override fun invalidate(path: String) = Unit
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            freshForMillis = Long.MAX_VALUE,
+        )
+        val reader = Executors.newSingleThreadExecutor()
+        try {
+            assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+            assertTrue(persistenceStarted.await(2L, TimeUnit.SECONDS))
+            assertNotNull(reader.submit { cached.resolve("Photos/cached.dat") }.get(1L, TimeUnit.SECONDS))
+        } finally {
+            releasePersistence.countDown()
+            reader.shutdownNow()
+            cached.close()
+        }
+    }
+
+    @Test
+    fun `persisted load racing mutation cannot reinstall stale metadata`() {
+        val delegate = MutableFixtureBackend()
+        val stale = LinuxVirtualDirectorySnapshot(
+            listOf(LinuxVirtualFileNode("Old", "Old", true, 0L, "old-etag")),
+            fetchedAtEpochMillis = Long.MAX_VALUE,
+        )
+        val loadStarted = CountDownLatch(1)
+        val releaseLoad = CountDownLatch(1)
+        val invalidationMarked = CountDownLatch(1)
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? {
+                loadStarted.countDown()
+                check(releaseLoad.await(2L, TimeUnit.SECONDS))
+                return stale
+            }
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun invalidate(path: String) = Unit
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            freshForMillis = Long.MAX_VALUE,
+            afterPersistedInvalidationMarked = invalidationMarked::countDown,
+        )
+        val workers = Executors.newFixedThreadPool(2)
+        try {
+            val listing = workers.submit<List<String>> { cached.list("").map(LinuxVirtualFileNode::name) }
+            assertTrue(loadStarted.await(2L, TimeUnit.SECONDS))
+            val mutation = workers.submit { cached.createDirectory("Albums") }
+            assertTrue(invalidationMarked.await(2L, TimeUnit.SECONDS))
+            releaseLoad.countDown()
+
+            assertEquals(setOf("Photos", "Albums"), listing.get(2L, TimeUnit.SECONDS).toSet())
+            mutation.get(2L, TimeUnit.SECONDS)
+        } finally {
+            releaseLoad.countDown()
+            workers.shutdownNow()
+            cached.close()
+        }
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -895,7 +895,7 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
-    fun `persisted metadata is reused only for the same remote revision`() {
+    fun `virtual metadata persistence never degrades the authoritative Files listing`() {
         val root = Files.createTempDirectory("linux-virtual-metadata-")
         val preferences = Preferences.userRoot().node(
             "dev/obiente/nextcloudnative/tests/linux-virtual-metadata/${UUID.randomUUID()}",
@@ -927,9 +927,8 @@ class LinuxVirtualFileSystemTest {
                 ),
             )
             val unchanged = cache.cachedListing(accountId, "Photos").orEmpty().single()
-            assertEquals("image/x-raw", unchanged.mimeType)
-            assertEquals("RGDNVW", unchanged.permissions)
-            assertEquals(listOf("SHA256:abc"), unchanged.checksums)
+            assertEquals(previous, unchanged)
+            assertEquals("revision-1", store.load("Photos")?.nodes?.single()?.remoteRevision)
 
             store.store(
                 "Photos",
@@ -939,14 +938,10 @@ class LinuxVirtualFileSystemTest {
                 ),
             )
             val replaced = cache.cachedListing(accountId, "Photos").orEmpty().single()
-            assertEquals("revision-2", replaced.etag)
-            assertEquals(8L, replaced.size)
-            assertNull(replaced.mimeType)
-            assertNull(replaced.lastModified)
-            assertNull(replaced.fileId)
-            assertTrue(!replaced.hasPreview)
-            assertNull(replaced.permissions)
-            assertTrue(replaced.checksums.isEmpty())
+            assertEquals(previous, replaced)
+            val virtualReplacement = requireNotNull(store.load("Photos")).nodes.single()
+            assertEquals("revision-2", virtualReplacement.remoteRevision)
+            assertEquals(8L, virtualReplacement.size)
 
             val authoritative = previous.copy(name = "authoritative.raf", etag = "revision-3")
             cache.storeListing(accountId, "Photos", listOf(authoritative), nowEpochMillis = 10L)
@@ -958,9 +953,44 @@ class LinuxVirtualFileSystemTest {
                 ),
             )
             assertEquals(authoritative, cache.cachedListing(accountId, "Photos").orEmpty().single())
+            assertEquals("revision-older", store.load("Photos")?.nodes?.single()?.remoteRevision)
         } finally {
             runCatching { preferences.removeNode() }
             root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `concurrent blocking metadata misses stay within a fixed network bound`() {
+        val active = AtomicInteger(0)
+        val maximumActive = AtomicInteger(0)
+        val started = CountDownLatch(2)
+        val release = CountDownLatch(1)
+        val delegate = object : LinuxVirtualFileBackend by MutableFixtureBackend() {
+            override fun list(path: String): List<LinuxVirtualFileNode> {
+                val current = active.incrementAndGet()
+                maximumActive.updateAndGet { previous -> maxOf(previous, current) }
+                started.countDown()
+                try {
+                    check(release.await(2L, TimeUnit.SECONDS))
+                    return emptyList()
+                } finally {
+                    active.decrementAndGet()
+                }
+            }
+        }
+        val cached = CachingLinuxVirtualFileBackend(delegate, MemoryLinuxVirtualMetadataStore())
+        val workers = Executors.newFixedThreadPool(8)
+        try {
+            val reads = List(8) { index -> workers.submit<List<LinuxVirtualFileNode>> { cached.list("Folder-$index") } }
+            assertTrue(started.await(2L, TimeUnit.SECONDS))
+            assertEquals(2, maximumActive.get())
+            release.countDown()
+            reads.forEach { read -> assertTrue(read.get(2L, TimeUnit.SECONDS).isEmpty()) }
+        } finally {
+            release.countDown()
+            workers.shutdownNow()
+            cached.close()
         }
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -9,6 +9,8 @@ import java.nio.file.Files
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -678,6 +680,67 @@ class LinuxVirtualFileSystemTest {
 
         assertEquals(1, invalidations.get())
         cached.close()
+    }
+
+    @Test
+    fun `same size truncate still invalidates the committed remote revision`() {
+        val delegate = MutableFixtureBackend().apply { addFile("Photos/draft.txt", "old".encodeToByteArray()) }
+        val invalidations = AtomicInteger(0)
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun invalidate(path: String) {
+                invalidations.incrementAndGet()
+            }
+        }
+        val cached = CachingLinuxVirtualFileBackend(delegate, store)
+        val existing = requireNotNull(delegate.resolve("Photos/draft.txt"))
+        val handle = cached.openWrite(existing.path, existing, truncate = false)
+
+        handle.truncate(existing.size)
+        handle.flush()
+        handle.close()
+
+        assertEquals(1, invalidations.get())
+        cached.close()
+    }
+
+    @Test
+    fun `queued persistence snapshots remain within the metadata entry budget`() {
+        val delegate = MutableFixtureBackend().apply {
+            addFile("Photos/one.dat", byteArrayOf(1))
+            addFile("Archive/two.dat", byteArrayOf(2))
+        }
+        val executorStarted = CountDownLatch(1)
+        val releaseExecutor = CountDownLatch(1)
+        val executor = ThreadPoolExecutor(
+            1,
+            1,
+            0L,
+            TimeUnit.MILLISECONDS,
+            LinkedBlockingQueue(),
+        ).apply {
+            execute {
+                executorStarted.countDown()
+                releaseExecutor.await()
+            }
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = MemoryLinuxVirtualMetadataStore(),
+            freshForMillis = Long.MAX_VALUE,
+            maximumRetainedMetadataEntries = 1,
+            refreshExecutor = executor,
+        )
+        try {
+            assertTrue(executorStarted.await(2L, TimeUnit.SECONDS))
+            assertEquals(listOf("one.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+            assertEquals(listOf("two.dat"), cached.list("Archive").map(LinuxVirtualFileNode::name))
+            assertEquals(1, executor.queue.size)
+        } finally {
+            releaseExecutor.countDown()
+            cached.close()
+        }
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -290,6 +290,34 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `destructive directory operations ignore a stale cached empty listing`() {
+        val fixture = MutableFixtureBackend().apply {
+            createDirectory("Photos/Trips")
+            addFile("Photos/Trips/new.raf", byteArrayOf(1))
+            createDirectory("Photos/Replacement")
+            addFile("Photos/Replacement/new.raf", byteArrayOf(2))
+            createDirectory("Photos/Source")
+        }
+        val backend = object : LinuxVirtualFileBackend by fixture {
+            override fun list(path: String): List<LinuxVirtualFileNode> =
+                if (path.trim('/') in setOf("Photos/Trips", "Photos/Replacement")) emptyList()
+                else fixture.list(path)
+
+            override fun isDirectoryEmpty(node: LinuxVirtualFileNode): Boolean =
+                fixture.list(node.path).isEmpty()
+        }
+        val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
+
+        assertEquals(-ErrorCodes.ENOTEMPTY(), fileSystem.rmdir("/Photos/Trips"))
+        assertEquals(
+            -ErrorCodes.ENOTEMPTY(),
+            fileSystem.rename("/Photos/Source", "/Photos/Replacement"),
+        )
+        assertNotNull(fixture.resolve("Photos/Trips/new.raf"))
+        assertNotNull(fixture.resolve("Photos/Replacement/new.raf"))
+    }
+
+    @Test
     fun `readdir resumes from the supplied continuation offset`() {
         val backend = MutableFixtureBackend()
         val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
@@ -761,6 +789,43 @@ class LinuxVirtualFileSystemTest {
             assertEquals(2, delegate.listCallCount(""))
         } finally {
             cached.close()
+        }
+    }
+
+    @Test
+    fun `failed persisted invalidation survives a backend remount`() {
+        val delegate = MutableFixtureBackend()
+        val stale = LinuxVirtualDirectorySnapshot(
+            nodes = listOf(LinuxVirtualFileNode("Photos", "Photos", true, 0L, "stale-photos")),
+            fetchedAtEpochMillis = 100L,
+        )
+        var failedInvalidations = emptySet<String>()
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = stale.takeIf { path.isEmpty() }
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean = false
+            override fun invalidate(path: String): Unit = error("Simulated persisted invalidation failure")
+            override fun retainedPaths(): Set<String> = setOf("")
+            override fun failedInvalidations(): Set<String> = failedInvalidations
+            override fun replaceFailedInvalidations(paths: Set<String>) {
+                failedInvalidations = paths.toSet()
+            }
+        }
+        val first = CachingLinuxVirtualFileBackend(delegate, store, freshForMillis = Long.MAX_VALUE)
+        assertEquals(listOf("Photos"), first.list("").map(LinuxVirtualFileNode::name))
+        delegate.createDirectory("Albums")
+        first.invalidateAfterExternalMutation("Albums")
+        assertEquals(setOf("Albums"), failedInvalidations)
+        first.close()
+
+        val remounted = CachingLinuxVirtualFileBackend(delegate, store, freshForMillis = Long.MAX_VALUE)
+        try {
+            assertEquals(
+                setOf("Photos", "Albums"),
+                remounted.list("").mapTo(mutableSetOf(), LinuxVirtualFileNode::name),
+            )
+            assertEquals(1, delegate.listCallCount(""))
+        } finally {
+            remounted.close()
         }
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -19,6 +19,7 @@ import java.util.prefs.Preferences
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -563,6 +564,44 @@ class LinuxVirtualFileSystemTest {
         clock.set(5_000L)
         assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
         assertTrue(waitUntil { attempts.get() == 3 })
+        cached.close()
+    }
+
+    @Test
+    fun `refresh failure backoff records stay within the directory budget`() {
+        val delegate = object : LinuxVirtualFileBackend by MutableFixtureBackend() {
+            override fun list(path: String): List<LinuxVirtualFileNode> =
+                error("Simulated offline listing failure for $path")
+        }
+        val staleNode = { path: String ->
+            LinuxVirtualDirectorySnapshot(
+                listOf(LinuxVirtualFileNode("$path/cached.dat", "cached.dat", false, 1L, "cached-etag")),
+                fetchedAtEpochMillis = 1L,
+            )
+        }
+        val store = MemoryLinuxVirtualMetadataStore().apply {
+            seed("First", staleNode("First"))
+            seed("Second", staleNode("Second"))
+            seed("Third", staleNode("Third"))
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            nowEpochMillis = { 10_000L },
+            freshForMillis = 1_000L,
+            maximumRetainedDirectories = 2,
+        )
+
+        cached.list("First")
+        assertTrue(waitUntil { cached.hasRecordedRefreshFailure("First") })
+        cached.list("Second")
+        assertTrue(waitUntil { cached.hasRecordedRefreshFailure("Second") })
+        cached.list("Third")
+        assertTrue(waitUntil { cached.hasRecordedRefreshFailure("Third") })
+
+        assertFalse(cached.hasRecordedRefreshFailure("First"))
+        assertTrue(cached.hasRecordedRefreshFailure("Second"))
+        assertTrue(cached.hasRecordedRefreshFailure("Third"))
         cached.close()
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -857,6 +857,43 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `failed quarantine persistence removes stale cache before mutation completion`() {
+        val delegate = MutableFixtureBackend()
+        val stale = LinuxVirtualDirectorySnapshot(
+            nodes = listOf(LinuxVirtualFileNode("Photos", "Photos", true, 0L, "stale-photos")),
+            fetchedAtEpochMillis = Long.MAX_VALUE,
+        )
+        val persistedInvalidated = AtomicBoolean(false)
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = stale.takeIf { path.isEmpty() }
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = true
+            override fun invalidate(path: String) {
+                persistedInvalidated.set(true)
+            }
+            override fun replaceFailedInvalidations(paths: Set<String>): Unit =
+                error("Simulated unavailable preferences store")
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            freshForMillis = Long.MAX_VALUE,
+            afterPersistedInvalidationMarked = { assertTrue(persistedInvalidated.get()) },
+        )
+        try {
+            assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
+            cached.createDirectory("Albums")
+
+            assertTrue(persistedInvalidated.get())
+            assertEquals(
+                setOf("Photos", "Albums"),
+                cached.list("").mapTo(mutableSetOf(), LinuxVirtualFileNode::name),
+            )
+        } finally {
+            cached.close()
+        }
+    }
+
+    @Test
     fun `failed stale refresh backs off during cached directory enumeration`() {
         val attempts = AtomicInteger(0)
         val delegate = object : LinuxVirtualFileBackend by MutableFixtureBackend() {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -378,6 +378,30 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `slow directory materialization does not block an unrelated open`() {
+        val fixture = MutableFixtureBackend().apply { createDirectory("Slow") }
+        val backend = BlockingListBackend(fixture, "Slow")
+        val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
+        val runtime = Runtime.getSystemRuntime()
+        val slow = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val fast = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val workers = Executors.newFixedThreadPool(2)
+        try {
+            val slowOpen = workers.submit<Int> { fileSystem.opendir("/Slow", slow) }
+            assertTrue(backend.started.await(2L, TimeUnit.SECONDS))
+
+            assertEquals(0, workers.submit<Int> { fileSystem.opendir("/Photos", fast) }.get(1L, TimeUnit.SECONDS))
+            assertEquals(0, fileSystem.releasedir("/Photos", fast))
+            backend.release.countDown()
+            assertEquals(0, slowOpen.get(2L, TimeUnit.SECONDS))
+            assertEquals(0, fileSystem.releasedir("/Slow", slow))
+        } finally {
+            backend.release.countDown()
+            workers.shutdownNow()
+        }
+    }
+
+    @Test
     fun `listing persistence keeps causal order from before the network request`() {
         val root = Files.createTempDirectory("linux-virtual-causal-listing-")
         val preferences = Preferences.userRoot().node(
@@ -400,9 +424,10 @@ class LinuxVirtualFileSystemTest {
             }
             val persisted = DesktopLinuxVirtualMetadataStore(cache, accountId)
             val store = object : LinuxVirtualMetadataStore by persisted {
-                override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
-                    persisted.store(path, snapshot)
+                override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean {
+                    val stored = persisted.store(path, snapshot)
                     persistenceAttempted.countDown()
+                    return stored
                 }
             }
             val clock = AtomicLong(100L)
@@ -430,6 +455,48 @@ class LinuxVirtualFileSystemTest {
         } finally {
             runCatching { preferences.removeNode() }
             root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `a skipped persisted refresh keeps its invalidation tombstone`() {
+        val delegate = MutableFixtureBackend()
+        val stale = LinuxVirtualDirectorySnapshot(
+            nodes = listOf(LinuxVirtualFileNode("Photos", "Photos", true, 0L, "stale-photos")),
+            fetchedAtEpochMillis = 100L,
+        )
+        val persistenceAttempted = CountDownLatch(1)
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = stale.takeIf { path.isEmpty() }
+
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean {
+                if (path.isEmpty()) persistenceAttempted.countDown()
+                return false
+            }
+
+            override fun invalidate(path: String): Unit = error("Simulated persisted invalidation failure")
+            override fun retainedPaths(): Set<String> = setOf("")
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            nowEpochMillis = { 100L },
+            freshForMillis = Long.MAX_VALUE,
+            maximumRetainedDirectories = 1,
+        )
+        try {
+            assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
+            cached.createDirectory("Albums")
+            assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(mutableSetOf(), LinuxVirtualFileNode::name))
+            assertTrue(persistenceAttempted.await(2L, TimeUnit.SECONDS))
+            assertEquals(0, cached.revalidatedPersistedListingCount())
+            assertEquals(1, cached.failedPersistedInvalidationCount())
+
+            cached.list("Photos")
+            assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(mutableSetOf(), LinuxVirtualFileNode::name))
+            assertEquals(2, delegate.listCallCount(""))
+        } finally {
+            cached.close()
         }
     }
 
@@ -612,9 +679,10 @@ class LinuxVirtualFileSystemTest {
         val releasePersistence = CountDownLatch(1)
         val store = object : LinuxVirtualMetadataStore {
             override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
-            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean {
                 persistenceStarted.countDown()
                 check(releasePersistence.await(2L, TimeUnit.SECONDS))
+                return true
             }
             override fun invalidate(path: String) = Unit
         }
@@ -656,7 +724,7 @@ class LinuxVirtualFileSystemTest {
                 check(releaseLoad.await(2L, TimeUnit.SECONDS))
                 return stale
             }
-            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = true
             override fun invalidate(path: String) = Unit
         }
         val cached = CachingLinuxVirtualFileBackend(
@@ -726,7 +794,7 @@ class LinuxVirtualFileSystemTest {
         }
         val store = object : LinuxVirtualMetadataStore {
             override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
-            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = true
             override fun invalidate(path: String) = Unit
         }
         val cached = CachingLinuxVirtualFileBackend(
@@ -755,7 +823,7 @@ class LinuxVirtualFileSystemTest {
             override fun load(path: String): LinuxVirtualDirectorySnapshot? =
                 stale.takeIf { path.isEmpty() }.also { loads.incrementAndGet() }
 
-            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = true
             override fun invalidate(path: String): Unit = error("Simulated cache publication failure")
         }
         val cached = CachingLinuxVirtualFileBackend(
@@ -777,7 +845,7 @@ class LinuxVirtualFileSystemTest {
         val invalidations = AtomicInteger(0)
         val store = object : LinuxVirtualMetadataStore {
             override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
-            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = true
             override fun invalidate(path: String) {
                 invalidations.incrementAndGet()
             }
@@ -801,7 +869,7 @@ class LinuxVirtualFileSystemTest {
         val invalidations = AtomicInteger(0)
         val store = object : LinuxVirtualMetadataStore {
             override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
-            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = true
             override fun invalidate(path: String) {
                 invalidations.incrementAndGet()
             }
@@ -1026,6 +1094,49 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `directory release and rename cannot leak a readdressed handle`() {
+        val fixture = MutableFixtureBackend()
+        val moveCommitted = CountDownLatch(1)
+        val backend = object : LinuxVirtualFileBackend by fixture {
+            override fun move(node: LinuxVirtualFileNode, destinationPath: String) {
+                fixture.move(node, destinationPath)
+                moveCommitted.countDown()
+            }
+        }
+        val releaseLoaded = CountDownLatch(1)
+        val allowRemoval = CountDownLatch(1)
+        val fileSystem = LinuxNextcloudVirtualFileSystem(
+            backend = backend,
+            maximumOpenDirectoryEntries = 2,
+            beforeDirectoryHandleRemoval = {
+                releaseLoaded.countDown()
+                check(allowRemoval.await(2L, TimeUnit.SECONDS))
+            },
+        )
+        val runtime = Runtime.getSystemRuntime()
+        val opened = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val reopened = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val workers = Executors.newFixedThreadPool(2)
+        try {
+            assertEquals(0, fileSystem.opendir("/Photos", opened))
+            val release = workers.submit<Int> { fileSystem.releasedir("/Photos", opened) }
+            assertTrue(releaseLoaded.await(2L, TimeUnit.SECONDS))
+            val rename = workers.submit<Int> { fileSystem.rename("/Photos", "/Albums") }
+            assertTrue(moveCommitted.await(2L, TimeUnit.SECONDS))
+            assertFalse(rename.isDone)
+
+            allowRemoval.countDown()
+            assertEquals(0, release.get(2L, TimeUnit.SECONDS))
+            assertEquals(0, rename.get(2L, TimeUnit.SECONDS))
+            assertEquals(0, fileSystem.opendir("/Albums", reopened))
+            assertEquals(0, fileSystem.releasedir("/Albums", reopened))
+        } finally {
+            allowRemoval.countDown()
+            workers.shutdownNow()
+        }
+    }
+
+    @Test
     fun `release reports a close time writeback failure`() {
         val backend = MutableFixtureBackend(failClose = true)
         val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
@@ -1235,8 +1346,9 @@ class LinuxVirtualFileSystemTest {
         override fun load(path: String): LinuxVirtualDirectorySnapshot? = snapshots[path]
 
         @Synchronized
-        override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+        override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean {
             snapshots[path] = snapshot
+            return true
         }
 
         @Synchronized

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -568,6 +568,41 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `mutation does not discard an unrelated directory refresh`() {
+        val fixture = MutableFixtureBackend().apply { addFile("Archive/kept.dat", byteArrayOf(1)) }
+        val listingStarted = CountDownLatch(1)
+        val releaseListing = CountDownLatch(1)
+        val archiveCalls = AtomicInteger(0)
+        val delegate = object : LinuxVirtualFileBackend by fixture {
+            override fun list(path: String): List<LinuxVirtualFileNode> {
+                if (path == "Archive") {
+                    archiveCalls.incrementAndGet()
+                    listingStarted.countDown()
+                    check(releaseListing.await(2L, TimeUnit.SECONDS))
+                }
+                return fixture.list(path)
+            }
+        }
+        val cached = CachingLinuxVirtualFileBackend(delegate, MemoryLinuxVirtualMetadataStore())
+        val workers = Executors.newFixedThreadPool(2)
+        try {
+            val archive = workers.submit<List<String>> {
+                cached.list("Archive").map(LinuxVirtualFileNode::name)
+            }
+            assertTrue(listingStarted.await(2L, TimeUnit.SECONDS))
+            cached.createDirectory("Photos/New")
+            releaseListing.countDown()
+
+            assertEquals(listOf("kept.dat"), archive.get(2L, TimeUnit.SECONDS))
+            assertEquals(1, archiveCalls.get())
+        } finally {
+            releaseListing.countDown()
+            workers.shutdownNow()
+            cached.close()
+        }
+    }
+
+    @Test
     fun `metadata snapshots evict least recently used directories within the global budget`() {
         val delegate = MutableFixtureBackend().apply {
             addFile("Photos/one.dat", byteArrayOf(1))

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -865,7 +865,9 @@ class LinuxVirtualFileSystemTest {
         )
         val persistedInvalidated = AtomicBoolean(false)
         val store = object : LinuxVirtualMetadataStore {
-            override fun load(path: String): LinuxVirtualDirectorySnapshot? = stale.takeIf { path.isEmpty() }
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = stale.takeIf {
+                path.isEmpty() && !persistedInvalidated.get()
+            }
             override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = true
             override fun invalidate(path: String) {
                 persistedInvalidated.set(true)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -656,6 +656,89 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `external mutation invalidation discards an older in flight directory refresh`() {
+        val delegate = MutableFixtureBackend().apply {
+            addFile("Photos/existing.dat", byteArrayOf(1))
+        }
+        val blocking = BlockingListBackend(delegate, "Photos")
+        val store = MemoryLinuxVirtualMetadataStore().apply {
+            seed(
+                "Photos",
+                LinuxVirtualDirectorySnapshot(
+                    listOf(LinuxVirtualFileNode("Photos/cached.dat", "cached.dat", false, 1L, "cached-etag")),
+                    fetchedAtEpochMillis = 1L,
+                ),
+            )
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = blocking,
+            store = store,
+            nowEpochMillis = { 10_000L },
+            freshForMillis = 1_000L,
+        )
+
+        assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertTrue(blocking.started.await(2L, TimeUnit.SECONDS))
+        delegate.createDirectory("Photos/New")
+        cached.invalidateAfterExternalMutation("Photos/New")
+        blocking.release.countDown()
+
+        assertEquals(
+            setOf("existing.dat", "New"),
+            cached.list("Photos").mapTo(mutableSetOf(), LinuxVirtualFileNode::name),
+        )
+        assertTrue(
+            waitUntil {
+                store.snapshot("Photos")?.nodes?.mapTo(mutableSetOf(), LinuxVirtualFileNode::name) ==
+                    setOf("existing.dat", "New")
+            },
+        )
+        assertEquals(2, delegate.listCallCount("Photos"))
+        cached.close()
+    }
+
+    @Test
+    fun `external recovery invalidation keeps a failed persisted tombstone`() {
+        val delegate = MutableFixtureBackend()
+        val stale = LinuxVirtualDirectorySnapshot(
+            nodes = listOf(LinuxVirtualFileNode("Photos", "Photos", true, 0L, "stale-photos")),
+            fetchedAtEpochMillis = 100L,
+        )
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = stale.takeIf { path.isEmpty() }
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean = false
+            override fun invalidate(path: String): Unit = error("Simulated persisted invalidation failure")
+            override fun retainedPaths(): Set<String> = setOf("")
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            nowEpochMillis = { 100L },
+            freshForMillis = Long.MAX_VALUE,
+            maximumRetainedDirectories = 1,
+        )
+        try {
+            assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
+            delegate.createDirectory("Albums")
+            cached.invalidateAfterExternalMutation("Albums")
+
+            assertEquals(
+                setOf("Photos", "Albums"),
+                cached.list("").mapTo(mutableSetOf(), LinuxVirtualFileNode::name),
+            )
+            assertEquals(1, cached.failedPersistedInvalidationCount())
+            cached.list("Albums")
+            assertEquals(
+                setOf("Photos", "Albums"),
+                cached.list("").mapTo(mutableSetOf(), LinuxVirtualFileNode::name),
+            )
+            assertEquals(2, delegate.listCallCount(""))
+        } finally {
+            cached.close()
+        }
+    }
+
+    @Test
     fun `failed stale refresh backs off during cached directory enumeration`() {
         val attempts = AtomicInteger(0)
         val delegate = object : LinuxVirtualFileBackend by MutableFixtureBackend() {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertFails
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -54,6 +55,31 @@ class LinuxVirtualFileSystemTest {
         assertContentEquals(bytes.copyOfRange(10, 17), read)
         assertEquals(0, fileSystem.release("/Photos/example.raf", fileInfo))
         assertEquals(1, closed)
+    }
+
+    @Test
+    fun `failed detach closes open handles and retains the backend for retry`() {
+        var handleClosed = 0
+        var backendClosed = 0
+        val fixture = fixtureBackend("content".encodeToByteArray()) { { handleClosed += 1 } }
+        val backend = object : LinuxVirtualFileBackend by fixture {
+            override fun close() {
+                backendClosed += 1
+            }
+        }
+        val fileSystem = LinuxNextcloudVirtualFileSystem(
+            backend = backend,
+            unmountOperation = { error("Simulated detach failure") },
+        )
+        val fileInfo = FuseFileInfo.of(Runtime.getSystemRuntime().memoryManager.allocateDirect(256))
+        assertEquals(0, fileSystem.open("/Photos/example.raf", fileInfo))
+
+        assertFails { fileSystem.unmount() }
+
+        assertEquals(1, handleClosed)
+        assertEquals(0, backendClosed)
+        val output = Runtime.getSystemRuntime().memoryManager.allocateDirect(1)
+        assertEquals(-ErrorCodes.EBADF(), fileSystem.read("/Photos/example.raf", output, 1L, 0L, fileInfo))
     }
 
     @Test
@@ -855,6 +881,40 @@ class LinuxVirtualFileSystemTest {
         } finally {
             releasePersistence.countDown()
             reader.shutdownNow()
+            cached.close()
+        }
+    }
+
+    @Test
+    fun `closing waits for an in-flight metadata publication`() {
+        val delegate = MutableFixtureBackend().apply { addFile("Photos/cached.dat", byteArrayOf(1)) }
+        val persistenceStarted = CountDownLatch(1)
+        val releasePersistence = CountDownLatch(1)
+        val closeFinished = CountDownLatch(1)
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot): Boolean {
+                persistenceStarted.countDown()
+                check(releasePersistence.await(2L, TimeUnit.SECONDS))
+                return true
+            }
+            override fun invalidate(path: String) = Unit
+        }
+        val cached = CachingLinuxVirtualFileBackend(delegate, store, freshForMillis = Long.MAX_VALUE)
+        val closer = Executors.newSingleThreadExecutor()
+        try {
+            cached.list("Photos")
+            assertTrue(persistenceStarted.await(2L, TimeUnit.SECONDS))
+            closer.execute {
+                cached.close()
+                closeFinished.countDown()
+            }
+            assertFalse(closeFinished.await(100L, TimeUnit.MILLISECONDS))
+            releasePersistence.countDown()
+            assertTrue(closeFinished.await(2L, TimeUnit.SECONDS))
+        } finally {
+            releasePersistence.countDown()
+            closer.shutdownNow()
             cached.close()
         }
     }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -402,6 +402,74 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `directory materialization follows a concurrent rename before registration`() {
+        val fixture = MutableFixtureBackend()
+        val backend = BlockingListBackend(fixture, "Photos")
+        val fileSystem = LinuxNextcloudVirtualFileSystem(backend, maximumOpenDirectoryEntries = 2)
+        val runtime = Runtime.getSystemRuntime()
+        val opened = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val reopened = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val worker = Executors.newSingleThreadExecutor()
+        try {
+            val opening = worker.submit<Int> { fileSystem.opendir("/Photos", opened) }
+            assertTrue(backend.started.await(2L, TimeUnit.SECONDS))
+            assertEquals(0, fileSystem.rename("/Photos", "/Albums"))
+            backend.release.countDown()
+
+            assertEquals(0, opening.get(2L, TimeUnit.SECONDS))
+            assertEquals(0, fileSystem.releasedir("/Albums", opened))
+            assertEquals(0, fileSystem.opendir("/Albums", reopened))
+            assertEquals(0, fileSystem.releasedir("/Albums", reopened))
+        } finally {
+            backend.release.countDown()
+            worker.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `open read handle is readdressed before rename cache maintenance`() {
+        val fixture = MutableFixtureBackend().apply {
+            addFile("Photos/open.txt", "read during rename".encodeToByteArray())
+        }
+        val maintenanceStarted = CountDownLatch(1)
+        val releaseMaintenance = CountDownLatch(1)
+        val backend = object : LinuxVirtualFileBackend by fixture {
+            override fun move(
+                node: LinuxVirtualFileNode,
+                destinationPath: String,
+                afterRemoteCommit: () -> Unit,
+            ) {
+                fixture.move(node, destinationPath)
+                afterRemoteCommit()
+                maintenanceStarted.countDown()
+                check(releaseMaintenance.await(2L, TimeUnit.SECONDS))
+            }
+        }
+        val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
+        val runtime = Runtime.getSystemRuntime()
+        val fileInfo = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val output = runtime.memoryManager.allocateDirect(4)
+        val worker = Executors.newSingleThreadExecutor()
+        try {
+            assertEquals(0, fileSystem.open("/Photos/open.txt", fileInfo))
+            val rename = worker.submit<Int> { fileSystem.rename("/Photos/open.txt", "/Photos/renamed.txt") }
+            assertTrue(maintenanceStarted.await(2L, TimeUnit.SECONDS))
+
+            assertEquals(4, fileSystem.read("/Photos/renamed.txt", output, 4L, 0L, fileInfo))
+            assertContentEquals(
+                "read".encodeToByteArray(),
+                ByteArray(4).also { bytes -> output.get(0L, bytes, 0, bytes.size) },
+            )
+            releaseMaintenance.countDown()
+            assertEquals(0, rename.get(2L, TimeUnit.SECONDS))
+            assertEquals(0, fileSystem.release("/Photos/renamed.txt", fileInfo))
+        } finally {
+            releaseMaintenance.countDown()
+            worker.shutdownNow()
+        }
+    }
+
+    @Test
     fun `listing persistence keeps causal order from before the network request`() {
         val root = Files.createTempDirectory("linux-virtual-causal-listing-")
         val preferences = Preferences.userRoot().node(
@@ -1098,9 +1166,14 @@ class LinuxVirtualFileSystemTest {
         val fixture = MutableFixtureBackend()
         val moveCommitted = CountDownLatch(1)
         val backend = object : LinuxVirtualFileBackend by fixture {
-            override fun move(node: LinuxVirtualFileNode, destinationPath: String) {
+            override fun move(
+                node: LinuxVirtualFileNode,
+                destinationPath: String,
+                afterRemoteCommit: () -> Unit,
+            ) {
                 fixture.move(node, destinationPath)
                 moveCommitted.countDown()
+                afterRemoteCommit()
             }
         }
         val releaseLoaded = CountDownLatch(1)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -857,7 +857,7 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
-    fun `authoritative persistence re-enables a listing after failed invalidation`() {
+    fun `authoritative persistence clears a covered failed invalidation`() {
         val fixture = MutableFixtureBackend()
         val failRootListing = AtomicBoolean(false)
         val delegate = object : LinuxVirtualFileBackend by fixture {
@@ -880,9 +880,14 @@ class LinuxVirtualFileSystemTest {
         assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
         assertTrue(waitUntil { persisted.snapshot("")?.nodes?.singleOrNull()?.name == "Photos" })
         cached.createDirectory("Albums")
+        assertEquals(1, cached.failedPersistedInvalidationCount())
         assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(hashSetOf(), LinuxVirtualFileNode::name))
         assertTrue(waitUntil { persisted.snapshot("")?.nodes?.any { it.name == "Albums" } == true })
+        assertTrue(waitUntil { cached.failedPersistedInvalidationCount() == 0 })
+        assertEquals(0, cached.revalidatedPersistedListingCount())
         cached.list("Photos")
+        assertTrue(waitUntil { persisted.snapshot("Photos") != null })
+        assertEquals(0, cached.revalidatedPersistedListingCount())
         failRootListing.set(true)
 
         assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(hashSetOf(), LinuxVirtualFileNode::name))
@@ -1196,12 +1201,15 @@ class LinuxVirtualFileSystemTest {
     private class MemoryLinuxVirtualMetadataStore : LinuxVirtualMetadataStore {
         private val snapshots = mutableMapOf<String, LinuxVirtualDirectorySnapshot>()
 
+        @Synchronized
         override fun load(path: String): LinuxVirtualDirectorySnapshot? = snapshots[path]
 
+        @Synchronized
         override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
             snapshots[path] = snapshot
         }
 
+        @Synchronized
         override fun invalidate(path: String) {
             val normalized = path.trim('/')
             val parent = normalized.substringBeforeLast('/', "")
@@ -1213,10 +1221,15 @@ class LinuxVirtualFileSystemTest {
             }
         }
 
+        @Synchronized
+        override fun retainedPaths(): Set<String> = snapshots.keys.toSet()
+
+        @Synchronized
         fun seed(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
             snapshots[path] = snapshot
         }
 
+        @Synchronized
         fun snapshot(path: String): LinuxVirtualDirectorySnapshot? = snapshots[path]
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -681,6 +681,38 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `authoritative persistence re-enables a listing after failed invalidation`() {
+        val fixture = MutableFixtureBackend()
+        val failRootListing = AtomicBoolean(false)
+        val delegate = object : LinuxVirtualFileBackend by fixture {
+            override fun list(path: String): List<LinuxVirtualFileNode> {
+                if (path.isEmpty() && failRootListing.get()) error("Simulated offline root listing")
+                return fixture.list(path)
+            }
+        }
+        val persisted = MemoryLinuxVirtualMetadataStore()
+        val store = object : LinuxVirtualMetadataStore by persisted {
+            override fun invalidate(path: String): Unit = error("Simulated cache invalidation failure")
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            freshForMillis = Long.MAX_VALUE,
+            maximumRetainedDirectories = 1,
+        )
+
+        assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
+        cached.createDirectory("Albums")
+        assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(hashSetOf(), LinuxVirtualFileNode::name))
+        assertTrue(waitUntil { persisted.snapshot("")?.nodes?.any { it.name == "Albums" } == true })
+        cached.list("Photos")
+        failRootListing.set(true)
+
+        assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(hashSetOf(), LinuxVirtualFileNode::name))
+        cached.close()
+    }
+
+    @Test
     fun `persisted metadata is reused only for the same remote revision`() {
         val root = Files.createTempDirectory("linux-virtual-metadata-")
         val preferences = Preferences.userRoot().node(

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -486,6 +486,52 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `metadata snapshots evict least recently used directories within the global budget`() {
+        val delegate = MutableFixtureBackend().apply {
+            addFile("Photos/one.dat", byteArrayOf(1))
+            createDirectory("Albums")
+            addFile("Albums/two.dat", byteArrayOf(2))
+        }
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun invalidate(path: String) = Unit
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            freshForMillis = Long.MAX_VALUE,
+            maximumRetainedMetadataEntries = 1,
+        )
+
+        assertEquals(listOf("one.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertEquals(listOf("two.dat"), cached.list("Albums").map(LinuxVirtualFileNode::name))
+        assertEquals(listOf("one.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertEquals(2, delegate.listCallCount("Photos"))
+        cached.close()
+    }
+
+    @Test
+    fun `completed mutation ignores disposable persisted invalidation failure`() {
+        val delegate = MutableFixtureBackend()
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun invalidate(path: String): Unit = error("Simulated cache publication failure")
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            freshForMillis = Long.MAX_VALUE,
+        )
+
+        assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
+        cached.createDirectory("Albums")
+        assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(hashSetOf(), LinuxVirtualFileNode::name))
+        cached.close()
+    }
+
+    @Test
     fun `persisted metadata is reused only for the same remote revision`() {
         val root = Files.createTempDirectory("linux-virtual-metadata-")
         val preferences = Preferences.userRoot().node(
@@ -538,6 +584,17 @@ class LinuxVirtualFileSystemTest {
             assertTrue(!replaced.hasPreview)
             assertNull(replaced.permissions)
             assertTrue(replaced.checksums.isEmpty())
+
+            val authoritative = previous.copy(name = "authoritative.raf", etag = "revision-3")
+            cache.storeListing(accountId, "Photos", listOf(authoritative), nowEpochMillis = 10L)
+            store.store(
+                "Photos",
+                LinuxVirtualDirectorySnapshot(
+                    listOf(LinuxVirtualFileNode(previous.path, previous.name, false, 9L, "revision-older")),
+                    fetchedAtEpochMillis = 4L,
+                ),
+            )
+            assertEquals(authoritative, cache.cachedListing(accountId, "Photos").orEmpty().single())
         } finally {
             runCatching { preferences.removeNode() }
             root.toFile().deleteRecursively()
@@ -558,6 +615,21 @@ class LinuxVirtualFileSystemTest {
         assertEquals(listOf("Photos", "Albums"), cached.list("").map(LinuxVirtualFileNode::name))
         assertEquals(2, delegate.listCallCount(""))
         cached.close()
+    }
+
+    @Test
+    fun `renaming an open directory readdresses its retained handle`() {
+        val backend = MutableFixtureBackend()
+        val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
+        val runtime = Runtime.getSystemRuntime()
+        val buffer = runtime.memoryManager.allocateDirect(8)
+        val fileInfo = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val filler = ru.serce.jnrfuse.FuseFillDir { _, _, _, _ -> 0 }
+
+        assertEquals(0, fileSystem.opendir("/Photos", fileInfo))
+        assertEquals(0, fileSystem.rename("/Photos", "/Albums"))
+        assertEquals(0, fileSystem.readdir("/Albums", buffer, filler, 0L, fileInfo))
+        assertEquals(0, fileSystem.releasedir("/Albums", fileInfo))
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -631,8 +631,15 @@ class LinuxVirtualFileSystemTest {
     @Test
     fun `completed mutation ignores disposable persisted invalidation failure`() {
         val delegate = MutableFixtureBackend()
+        val stale = LinuxVirtualDirectorySnapshot(
+            nodes = listOf(LinuxVirtualFileNode("Photos", "Photos", true, 0L, "stale-photos")),
+            fetchedAtEpochMillis = Long.MAX_VALUE,
+        )
+        val loads = AtomicInteger(0)
         val store = object : LinuxVirtualMetadataStore {
-            override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? =
+                stale.takeIf { path.isEmpty() }.also { loads.incrementAndGet() }
+
             override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
             override fun invalidate(path: String): Unit = error("Simulated cache publication failure")
         }
@@ -645,6 +652,31 @@ class LinuxVirtualFileSystemTest {
         assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
         cached.createDirectory("Albums")
         assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(hashSetOf(), LinuxVirtualFileNode::name))
+        assertEquals(1, loads.get())
+        cached.close()
+    }
+
+    @Test
+    fun `write invalidates metadata only once after a committed change`() {
+        val delegate = MutableFixtureBackend().apply { addFile("Photos/draft.txt", "old".encodeToByteArray()) }
+        val invalidations = AtomicInteger(0)
+        val store = object : LinuxVirtualMetadataStore {
+            override fun load(path: String): LinuxVirtualDirectorySnapshot? = null
+            override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) = Unit
+            override fun invalidate(path: String) {
+                invalidations.incrementAndGet()
+            }
+        }
+        val cached = CachingLinuxVirtualFileBackend(delegate, store)
+        val existing = requireNotNull(delegate.resolve("Photos/draft.txt"))
+        val handle = cached.openWrite(existing.path, existing, truncate = false)
+
+        handle.write(0L, "new".encodeToByteArray())
+        handle.flush()
+        handle.flush()
+        handle.close()
+
+        assertEquals(1, invalidations.get())
         cached.close()
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -5,9 +5,11 @@ import jnr.ffi.Pointer
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import java.nio.ByteBuffer
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import ru.serce.jnrfuse.ErrorCodes
 import ru.serce.jnrfuse.struct.FileStat
@@ -280,6 +282,121 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `large readdir keeps one stable snapshot across all continuation buffers`() {
+        val backend = MutableFixtureBackend()
+        repeat(12_000) { index ->
+            backend.addFile("Photos/item-${index.toString().padStart(5, '0')}.dat", byteArrayOf(1))
+        }
+        val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
+        val runtime = Runtime.getSystemRuntime()
+        val buffer = runtime.memoryManager.allocateDirect(8)
+        val fileInfo = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val names = mutableListOf<String>()
+        var offset = 0L
+
+        while (names.size < 12_002) {
+            val page = mutableListOf<Pair<String, Long>>()
+            val filler = ru.serce.jnrfuse.FuseFillDir { _: Pointer, name: ByteBuffer, stat, nextOffset: Long ->
+                if (page.size == 257) return@FuseFillDir 1
+                page += name.fuseName() to nextOffset
+                if (page.last().first !in setOf(".", "..")) assertNotNull(stat)
+                0
+            }
+            assertEquals(0, fileSystem.readdir("/Photos", buffer, filler, offset, fileInfo))
+            assertTrue(page.isNotEmpty())
+            names += page.map { it.first }
+            offset = page.last().second
+        }
+
+        assertEquals(12_002, names.distinct().size)
+        assertEquals(1, backend.listCallCount("Photos"))
+        assertEquals(0, fileSystem.releasedir("/Photos", fileInfo))
+    }
+
+    @Test
+    fun `cached parent snapshot prevents one remote listing per child getattr`() {
+        val delegate = MutableFixtureBackend()
+        repeat(10_000) { index ->
+            delegate.addFile("Photos/item-${index.toString().padStart(5, '0')}.dat", byteArrayOf(1))
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = MemoryLinuxVirtualMetadataStore(),
+            freshForMillis = Long.MAX_VALUE,
+        )
+        val fileSystem = LinuxNextcloudVirtualFileSystem(cached)
+        val runtime = Runtime.getSystemRuntime()
+        val buffer = runtime.memoryManager.allocateDirect(8)
+        val fileInfo = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val names = mutableListOf<String>()
+        val filler = ru.serce.jnrfuse.FuseFillDir { _: Pointer, name: ByteBuffer, _, _ ->
+            name.fuseName().takeUnless { it == "." || it == ".." }?.let(names::add)
+            0
+        }
+
+        assertEquals(0, fileSystem.opendir("/Photos", fileInfo))
+        assertEquals(0, fileSystem.readdir("/Photos", buffer, filler, 0L, fileInfo))
+        assertEquals(10_000, names.size)
+        names.forEach { name ->
+            assertEquals(0, fileSystem.getattr("/Photos/$name", FileStat(runtime)))
+        }
+
+        assertEquals(1, delegate.listCallCount(""))
+        assertEquals(1, delegate.listCallCount("Photos"))
+        assertEquals(0, fileSystem.releasedir("/Photos", fileInfo))
+        cached.close()
+    }
+
+    @Test
+    fun `stale persisted listing is returned while one background refresh replaces it`() {
+        val delegate = MutableFixtureBackend().apply {
+            addFile("Photos/new-a.dat", byteArrayOf(1))
+            addFile("Photos/new-b.dat", byteArrayOf(2))
+        }
+        val store = MemoryLinuxVirtualMetadataStore().apply {
+            seed(
+                "Photos",
+                LinuxVirtualDirectorySnapshot(
+                    listOf(LinuxVirtualFileNode("Photos/cached.dat", "cached.dat", false, 1L, "cached-etag")),
+                    fetchedAtEpochMillis = 1L,
+                ),
+            )
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = store,
+            nowEpochMillis = { 10_000L },
+            freshForMillis = 1_000L,
+        )
+
+        assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertTrue(
+            waitUntil {
+                cached.list("Photos").map(LinuxVirtualFileNode::name) == listOf("new-a.dat", "new-b.dat")
+            },
+        )
+        assertEquals(listOf("new-a.dat", "new-b.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+        assertEquals(1, delegate.listCallCount("Photos"))
+        cached.close()
+    }
+
+    @Test
+    fun `successful namespace mutation invalidates the affected parent listing`() {
+        val delegate = MutableFixtureBackend()
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = MemoryLinuxVirtualMetadataStore(),
+            freshForMillis = Long.MAX_VALUE,
+        )
+
+        assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
+        cached.createDirectory("Albums")
+        assertEquals(listOf("Photos", "Albums"), cached.list("").map(LinuxVirtualFileNode::name))
+        assertEquals(2, delegate.listCallCount(""))
+        cached.close()
+    }
+
+    @Test
     fun `release reports a close time writeback failure`() {
         val backend = MutableFixtureBackend(failClose = true)
         val fileSystem = LinuxNextcloudVirtualFileSystem(backend)
@@ -356,11 +473,13 @@ class LinuxVirtualFileSystemTest {
             "Photos" to LinuxVirtualFileNode("Photos", "Photos", true, 0L, "photos-etag"),
         )
         private val contents = linkedMapOf<String, ByteArray>()
+        private val listCalls = mutableMapOf<String, Int>()
 
         override fun resolve(path: String): LinuxVirtualFileNode? = nodes[path.trim('/')]
 
         override fun list(path: String): List<LinuxVirtualFileNode> {
             val parent = path.trim('/')
+            listCalls[parent] = listCalls.getOrDefault(parent, 0) + 1
             return nodes.values.filter { node ->
                 node.path.isNotEmpty() && node.path.substringBeforeLast('/', "") == parent
             }
@@ -454,6 +573,8 @@ class LinuxVirtualFileSystemTest {
 
         fun fileBytes(path: String): ByteArray = requireNotNull(contents[path])
 
+        fun listCallCount(path: String): Int = listCalls.getOrDefault(path.trim('/'), 0)
+
         fun addFile(path: String, bytes: ByteArray) {
             contents[path] = bytes.copyOf()
             nodes[path] = LinuxVirtualFileNode(
@@ -464,6 +585,39 @@ class LinuxVirtualFileSystemTest {
                 remoteRevision = "etag-${bytes.size}",
             )
         }
+    }
+
+    private class MemoryLinuxVirtualMetadataStore : LinuxVirtualMetadataStore {
+        private val snapshots = mutableMapOf<String, LinuxVirtualDirectorySnapshot>()
+
+        override fun load(path: String): LinuxVirtualDirectorySnapshot? = snapshots[path]
+
+        override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+            snapshots[path] = snapshot
+        }
+
+        override fun invalidate(path: String) {
+            val normalized = path.trim('/')
+            val parent = normalized.substringBeforeLast('/', "")
+            snapshots.keys.removeIf { cachedPath ->
+                normalized.isEmpty() ||
+                    cachedPath == normalized ||
+                    cachedPath.startsWith("$normalized/") ||
+                    cachedPath == parent
+            }
+        }
+
+        fun seed(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+            snapshots[path] = snapshot
+        }
+    }
+
+    private fun waitUntil(condition: () -> Boolean): Boolean {
+        repeat(200) {
+            if (condition()) return true
+            TimeUnit.MILLISECONDS.sleep(10L)
+        }
+        return condition()
     }
 }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -669,6 +669,33 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `slow directory refresh is fresh from response completion`() {
+        val fixture = MutableFixtureBackend().apply {
+            addFile("Photos/new.dat", byteArrayOf(1))
+        }
+        val clock = AtomicLong(0L)
+        val delegate = object : LinuxVirtualFileBackend by fixture {
+            override fun list(path: String): List<LinuxVirtualFileNode> = fixture.list(path).also {
+                clock.set(10_000L)
+            }
+        }
+        val cached = CachingLinuxVirtualFileBackend(
+            delegate = delegate,
+            store = MemoryLinuxVirtualMetadataStore(),
+            nowEpochMillis = clock::get,
+            freshForMillis = 5_000L,
+        )
+        try {
+            assertEquals(listOf("new.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
+            repeat(100) { assertNotNull(cached.resolve("Photos/new.dat")) }
+            TimeUnit.MILLISECONDS.sleep(100L)
+            assertEquals(1, fixture.listCallCount("Photos"))
+        } finally {
+            cached.close()
+        }
+    }
+
+    @Test
     fun `mutation invalidation discards an older in flight directory refresh`() {
         val delegate = MutableFixtureBackend().apply {
             addFile("Photos/existing.dat", byteArrayOf(1))

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -359,6 +359,80 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `open directory handles share one bounded entry budget`() {
+        val backend = MutableFixtureBackend().apply {
+            addFile("Photos/a.dat", byteArrayOf(1))
+            addFile("Photos/b.dat", byteArrayOf(2))
+        }
+        val fileSystem = LinuxNextcloudVirtualFileSystem(backend, maximumOpenDirectoryEntries = 4)
+        val runtime = Runtime.getSystemRuntime()
+        val first = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+        val second = FuseFileInfo.of(runtime.memoryManager.allocateDirect(256))
+
+        assertEquals(0, fileSystem.opendir("/Photos", first))
+        assertEquals(-ErrorCodes.ENOMEM(), fileSystem.opendir("/Photos", second))
+        assertEquals(0, fileSystem.releasedir("/Photos", first))
+        assertEquals(0, fileSystem.opendir("/Photos", second))
+        assertEquals(0, fileSystem.releasedir("/Photos", second))
+    }
+
+    @Test
+    fun `listing persistence keeps causal order from before the network request`() {
+        val root = Files.createTempDirectory("linux-virtual-causal-listing-")
+        val preferences = Preferences.userRoot().node(
+            "dev/obiente/nextcloudnative/tests/linux-virtual-causal-listing/${UUID.randomUUID()}",
+        )
+        val listingStarted = CountDownLatch(1)
+        val releaseListing = CountDownLatch(1)
+        val persistenceAttempted = CountDownLatch(1)
+        try {
+            val cache = DesktopFileReadCache(root.toFile(), preferences = preferences)
+            val accountId = "0".repeat(64)
+            val fixture = MutableFixtureBackend().apply { addFile("Photos/old.dat", byteArrayOf(1)) }
+            val delegate = object : LinuxVirtualFileBackend by fixture {
+                override fun list(path: String): List<LinuxVirtualFileNode> {
+                    val snapshot = fixture.list(path)
+                    listingStarted.countDown()
+                    check(releaseListing.await(2L, TimeUnit.SECONDS))
+                    return snapshot
+                }
+            }
+            val persisted = DesktopLinuxVirtualMetadataStore(cache, accountId)
+            val store = object : LinuxVirtualMetadataStore by persisted {
+                override fun store(path: String, snapshot: LinuxVirtualDirectorySnapshot) {
+                    persisted.store(path, snapshot)
+                    persistenceAttempted.countDown()
+                }
+            }
+            val clock = AtomicLong(100L)
+            val cached = CachingLinuxVirtualFileBackend(delegate, store, nowEpochMillis = clock::get)
+            val worker = Executors.newSingleThreadExecutor()
+            try {
+                val request = worker.submit<List<LinuxVirtualFileNode>> { cached.list("Photos") }
+                assertTrue(listingStarted.await(2L, TimeUnit.SECONDS))
+                cache.storeListing(
+                    accountId,
+                    "Photos",
+                    listOf(cachedNextcloudFile("Photos/current.dat", "current-etag")),
+                    nowEpochMillis = 200L,
+                )
+                clock.set(300L)
+                releaseListing.countDown()
+                assertEquals(listOf("old.dat"), request.get(2L, TimeUnit.SECONDS).map(LinuxVirtualFileNode::name))
+                assertTrue(persistenceAttempted.await(2L, TimeUnit.SECONDS))
+                assertEquals("Photos/current.dat", cache.cachedListing(accountId, "Photos")?.single()?.path)
+            } finally {
+                releaseListing.countDown()
+                worker.shutdownNow()
+                cached.close()
+            }
+        } finally {
+            runCatching { preferences.removeNode() }
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `directory snapshot indexes large child sets by canonical path`() {
         val nodes = List(50_000) { index ->
             val name = "item-${index.toString().padStart(5, '0')}.dat"
@@ -1067,6 +1141,18 @@ class LinuxVirtualFileSystemTest {
             )
         }
     }
+
+    private fun cachedNextcloudFile(path: String, etag: String) = NextcloudFile(
+        path = path,
+        name = path.substringAfterLast('/'),
+        isDirectory = false,
+        mimeType = "application/octet-stream",
+        size = 1L,
+        lastModified = null,
+        fileId = null,
+        hasPreview = false,
+        etag = etag,
+    )
 
     private class MemoryLinuxVirtualMetadataStore : LinuxVirtualMetadataStore {
         private val snapshots = mutableMapOf<String, LinuxVirtualDirectorySnapshot>()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -765,6 +765,7 @@ class LinuxVirtualFileSystemTest {
         )
 
         assertEquals(listOf("Photos"), cached.list("").map(LinuxVirtualFileNode::name))
+        assertTrue(waitUntil { persisted.snapshot("")?.nodes?.singleOrNull()?.name == "Photos" })
         cached.createDirectory("Albums")
         assertEquals(setOf("Photos", "Albums"), cached.list("").mapTo(hashSetOf(), LinuxVirtualFileNode::name))
         assertTrue(waitUntil { persisted.snapshot("")?.nodes?.any { it.name == "Albums" } == true })

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -512,7 +512,12 @@ class LinuxVirtualFileSystemTest {
         try {
             assertEquals(listOf("cached.dat"), cached.list("Photos").map(LinuxVirtualFileNode::name))
             assertTrue(persistenceStarted.await(2L, TimeUnit.SECONDS))
-            assertNotNull(reader.submit { cached.resolve("Photos/cached.dat") }.get(1L, TimeUnit.SECONDS))
+            assertEquals(
+                listOf("cached.dat"),
+                reader.submit<List<String>> {
+                    cached.list("Photos").map(LinuxVirtualFileNode::name)
+                }.get(1L, TimeUnit.SECONDS),
+            )
         } finally {
             releasePersistence.countDown()
             reader.shutdownNow()


### PR DESCRIPTION
## Summary

- coalesce Linux virtual-directory reads and index parent snapshots for constant-time child metadata
- keep stable FUSE directory snapshots and continuation cookies across multi-buffer reads and renames
- serve persisted metadata immediately while stale entries refresh with bounded retry backoff
- retain directory metadata within global entry and directory budgets
- stream bounded WebDAV parsing and keep cache maintenance from changing completed mutation results
- preserve newer shared Files listings when deferred FUSE metadata persistence finishes

## Validation

- `./gradlew --no-daemon :ui:desktopTest :ui:createDistributable`
- `bash tools/check-repository.sh`
- `git diff --check`

The desktop suite, distributable build, repository checks, and focused large-directory tests pass. Exact-head CI remains responsible for the privileged Linux FUSE runtime job.

## Tracking

Closes #298
Advances #11

Stack: 1 of 2. The selective virtual-folder PR is based on this foundation.
