### PR TITLE
docs(contributing): verify remote PR metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,12 +367,12 @@ final-device QA, not the only way to test.
 - The human contributor remains the author and is responsible for the complete
   change. Automated tools must not become author or committer and must not add
   bot/assistant `Co-authored-by` trailers.
-- DCO sign-off is controlled by the human contributor. When a maintainer or a
-  protected repository check requires it, an agent may add the human's
-  `Signed-off-by` trailer only after that human explicitly confirms review and
-  authorizes the sign-off. An automated reviewer must never request an agent to
-  manufacture or repair a human sign-off. Cryptographic commit signing remains
-  a separate repository requirement.
+- Every submitted commit must carry the human contributor's `Signed-off-by`
+  trailer. Only that human may add or authorize the trailer after reviewing the
+  commit; an agent must never add, manufacture, or repair it. Automated reviewers
+  must leave DCO enforcement to protected repository checks and maintainers and
+  must not report missing sign-off as a code-review finding. Cryptographic commit
+  signing remains a separate repository requirement.
 - Optional AI disclosure is appreciated in the PR description or an
   `Assisted-by: Tool[:model]` trailer, but it is not mandatory. Never disclose
   private prompts or account data.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,13 +356,23 @@ final-device QA, not the only way to test.
 - Amending, rebasing, force-pushing, deleting branches/tags/releases, or
   rewriting shared history requires explicit authority for that exact action.
 - Use Conventional Commit subjects.
+- Authorship and DCO are submission metadata, not code-review findings. Automated
+  reviewers must not post review comments about an author, committer, or missing
+  sign-off. Repository checks and maintainers own those submission gates.
+- Never infer Git identity from an agent sandbox, a local worktree, synthetic
+  patch commits, or rewritten review fixtures. If an operational workflow must
+  inspect PR commit identity, it must use the exact remote PR commits returned by
+  GitHub's API. If that evidence is unavailable or inconsistent, leave the
+  metadata decision to a maintainer rather than reporting a finding.
 - The human contributor remains the author and is responsible for the complete
   change. Automated tools must not become author or committer and must not add
   bot/assistant `Co-authored-by` trailers.
-- Every submitted commit needs the human contributor's DCO `Signed-off-by`
-  trailer. An agent may add it only after that human explicitly confirms they
-  reviewed the commit and authorize the sign-off. Cryptographic commit signing
-  remains a separate repository requirement.
+- DCO sign-off is controlled by the human contributor. When a maintainer or a
+  protected repository check requires it, an agent may add the human's
+  `Signed-off-by` trailer only after that human explicitly confirms review and
+  authorizes the sign-off. An automated reviewer must never request an agent to
+  manufacture or repair a human sign-off. Cryptographic commit signing remains
+  a separate repository requirement.
 - Optional AI disclosure is appreciated in the PR description or an
   `Assisted-by: Tool[:model]` trailer, but it is not mandatory. Never disclose
   private prompts or account data.

--- a/changes/unreleased/305-remote-review-metadata.md
+++ b/changes/unreleased/305-remote-review-metadata.md
@@ -1,0 +1,7 @@
+category: internal
+issue: 305
+pull: 306
+platforms: all
+user-facing: no
+
+Automated review guidance now requires remote pull-request evidence for commit metadata and leaves DCO enforcement to maintainers and repository checks.


### PR DESCRIPTION
## Summary

- classify authorship and DCO as maintainer or repository-check submission metadata rather than code-review findings
- require exact GitHub pull-request commit data for any operational identity inspection
- reject sandbox, local worktree, patch, and synthetic commit identity as review evidence
- preserve the rule that automation cannot manufacture a human sign-off

## Validation

- `bash tools/check-repository.sh`
- `git diff --check`

## Tracking

Closes #305
Advances #16