### PR TITLE
fix(release): retry Windows provenance attestation

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -318,7 +318,17 @@ jobs:
             -ExpectedVersion "${env:NIGHTLY_DESKTOP_VERSION}"
 
       - name: Attest Windows MSI provenance
+        id: attest-windows-msi
         if: matrix.platform == 'windows'
+        continue-on-error: true
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: ui/build/compose/binaries/main/msi/*.msi
+
+      - name: Retry Windows MSI provenance attestation
+        if: >-
+          matrix.platform == 'windows' &&
+          steps.attest-windows-msi.outcome == 'failure'
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: ui/build/compose/binaries/main/msi/*.msi

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -214,7 +214,17 @@ jobs:
             -ExpectedVersion "${env:RELEASE_DESKTOP_VERSION}"
 
       - name: Attest Windows MSI provenance
+        id: attest-windows-msi
         if: matrix.platform == 'windows'
+        continue-on-error: true
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: ui/build/compose/binaries/main/msi/*.msi
+
+      - name: Retry Windows MSI provenance attestation
+        if: >-
+          matrix.platform == 'windows' &&
+          steps.attest-windows-msi.outcome == 'failure'
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: ui/build/compose/binaries/main/msi/*.msi

--- a/changes/unreleased/307-windows-attestation-retry.md
+++ b/changes/unreleased/307-windows-attestation-retry.md
@@ -1,0 +1,7 @@
+category: internal
+issue: 307
+pull: none
+platforms: windows
+user-facing: no
+
+Windows release packaging now retries one transient provenance-service failure before omitting the verified MSI.

--- a/tools/test-nightly-release-workflow.sh
+++ b/tools/test-nightly-release-workflow.sh
@@ -21,6 +21,19 @@ require_text() {
     fi
 }
 
+require_count() {
+    local file="$1"
+    local expected="$2"
+    local count="$3"
+    local actual
+    actual="$(grep -Fc -- "$expected" "$file")"
+    if [[ "$actual" -ne "$count" ]]; then
+        printf '%s contains %s copies of release contract %s; expected %s.\n' \
+            "$file" "$actual" "$expected" "$count" >&2
+        exit 1
+    fi
+}
+
 require_text "$nightly" 'workflow_run:'
 require_text "$nightly" 'github.event.workflow_run.conclusion == '\''success'\'''
 require_text "$nightly" 'github.event.workflow_run.event == '\''push'\'''
@@ -44,6 +57,10 @@ require_text "$nightly" 'targets: x86_64-pc-windows-msvc'
 require_text "$nightly" 'name: Verify unsigned Windows MSI'
 require_text "$nightly" 'tools/verify-windows-package.ps1'
 require_text "$nightly" 'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1'
+require_count "$nightly" 'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1' 2
+require_text "$nightly" 'id: attest-windows-msi'
+require_text "$nightly" 'name: Retry Windows MSI provenance attestation'
+require_text "$nightly" "steps.attest-windows-msi.outcome == 'failure'"
 require_text "$nightly" 'subject-path: ui/build/compose/binaries/main/msi/*.msi'
 require_text "$nightly" 'artifact-metadata: write'
 require_text "$nightly" 'attestations: write'
@@ -122,6 +139,10 @@ require_text "$prerelease" 'name: Set up Rust for Windows packaging'
 require_text "$prerelease" 'targets: x86_64-pc-windows-msvc'
 require_text "$prerelease" 'tools/verify-windows-package.ps1'
 require_text "$prerelease" 'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1'
+require_count "$prerelease" 'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1' 2
+require_text "$prerelease" 'id: attest-windows-msi'
+require_text "$prerelease" 'name: Retry Windows MSI provenance attestation'
+require_text "$prerelease" "steps.attest-windows-msi.outcome == 'failure'"
 require_text "$prerelease" 'subject-path: ui/build/compose/binaries/main/msi/*.msi'
 require_text "$prerelease" 'artifact-metadata: write'
 require_text "$prerelease" 'attestations: write'


### PR DESCRIPTION
## Summary

- retry one transient Windows MSI provenance-attestation failure in nightly and curated prerelease workflows
- keep the retry mandatory before the verified MSI can be uploaded
- lock both pinned attestation attempts and the failure condition in the release workflow contract

## Validation

- `bash tools/test-nightly-release-workflow.sh`
- `tools/test-prerelease-update-contract.sh`
- `bash tools/check-repository.sh`

## Relationships

- Closes #307
- Advances #102