### PR TITLE
fix(windows): remove stale Cloud Files registrations

### DIFF
--- a/changes/unreleased/312-windows-registration-conflict-cleanup.md
+++ b/changes/unreleased/312-windows-registration-conflict-cleanup.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 312
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows filesync setup now removes stale Nextcloud Native registrations left by previous accounts or interrupted setup while preserving their local files, then connects the current account.

--- a/changes/unreleased/312-windows-registration-conflict-cleanup.md
+++ b/changes/unreleased/312-windows-registration-conflict-cleanup.md
@@ -4,4 +4,4 @@ pull: none
 platforms: windows
 user-facing: yes
 
-Windows filesync setup now removes stale Nextcloud Native registrations left by previous accounts or interrupted setup while preserving their local files, then connects the current account.
+Windows filesync setup now repairs stale Nextcloud Native registrations while preserving local files and retaining ambiguous live roots for recovery.

--- a/changes/unreleased/312-windows-registration-conflict-cleanup.md
+++ b/changes/unreleased/312-windows-registration-conflict-cleanup.md
@@ -4,4 +4,4 @@ pull: none
 platforms: windows
 user-facing: yes
 
-Windows filesync setup now repairs stale Nextcloud Native registrations while preserving local files and retaining ambiguous live roots for recovery.
+Windows filesync setup now repairs stale Nextcloud Native registrations while preserving local files and retaining live roots for recovery.

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -53,6 +53,7 @@ enum ExistingRegistrationAction {
     KeepCurrent,
     ReplaceCurrent,
     RemoveStaleOwned,
+    RetainOwnedRecovery,
     IgnoreForeign,
     RejectUnsafeCurrent,
 }
@@ -82,7 +83,10 @@ fn existing_registration_action(
             ExistingRegistrationAction::RejectUnsafeCurrent
         }
         (true, false, _) => ExistingRegistrationAction::RejectUnsafeCurrent,
-        (false, true, _) => ExistingRegistrationAction::RemoveStaleOwned,
+        (false, true, OwnedCurrentRegistrationState::Replaceable) => {
+            ExistingRegistrationAction::RemoveStaleOwned
+        }
+        (false, true, _) => ExistingRegistrationAction::RetainOwnedRecovery,
         (false, false, _) => ExistingRegistrationAction::IgnoreForeign,
     }
 }
@@ -282,6 +286,24 @@ mod platform {
         })
     }
 
+    fn non_current_registration_state(
+        existing: &StorageProviderSyncRootInfo,
+        root: &Path,
+    ) -> OwnedCurrentRegistrationState {
+        let existing_path = match existing.Path().and_then(|folder| folder.Path()) {
+            Ok(path) => path,
+            Err(failure) if is_windows_absence_hresult(failure.code().0) => {
+                return OwnedCurrentRegistrationState::Replaceable;
+            }
+            Err(_) => return OwnedCurrentRegistrationState::UnsafeExistingPath,
+        };
+        match registered_path_state(&PathBuf::from(existing_path.to_os_string()), root) {
+            Ok(RegisteredPathState::Missing) => OwnedCurrentRegistrationState::Replaceable,
+            Ok(RegisteredPathState::SameExisting | RegisteredPathState::DifferentExisting)
+            | Err(_) => OwnedCurrentRegistrationState::UnsafeExistingPath,
+        }
+    }
+
     fn unregister_owned_registration(id: &HSTRING) -> windows::core::Result<()> {
         match StorageProviderSyncRootManager::Unregister(id) {
             Ok(()) => Ok(()),
@@ -436,6 +458,7 @@ mod platform {
                         return Err(Box::new(UnsafeRegistrationConflict));
                     }
                     ExistingRegistrationAction::RemoveStaleOwned
+                    | ExistingRegistrationAction::RetainOwnedRecovery
                     | ExistingRegistrationAction::IgnoreForeign => unreachable!(),
                 }
             }
@@ -454,11 +477,13 @@ mod platform {
             if existing_id == id {
                 continue;
             }
-            match existing_registration_action(
-                false,
-                existing_provider_id == PROVIDER_GUID,
-                OwnedCurrentRegistrationState::Ready,
-            ) {
+            let provider_owned = existing_provider_id == PROVIDER_GUID;
+            let cleanup_state = if provider_owned {
+                non_current_registration_state(&existing, &root)
+            } else {
+                OwnedCurrentRegistrationState::UnsafeExistingPath
+            };
+            match existing_registration_action(false, provider_owned, cleanup_state) {
                 ExistingRegistrationAction::ReplaceCurrent
                 | ExistingRegistrationAction::RemoveStaleOwned => {
                     // Older versions could leave account registrations behind after an interrupted
@@ -466,6 +491,7 @@ mod platform {
                     unregister_owned_registration(&existing_id)?;
                 }
                 ExistingRegistrationAction::KeepCurrent
+                | ExistingRegistrationAction::RetainOwnedRecovery
                 | ExistingRegistrationAction::IgnoreForeign => {}
                 ExistingRegistrationAction::RejectUnsafeCurrent => {
                     return Err(Box::new(UnsafeRegistrationConflict));
@@ -709,8 +735,16 @@ mod tests {
             ExistingRegistrationAction::RejectUnsafeCurrent
         );
         assert_eq!(
-            existing_registration_action(false, true, OwnedCurrentRegistrationState::Ready),
+            existing_registration_action(false, true, OwnedCurrentRegistrationState::Replaceable,),
             ExistingRegistrationAction::RemoveStaleOwned
+        );
+        assert_eq!(
+            existing_registration_action(
+                false,
+                true,
+                OwnedCurrentRegistrationState::UnsafeExistingPath,
+            ),
+            ExistingRegistrationAction::RetainOwnedRecovery
         );
         assert_eq!(
             existing_registration_action(false, false, OwnedCurrentRegistrationState::Ready),

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -24,24 +24,64 @@ fn paths_refer_to_same_existing_entry(
 
 #[cfg(any(windows, test))]
 #[derive(Debug, PartialEq, Eq)]
+enum RegisteredPathState {
+    Missing,
+    SameExisting,
+    DifferentExisting,
+}
+
+#[cfg(any(windows, test))]
+fn registered_path_state(
+    registered: &std::path::Path,
+    requested: &std::path::Path,
+) -> std::io::Result<RegisteredPathState> {
+    if !registered.try_exists()? {
+        return Ok(RegisteredPathState::Missing);
+    }
+    Ok(
+        if paths_refer_to_same_existing_entry(registered, requested)? {
+            RegisteredPathState::SameExisting
+        } else {
+            RegisteredPathState::DifferentExisting
+        },
+    )
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
 enum ExistingRegistrationAction {
     KeepCurrent,
     ReplaceCurrent,
     RemoveStaleOwned,
     IgnoreForeign,
-    RejectForeignCurrent,
+    RejectUnsafeCurrent,
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
+enum OwnedCurrentRegistrationState {
+    Ready,
+    Replaceable,
+    UnsafeExistingPath,
 }
 
 #[cfg(any(windows, test))]
 fn existing_registration_action(
     current_id: bool,
     provider_owned: bool,
-    current_metadata: bool,
+    current_state: OwnedCurrentRegistrationState,
 ) -> ExistingRegistrationAction {
-    match (current_id, provider_owned, current_metadata) {
-        (true, true, true) => ExistingRegistrationAction::KeepCurrent,
-        (true, true, false) => ExistingRegistrationAction::ReplaceCurrent,
-        (true, false, _) => ExistingRegistrationAction::RejectForeignCurrent,
+    match (current_id, provider_owned, current_state) {
+        (true, true, OwnedCurrentRegistrationState::Ready) => {
+            ExistingRegistrationAction::KeepCurrent
+        }
+        (true, true, OwnedCurrentRegistrationState::Replaceable) => {
+            ExistingRegistrationAction::ReplaceCurrent
+        }
+        (true, true, OwnedCurrentRegistrationState::UnsafeExistingPath) => {
+            ExistingRegistrationAction::RejectUnsafeCurrent
+        }
+        (true, false, _) => ExistingRegistrationAction::RejectUnsafeCurrent,
         (false, true, _) => ExistingRegistrationAction::RemoveStaleOwned,
         (false, false, _) => ExistingRegistrationAction::IgnoreForeign,
     }
@@ -166,9 +206,11 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 #[cfg(windows)]
 mod platform {
     use super::{
-        ExistingRegistrationAction, PROVIDER_ID, RegistrationNotFound, UnsafeRegistrationConflict,
-        decode_identity_hex, existing_registration_action, is_windows_absence_hresult,
-        paths_refer_to_same_existing_entry, sid_string, valid_account_id, valid_display_name,
+        ExistingRegistrationAction, OwnedCurrentRegistrationState, PROVIDER_ID,
+        RegisteredPathState, RegistrationNotFound, UnsafeRegistrationConflict, decode_identity_hex,
+        existing_registration_action, is_windows_absence_hresult,
+        paths_refer_to_same_existing_entry, registered_path_state, sid_string, valid_account_id,
+        valid_display_name,
     };
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
@@ -202,27 +244,42 @@ mod platform {
         paths_refer_to_same_existing_entry(&PathBuf::from(path.to_os_string()), requested)
     }
 
-    fn current_registration_metadata_matches(
+    fn current_registration_state(
         existing: &StorageProviderSyncRootInfo,
         root: &Path,
         display_name: &HSTRING,
         icon_resource: &HSTRING,
         context: &windows::Storage::Streams::IBuffer,
-    ) -> bool {
-        let matches = || -> WindowsResult<bool> {
-            let existing_path = existing.Path()?.Path()?;
-            if registered_path_is_missing(&existing_path).unwrap_or(false)
-                || !registered_path_matches(&existing_path, root).unwrap_or(false)
-            {
-                return Ok(false);
+    ) -> WindowsResult<OwnedCurrentRegistrationState> {
+        let existing_path = match existing.Path().and_then(|folder| folder.Path()) {
+            Ok(path) => path,
+            Err(failure) if is_windows_absence_hresult(failure.code().0) => {
+                return Ok(OwnedCurrentRegistrationState::Replaceable);
             }
+            Err(failure) => return Err(failure),
+        };
+        match registered_path_state(&PathBuf::from(existing_path.to_os_string()), root) {
+            Ok(RegisteredPathState::Missing) => {
+                return Ok(OwnedCurrentRegistrationState::Replaceable);
+            }
+            Ok(RegisteredPathState::SameExisting) => {}
+            Ok(RegisteredPathState::DifferentExisting) | Err(_) => {
+                return Ok(OwnedCurrentRegistrationState::UnsafeExistingPath);
+            }
+        }
+        let metadata_matches = (|| -> WindowsResult<bool> {
             Ok(existing.DisplayNameResource()? == *display_name
                 && existing.IconResource()? == *icon_resource
                 && CryptographicBuffer::Compare(&existing.Context()?, context)?)
-        };
-        // Once the stable ID and provider GUID prove ownership, unreadable or incomplete
-        // properties are stale metadata to replace, not a reason to strand the account.
-        matches().unwrap_or(false)
+        })()
+        .unwrap_or(false);
+        Ok(if metadata_matches {
+            OwnedCurrentRegistrationState::Ready
+        } else {
+            // Re-registering the same directory updates provider metadata without moving or
+            // deleting local files.
+            OwnedCurrentRegistrationState::Replaceable
+        })
     }
 
     fn unregister_owned_registration(id: &HSTRING) -> windows::core::Result<()> {
@@ -355,15 +412,18 @@ mod platform {
         match StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
             Ok(existing) => {
                 let provider_owned = existing.ProviderId()? == PROVIDER_GUID;
-                let current_metadata = provider_owned
-                    && current_registration_metadata_matches(
+                let current_state = if provider_owned {
+                    current_registration_state(
                         &existing,
                         &root,
                         &display_name,
                         &icon_resource,
                         &context,
-                    );
-                match existing_registration_action(true, provider_owned, current_metadata) {
+                    )?
+                } else {
+                    OwnedCurrentRegistrationState::UnsafeExistingPath
+                };
+                match existing_registration_action(true, provider_owned, current_state) {
                     ExistingRegistrationAction::KeepCurrent => {
                         current_registration_is_ready = true;
                     }
@@ -372,7 +432,7 @@ mod platform {
                         // and every local file in it remain untouched for manual recovery.
                         unregister_owned_registration(&id)?;
                     }
-                    ExistingRegistrationAction::RejectForeignCurrent => {
+                    ExistingRegistrationAction::RejectUnsafeCurrent => {
                         return Err(Box::new(UnsafeRegistrationConflict));
                     }
                     ExistingRegistrationAction::RemoveStaleOwned
@@ -389,10 +449,15 @@ mod platform {
             let Ok(existing_provider_id) = existing.ProviderId() else {
                 continue;
             };
+            // The exact current ID was handled above with its path recovery checks. Never make a
+            // second, less-informed decision about that registration from the enumeration view.
+            if existing_id == id {
+                continue;
+            }
             match existing_registration_action(
-                existing_id == id,
+                false,
                 existing_provider_id == PROVIDER_GUID,
-                current_registration_is_ready,
+                OwnedCurrentRegistrationState::Ready,
             ) {
                 ExistingRegistrationAction::ReplaceCurrent
                 | ExistingRegistrationAction::RemoveStaleOwned => {
@@ -402,7 +467,7 @@ mod platform {
                 }
                 ExistingRegistrationAction::KeepCurrent
                 | ExistingRegistrationAction::IgnoreForeign => {}
-                ExistingRegistrationAction::RejectForeignCurrent => {
+                ExistingRegistrationAction::RejectUnsafeCurrent => {
                     return Err(Box::new(UnsafeRegistrationConflict));
                 }
             }
@@ -628,24 +693,66 @@ mod tests {
     #[test]
     fn removes_only_stale_owned_registrations() {
         assert_eq!(
-            existing_registration_action(true, true, true),
+            existing_registration_action(true, true, OwnedCurrentRegistrationState::Ready),
             ExistingRegistrationAction::KeepCurrent
         );
         assert_eq!(
-            existing_registration_action(true, true, false),
+            existing_registration_action(true, true, OwnedCurrentRegistrationState::Replaceable),
             ExistingRegistrationAction::ReplaceCurrent
         );
         assert_eq!(
-            existing_registration_action(false, true, false),
+            existing_registration_action(
+                true,
+                true,
+                OwnedCurrentRegistrationState::UnsafeExistingPath,
+            ),
+            ExistingRegistrationAction::RejectUnsafeCurrent
+        );
+        assert_eq!(
+            existing_registration_action(false, true, OwnedCurrentRegistrationState::Ready),
             ExistingRegistrationAction::RemoveStaleOwned
         );
         assert_eq!(
-            existing_registration_action(false, false, false),
+            existing_registration_action(false, false, OwnedCurrentRegistrationState::Ready),
             ExistingRegistrationAction::IgnoreForeign
         );
         assert_eq!(
-            existing_registration_action(true, false, false),
-            ExistingRegistrationAction::RejectForeignCurrent
+            existing_registration_action(true, false, OwnedCurrentRegistrationState::Ready),
+            ExistingRegistrationAction::RejectUnsafeCurrent
         );
+    }
+
+    #[test]
+    fn distinguishes_missing_same_and_different_existing_registration_paths() {
+        let base = std::env::temp_dir().join(format!(
+            "nextcloud-native-registration-path-state-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after Unix epoch")
+                .as_nanos()
+        ));
+        let registered = base.join("registered");
+        let requested = base.join("requested");
+        std::fs::create_dir_all(&registered).expect("create registered path fixture");
+        std::fs::create_dir_all(&requested).expect("create requested path fixture");
+
+        assert_eq!(
+            registered_path_state(&base.join("missing"), &requested)
+                .expect("classify missing registration path"),
+            RegisteredPathState::Missing
+        );
+        assert_eq!(
+            registered_path_state(&registered, &registered)
+                .expect("classify matching registration path"),
+            RegisteredPathState::SameExisting
+        );
+        assert_eq!(
+            registered_path_state(&registered, &requested)
+                .expect("classify different registration path"),
+            RegisteredPathState::DifferentExisting
+        );
+
+        std::fs::remove_dir_all(&base).expect("remove registration path fixture");
     }
 }

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -2,6 +2,10 @@
 
 #[cfg(windows)]
 const PROVIDER_ID: &str = "Obiente.NextcloudNative";
+#[cfg(windows)]
+const RECOVERABLE_ROOT_ARGUMENT: &str = "--recoverable-root";
+#[cfg(windows)]
+const MAX_RECOVERABLE_ROOTS: usize = 16;
 #[cfg(any(windows, test))]
 const ACCOUNT_ID_LENGTH: usize = 64;
 #[cfg(any(windows, test))]
@@ -89,6 +93,32 @@ fn existing_registration_action(
         (false, true, _) => ExistingRegistrationAction::RetainOwnedRecovery,
         (false, false, _) => ExistingRegistrationAction::IgnoreForeign,
     }
+}
+
+#[cfg(any(windows, test))]
+fn account_id_from_sync_root_id(value: &str) -> Option<&str> {
+    let (provider_and_sid, account_id) = value.rsplit_once('!')?;
+    if provider_and_sid.starts_with("Obiente.NextcloudNative!") && valid_account_id(account_id) {
+        Some(account_id)
+    } else {
+        None
+    }
+}
+
+#[cfg(any(windows, test))]
+fn recoverable_root_matches(
+    recoverable_roots: &std::collections::HashMap<String, std::path::PathBuf>,
+    account_id: &str,
+    registered_path: &std::path::Path,
+) -> bool {
+    recoverable_roots
+        .get(account_id)
+        .is_some_and(|recovery_root| {
+            matches!(
+                registered_path_state(registered_path, recovery_root),
+                Ok(RegisteredPathState::SameExisting)
+            )
+        })
 }
 
 #[cfg(windows)]
@@ -210,12 +240,14 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 #[cfg(windows)]
 mod platform {
     use super::{
-        ExistingRegistrationAction, OwnedCurrentRegistrationState, PROVIDER_ID,
-        RegisteredPathState, RegistrationNotFound, UnsafeRegistrationConflict, decode_identity_hex,
+        ExistingRegistrationAction, MAX_RECOVERABLE_ROOTS, OwnedCurrentRegistrationState,
+        PROVIDER_ID, RECOVERABLE_ROOT_ARGUMENT, RegisteredPathState, RegistrationNotFound,
+        UnsafeRegistrationConflict, account_id_from_sync_root_id, decode_identity_hex,
         existing_registration_action, is_windows_absence_hresult,
-        paths_refer_to_same_existing_entry, registered_path_state, sid_string, valid_account_id,
-        valid_display_name,
+        paths_refer_to_same_existing_entry, recoverable_root_matches, registered_path_state,
+        sid_string, valid_account_id, valid_display_name,
     };
+    use std::collections::HashMap;
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
     use std::path::{Path, PathBuf};
@@ -288,7 +320,8 @@ mod platform {
 
     fn non_current_registration_state(
         existing: &StorageProviderSyncRootInfo,
-        root: &Path,
+        existing_id: &HSTRING,
+        recoverable_roots: &HashMap<String, PathBuf>,
     ) -> OwnedCurrentRegistrationState {
         let existing_path = match existing.Path().and_then(|folder| folder.Path()) {
             Ok(path) => path,
@@ -297,10 +330,23 @@ mod platform {
             }
             Err(_) => return OwnedCurrentRegistrationState::UnsafeExistingPath,
         };
-        match registered_path_state(&PathBuf::from(existing_path.to_os_string()), root) {
+        let registered_path = PathBuf::from(existing_path.to_os_string());
+        match registered_path_state(&registered_path, &registered_path) {
             Ok(RegisteredPathState::Missing) => OwnedCurrentRegistrationState::Replaceable,
-            Ok(RegisteredPathState::SameExisting | RegisteredPathState::DifferentExisting)
-            | Err(_) => OwnedCurrentRegistrationState::UnsafeExistingPath,
+            Ok(RegisteredPathState::SameExisting) => {
+                let existing_id_value = existing_id.to_string();
+                let Some(account_id) = account_id_from_sync_root_id(&existing_id_value) else {
+                    return OwnedCurrentRegistrationState::UnsafeExistingPath;
+                };
+                if recoverable_root_matches(recoverable_roots, account_id, &registered_path) {
+                    OwnedCurrentRegistrationState::Replaceable
+                } else {
+                    OwnedCurrentRegistrationState::UnsafeExistingPath
+                }
+            }
+            Ok(RegisteredPathState::DifferentExisting) | Err(_) => {
+                OwnedCurrentRegistrationState::UnsafeExistingPath
+            }
         }
     }
 
@@ -412,6 +458,7 @@ mod platform {
         display_name: String,
         icon: PathBuf,
         identity_hex: String,
+        recoverable_roots: HashMap<String, PathBuf>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if !valid_account_id(&account_id) {
             return Err("invalid account identity".into());
@@ -479,7 +526,7 @@ mod platform {
             }
             let provider_owned = existing_provider_id == PROVIDER_GUID;
             let cleanup_state = if provider_owned {
-                non_current_registration_state(&existing, &root)
+                non_current_registration_state(&existing, &existing_id, &recoverable_roots)
             } else {
                 OwnedCurrentRegistrationState::UnsafeExistingPath
             };
@@ -590,10 +637,41 @@ mod platform {
                     .next()
                     .and_then(|value| value.into_string().ok())
                     .ok_or("invalid sync root identity")?;
-                if values.next().is_some() {
-                    return Err("unexpected arguments".into());
+                let mut recoverable_roots = HashMap::new();
+                while let Some(argument) = values.next() {
+                    if argument != OsStr::new(RECOVERABLE_ROOT_ARGUMENT) {
+                        return Err("unexpected arguments".into());
+                    }
+                    let recovery_account_id = values
+                        .next()
+                        .and_then(|value| value.into_string().ok())
+                        .ok_or("invalid recovery account identity")?;
+                    if !valid_account_id(&recovery_account_id) {
+                        return Err("invalid recovery account identity".into());
+                    }
+                    let recovery_root = values
+                        .next()
+                        .map(PathBuf::from)
+                        .filter(|path| path.is_absolute())
+                        .ok_or("invalid recovery root")?;
+                    if recoverable_roots.len() >= MAX_RECOVERABLE_ROOTS {
+                        return Err("too many recovery roots".into());
+                    }
+                    if recoverable_roots
+                        .insert(recovery_account_id, recovery_root)
+                        .is_some()
+                    {
+                        return Err("duplicate recovery account identity".into());
+                    }
                 }
-                register(root, account_id, display_name, icon, identity_hex)
+                register(
+                    root,
+                    account_id,
+                    display_name,
+                    icon,
+                    identity_hex,
+                    recoverable_roots,
+                )
             }
             Some("unregister") => {
                 let root = values
@@ -786,7 +864,39 @@ mod tests {
                 .expect("classify different registration path"),
             RegisteredPathState::DifferentExisting
         );
+        let account_id = "a5".repeat(32);
+        let mut recoverable_roots = std::collections::HashMap::new();
+        recoverable_roots.insert(account_id.clone(), registered.clone());
+        assert!(recoverable_root_matches(
+            &recoverable_roots,
+            &account_id,
+            &registered,
+        ));
+        assert!(!recoverable_root_matches(
+            &recoverable_roots,
+            &account_id,
+            &requested,
+        ));
 
         std::fs::remove_dir_all(&base).expect("remove registration path fixture");
+    }
+
+    #[test]
+    fn extracts_only_owned_well_formed_account_ids_from_sync_root_ids() {
+        let account_id = "a5".repeat(32);
+        assert_eq!(
+            account_id_from_sync_root_id(&format!(
+                "Obiente.NextcloudNative!S-1-5-21-1000!{account_id}"
+            )),
+            Some(account_id.as_str())
+        );
+        assert_eq!(
+            account_id_from_sync_root_id(&format!("Other.Provider!S-1-5-21-1000!{account_id}")),
+            None
+        );
+        assert_eq!(
+            account_id_from_sync_root_id("Obiente.NextcloudNative!S-1-5-21-1000!invalid"),
+            None
+        );
     }
 }

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -58,6 +58,7 @@ enum ExistingRegistrationAction {
     ReplaceCurrent,
     RemoveStaleOwned,
     RetainOwnedRecovery,
+    ReportOwnedPathConflict,
     IgnoreForeign,
     RejectUnsafeCurrent,
 }
@@ -67,6 +68,7 @@ enum ExistingRegistrationAction {
 enum OwnedCurrentRegistrationState {
     Ready,
     Replaceable,
+    RequestedRootConflict,
     UnsafeExistingPath,
 }
 
@@ -83,12 +85,18 @@ fn existing_registration_action(
         (true, true, OwnedCurrentRegistrationState::Replaceable) => {
             ExistingRegistrationAction::ReplaceCurrent
         }
+        (true, true, OwnedCurrentRegistrationState::RequestedRootConflict) => {
+            ExistingRegistrationAction::RejectUnsafeCurrent
+        }
         (true, true, OwnedCurrentRegistrationState::UnsafeExistingPath) => {
             ExistingRegistrationAction::RejectUnsafeCurrent
         }
         (true, false, _) => ExistingRegistrationAction::RejectUnsafeCurrent,
         (false, true, OwnedCurrentRegistrationState::Replaceable) => {
             ExistingRegistrationAction::RemoveStaleOwned
+        }
+        (false, true, OwnedCurrentRegistrationState::RequestedRootConflict) => {
+            ExistingRegistrationAction::ReportOwnedPathConflict
         }
         (false, true, _) => ExistingRegistrationAction::RetainOwnedRecovery,
         (false, false, _) => ExistingRegistrationAction::IgnoreForeign,
@@ -241,9 +249,9 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 mod platform {
     use super::{
         ExistingRegistrationAction, MAX_RECOVERABLE_ROOTS, OwnedCurrentRegistrationState,
-        PROVIDER_ID, RECOVERABLE_ROOT_ARGUMENT, RegisteredPathState, RegistrationNotFound,
-        UnsafeRegistrationConflict, account_id_from_sync_root_id, decode_identity_hex,
-        existing_registration_action, is_windows_absence_hresult,
+        OwnedPathConflict, PROVIDER_ID, RECOVERABLE_ROOT_ARGUMENT, RegisteredPathState,
+        RegistrationNotFound, UnsafeRegistrationConflict, account_id_from_sync_root_id,
+        decode_identity_hex, existing_registration_action, is_windows_absence_hresult,
         paths_refer_to_same_existing_entry, recoverable_root_matches, registered_path_state,
         sid_string, valid_account_id, valid_display_name,
     };
@@ -321,6 +329,7 @@ mod platform {
     fn non_current_registration_state(
         existing: &StorageProviderSyncRootInfo,
         existing_id: &HSTRING,
+        requested_root: &Path,
         recoverable_roots: &HashMap<String, PathBuf>,
     ) -> OwnedCurrentRegistrationState {
         let existing_path = match existing.Path().and_then(|folder| folder.Path()) {
@@ -334,6 +343,12 @@ mod platform {
         match registered_path_state(&registered_path, &registered_path) {
             Ok(RegisteredPathState::Missing) => OwnedCurrentRegistrationState::Replaceable,
             Ok(RegisteredPathState::SameExisting) => {
+                if matches!(
+                    registered_path_state(&registered_path, requested_root),
+                    Ok(RegisteredPathState::SameExisting)
+                ) {
+                    return OwnedCurrentRegistrationState::RequestedRootConflict;
+                }
                 let existing_id_value = existing_id.to_string();
                 let Some(account_id) = account_id_from_sync_root_id(&existing_id_value) else {
                     return OwnedCurrentRegistrationState::UnsafeExistingPath;
@@ -506,6 +521,7 @@ mod platform {
                     }
                     ExistingRegistrationAction::RemoveStaleOwned
                     | ExistingRegistrationAction::RetainOwnedRecovery
+                    | ExistingRegistrationAction::ReportOwnedPathConflict
                     | ExistingRegistrationAction::IgnoreForeign => unreachable!(),
                 }
             }
@@ -526,7 +542,7 @@ mod platform {
             }
             let provider_owned = existing_provider_id == PROVIDER_GUID;
             let cleanup_state = if provider_owned {
-                non_current_registration_state(&existing, &existing_id, &recoverable_roots)
+                non_current_registration_state(&existing, &existing_id, &root, &recoverable_roots)
             } else {
                 OwnedCurrentRegistrationState::UnsafeExistingPath
             };
@@ -540,6 +556,9 @@ mod platform {
                 ExistingRegistrationAction::KeepCurrent
                 | ExistingRegistrationAction::RetainOwnedRecovery
                 | ExistingRegistrationAction::IgnoreForeign => {}
+                ExistingRegistrationAction::ReportOwnedPathConflict => {
+                    return Err(Box::new(OwnedPathConflict));
+                }
                 ExistingRegistrationAction::RejectUnsafeCurrent => {
                     return Err(Box::new(UnsafeRegistrationConflict));
                 }
@@ -823,6 +842,14 @@ mod tests {
                 OwnedCurrentRegistrationState::UnsafeExistingPath,
             ),
             ExistingRegistrationAction::RetainOwnedRecovery
+        );
+        assert_eq!(
+            existing_registration_action(
+                false,
+                true,
+                OwnedCurrentRegistrationState::RequestedRootConflict,
+            ),
+            ExistingRegistrationAction::ReportOwnedPathConflict
         );
         assert_eq!(
             existing_registration_action(false, false, OwnedCurrentRegistrationState::Ready),

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -22,6 +22,31 @@ fn paths_refer_to_same_existing_entry(
     Ok(first.canonicalize()? == second.canonicalize()?)
 }
 
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
+enum ExistingRegistrationAction {
+    KeepCurrent,
+    ReplaceCurrent,
+    RemoveStaleOwned,
+    IgnoreForeign,
+    RejectForeignCurrent,
+}
+
+#[cfg(any(windows, test))]
+fn existing_registration_action(
+    current_id: bool,
+    provider_owned: bool,
+    current_metadata: bool,
+) -> ExistingRegistrationAction {
+    match (current_id, provider_owned, current_metadata) {
+        (true, true, true) => ExistingRegistrationAction::KeepCurrent,
+        (true, true, false) => ExistingRegistrationAction::ReplaceCurrent,
+        (true, false, _) => ExistingRegistrationAction::RejectForeignCurrent,
+        (false, true, _) => ExistingRegistrationAction::RemoveStaleOwned,
+        (false, false, _) => ExistingRegistrationAction::IgnoreForeign,
+    }
+}
+
 #[cfg(windows)]
 #[derive(Debug)]
 struct OwnedPathConflict;
@@ -141,9 +166,9 @@ fn sid_string(bytes: &[u8]) -> Option<String> {
 #[cfg(windows)]
 mod platform {
     use super::{
-        OwnedPathConflict, PROVIDER_ID, RegistrationNotFound, UnsafeRegistrationConflict,
-        decode_identity_hex, is_windows_absence_hresult, paths_refer_to_same_existing_entry,
-        sid_string, valid_account_id, valid_display_name,
+        ExistingRegistrationAction, PROVIDER_ID, RegistrationNotFound, UnsafeRegistrationConflict,
+        decode_identity_hex, existing_registration_action, is_windows_absence_hresult,
+        paths_refer_to_same_existing_entry, sid_string, valid_account_id, valid_display_name,
     };
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
@@ -175,6 +200,29 @@ mod platform {
             return Ok(true);
         }
         paths_refer_to_same_existing_entry(&PathBuf::from(path.to_os_string()), requested)
+    }
+
+    fn current_registration_metadata_matches(
+        existing: &StorageProviderSyncRootInfo,
+        root: &Path,
+        display_name: &HSTRING,
+        icon_resource: &HSTRING,
+        context: &windows::Storage::Streams::IBuffer,
+    ) -> bool {
+        let matches = || -> WindowsResult<bool> {
+            let existing_path = existing.Path()?.Path()?;
+            if registered_path_is_missing(&existing_path).unwrap_or(false)
+                || !registered_path_matches(&existing_path, root).unwrap_or(false)
+            {
+                return Ok(false);
+            }
+            Ok(existing.DisplayNameResource()? == *display_name
+                && existing.IconResource()? == *icon_resource
+                && CryptographicBuffer::Compare(&existing.Context()?, context)?)
+        };
+        // Once the stable ID and provider GUID prove ownership, unreadable or incomplete
+        // properties are stale metadata to replace, not a reason to strand the account.
+        matches().unwrap_or(false)
     }
 
     fn unregister_owned_registration(id: &HSTRING) -> windows::core::Result<()> {
@@ -303,42 +351,65 @@ mod platform {
         let context = CryptographicBuffer::CreateFromByteArray(&identity)?;
 
         let id = sync_root_id(&account_id)?;
+        let mut current_registration_is_ready = false;
         match StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
             Ok(existing) => {
-                if existing.ProviderId()? != PROVIDER_GUID {
-                    return Err(Box::new(UnsafeRegistrationConflict));
-                }
-                match existing.Path().and_then(|folder| folder.Path()) {
-                    Ok(existing_path) if registered_path_is_missing(&existing_path)? => {}
-                    Ok(existing_path) if registered_path_matches(&existing_path, &root)? => {
-                        if existing.DisplayNameResource()? == display_name
-                            && existing.IconResource()? == icon_resource
-                            && CryptographicBuffer::Compare(&existing.Context()?, &context)?
-                        {
-                            return Ok(());
-                        }
+                let provider_owned = existing.ProviderId()? == PROVIDER_GUID;
+                let current_metadata = provider_owned
+                    && current_registration_metadata_matches(
+                        &existing,
+                        &root,
+                        &display_name,
+                        &icon_resource,
+                        &context,
+                    );
+                match existing_registration_action(true, provider_owned, current_metadata) {
+                    ExistingRegistrationAction::KeepCurrent => {
+                        current_registration_is_ready = true;
                     }
-                    Ok(_) => return Err(Box::new(UnsafeRegistrationConflict)),
-                    Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
-                    Err(failure) => return Err(failure.into()),
+                    ExistingRegistrationAction::ReplaceCurrent => {
+                        // Unregistering changes only Windows provider metadata. The old directory
+                        // and every local file in it remain untouched for manual recovery.
+                        unregister_owned_registration(&id)?;
+                    }
+                    ExistingRegistrationAction::RejectForeignCurrent => {
+                        return Err(Box::new(UnsafeRegistrationConflict));
+                    }
+                    ExistingRegistrationAction::RemoveStaleOwned
+                    | ExistingRegistrationAction::IgnoreForeign => unreachable!(),
                 }
-                unregister_owned_registration(&id)?;
             }
             Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
             Err(failure) => return Err(failure.into()),
         }
         for existing in StorageProviderSyncRootManager::GetCurrentSyncRoots()? {
-            if existing.Id()? != id && existing.ProviderId()? == PROVIDER_GUID {
-                match existing.Path().and_then(|folder| folder.Path()) {
-                    Ok(existing_path) if registered_path_is_missing(&existing_path)? => {}
-                    Ok(existing_path) if registered_path_matches(&existing_path, &root)? => {
-                        return Err(Box::new(OwnedPathConflict));
-                    }
-                    Ok(_) => {}
-                    Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
-                    Err(failure) => return Err(failure.into()),
+            let Ok(existing_id) = existing.Id() else {
+                continue;
+            };
+            let Ok(existing_provider_id) = existing.ProviderId() else {
+                continue;
+            };
+            match existing_registration_action(
+                existing_id == id,
+                existing_provider_id == PROVIDER_GUID,
+                current_registration_is_ready,
+            ) {
+                ExistingRegistrationAction::ReplaceCurrent
+                | ExistingRegistrationAction::RemoveStaleOwned => {
+                    // Older versions could leave account registrations behind after an interrupted
+                    // setup or sign-out. Removing the registration never deletes its directory.
+                    unregister_owned_registration(&existing_id)?;
+                }
+                ExistingRegistrationAction::KeepCurrent
+                | ExistingRegistrationAction::IgnoreForeign => {}
+                ExistingRegistrationAction::RejectForeignCurrent => {
+                    return Err(Box::new(UnsafeRegistrationConflict));
                 }
             }
+        }
+
+        if current_registration_is_ready {
+            return Ok(());
         }
 
         let info = StorageProviderSyncRootInfo::new()?;
@@ -552,5 +623,29 @@ mod tests {
         );
 
         std::fs::remove_dir_all(&base).expect("remove path-equivalence fixture");
+    }
+
+    #[test]
+    fn removes_only_stale_owned_registrations() {
+        assert_eq!(
+            existing_registration_action(true, true, true),
+            ExistingRegistrationAction::KeepCurrent
+        );
+        assert_eq!(
+            existing_registration_action(true, true, false),
+            ExistingRegistrationAction::ReplaceCurrent
+        );
+        assert_eq!(
+            existing_registration_action(false, true, false),
+            ExistingRegistrationAction::RemoveStaleOwned
+        );
+        assert_eq!(
+            existing_registration_action(false, false, false),
+            ExistingRegistrationAction::IgnoreForeign
+        );
+        assert_eq!(
+            existing_registration_action(true, false, false),
+            ExistingRegistrationAction::RejectForeignCurrent
+        );
     }
 }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -273,6 +273,32 @@ internal fun windowsCloudFilesRootPreferenceKey(accountId: String): String {
     }
 }
 
+internal fun persistedWindowsCloudFilesRecoveryRoots(
+    preferences: Preferences = Preferences.userRoot().node("dev/obiente/nextcloudnative"),
+): Map<String, Path> = preferences.keys()
+    .asSequence()
+    .filter { key -> key.startsWith(KEY_WINDOWS_CLOUD_FILES_ROOT_PREFIX) }
+    .mapNotNull { key ->
+        val accountId = key.removePrefix(KEY_WINDOWS_CLOUD_FILES_ROOT_PREFIX)
+        if (accountId.length != 64 || accountId.any { it !in '0'..'9' && it !in 'a'..'f' }) {
+            return@mapNotNull null
+        }
+        val value = preferences.get(key, null)
+            ?.takeIf { it.length <= Preferences.MAX_VALUE_LENGTH }
+            ?: return@mapNotNull null
+        val path = runCatching { File(value).toPath().normalize() }.getOrNull()
+            ?.takeIf(Path::isAbsolute)
+            ?: return@mapNotNull null
+        if (
+            !Files.isDirectory(path, java.nio.file.LinkOption.NOFOLLOW_LINKS) ||
+            Files.isSymbolicLink(path)
+        ) {
+            return@mapNotNull null
+        }
+        accountId to path
+    }
+    .toMap()
+
 private fun desktopLegacyWindowsCloudFilesRoot(accountId: String, userHome: File): File =
     File(File(userHome, "Nextcloud Native"), accountId)
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -159,7 +159,6 @@ private const val VIRTUAL_FOLDER_REFRESH_INTERVAL_MILLIS = 6L * 60L * 60L * 1_00
 private const val VIRTUAL_FOLDER_REFRESH_RETRY_MILLIS = 30L * 60L * 1_000L
 private const val KEY_WINDOWS_CLOUD_FILES_ROOT = "windows-cloud-files-root"
 private const val KEY_WINDOWS_CLOUD_FILES_ROOT_PREFIX = "wcfr."
-private const val KEY_VIRTUAL_FILE_PROVIDER_ACTIVE_PREFIX = "vfp-active."
 private const val KEY_VIRTUAL_FILE_ROOT_PREFIX = "vfp-root."
 private const val WINDOWS_CLOUD_FILES_ROOT_SUFFIX = "-v2"
 
@@ -304,28 +303,6 @@ private fun clearWindowsCloudFilesRootPreferences(
     }
 }
 
-internal fun clearStaleWindowsCloudFilesPreferences(
-    preferences: Preferences,
-    activeAccountId: String,
-) {
-    require(activeAccountId.length == 64 && activeAccountId.all { it in '0'..'9' || it in 'a'..'f' })
-    val activeKeys = setOf(
-        windowsCloudFilesRootPreferenceKey(activeAccountId),
-        virtualFileProviderPreferenceKey(activeAccountId),
-    )
-    preferences.keys().forEach { key ->
-        val accountScoped = listOf(
-            KEY_WINDOWS_CLOUD_FILES_ROOT_PREFIX,
-            KEY_VIRTUAL_FILE_PROVIDER_ACTIVE_PREFIX,
-        ).any { prefix ->
-            key.startsWith(prefix) && key.removePrefix(prefix).let { accountId ->
-                accountId.length == 64 && accountId.all { it in '0'..'9' || it in 'a'..'f' }
-            }
-        }
-        if (accountScoped && key !in activeKeys) preferences.remove(key)
-    }
-}
-
 internal fun unregisterWindowsCloudFilesRootForUninstall(
     preferences: Preferences = Preferences.userRoot().node("dev/obiente/nextcloudnative"),
     userHome: File = File(System.getProperty("user.home")),
@@ -390,7 +367,7 @@ private fun validatedWindowsCloudFilesRoot(root: File, userHome: File): Path {
 
 internal fun virtualFileProviderPreferenceKey(accountId: String): String {
     require(accountId.length == 64 && accountId.all { it in '0'..'9' || it in 'a'..'f' })
-    return "$KEY_VIRTUAL_FILE_PROVIDER_ACTIVE_PREFIX$accountId".also { key ->
+    return "vfp-active.$accountId".also { key ->
         check(key.length <= Preferences.MAX_KEY_LENGTH)
     }
 }
@@ -1548,9 +1525,6 @@ class DesktopNextcloudServices(
                         windowsCloudFilesRootPreferenceKey(accountId),
                         root.toAbsolutePath().toString(),
                     )
-                    // Preference cleanup is repair bookkeeping. A transient backing-store failure
-                    // must not disconnect a provider that Windows already registered successfully.
-                    runCatching { clearStaleWindowsCloudFilesPreferences(preferences, accountId) }
                     preferences.remove(KEY_WINDOWS_CLOUD_FILES_ROOT)
                     preferences.putBoolean(virtualFileProviderPreferenceKey(accountId), true)
                 } catch (failure: Throwable) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -159,6 +159,7 @@ private const val VIRTUAL_FOLDER_REFRESH_INTERVAL_MILLIS = 6L * 60L * 60L * 1_00
 private const val VIRTUAL_FOLDER_REFRESH_RETRY_MILLIS = 30L * 60L * 1_000L
 private const val KEY_WINDOWS_CLOUD_FILES_ROOT = "windows-cloud-files-root"
 private const val KEY_WINDOWS_CLOUD_FILES_ROOT_PREFIX = "wcfr."
+private const val KEY_VIRTUAL_FILE_PROVIDER_ACTIVE_PREFIX = "vfp-active."
 private const val KEY_VIRTUAL_FILE_ROOT_PREFIX = "vfp-root."
 private const val WINDOWS_CLOUD_FILES_ROOT_SUFFIX = "-v2"
 
@@ -303,6 +304,28 @@ private fun clearWindowsCloudFilesRootPreferences(
     }
 }
 
+internal fun clearStaleWindowsCloudFilesPreferences(
+    preferences: Preferences,
+    activeAccountId: String,
+) {
+    require(activeAccountId.length == 64 && activeAccountId.all { it in '0'..'9' || it in 'a'..'f' })
+    val activeKeys = setOf(
+        windowsCloudFilesRootPreferenceKey(activeAccountId),
+        virtualFileProviderPreferenceKey(activeAccountId),
+    )
+    preferences.keys().forEach { key ->
+        val accountScoped = listOf(
+            KEY_WINDOWS_CLOUD_FILES_ROOT_PREFIX,
+            KEY_VIRTUAL_FILE_PROVIDER_ACTIVE_PREFIX,
+        ).any { prefix ->
+            key.startsWith(prefix) && key.removePrefix(prefix).let { accountId ->
+                accountId.length == 64 && accountId.all { it in '0'..'9' || it in 'a'..'f' }
+            }
+        }
+        if (accountScoped && key !in activeKeys) preferences.remove(key)
+    }
+}
+
 internal fun unregisterWindowsCloudFilesRootForUninstall(
     preferences: Preferences = Preferences.userRoot().node("dev/obiente/nextcloudnative"),
     userHome: File = File(System.getProperty("user.home")),
@@ -367,7 +390,7 @@ private fun validatedWindowsCloudFilesRoot(root: File, userHome: File): Path {
 
 internal fun virtualFileProviderPreferenceKey(accountId: String): String {
     require(accountId.length == 64 && accountId.all { it in '0'..'9' || it in 'a'..'f' })
-    return "vfp-active.$accountId".also { key ->
+    return "$KEY_VIRTUAL_FILE_PROVIDER_ACTIVE_PREFIX$accountId".also { key ->
         check(key.length <= Preferences.MAX_KEY_LENGTH)
     }
 }
@@ -1525,6 +1548,9 @@ class DesktopNextcloudServices(
                         windowsCloudFilesRootPreferenceKey(accountId),
                         root.toAbsolutePath().toString(),
                     )
+                    // Preference cleanup is repair bookkeeping. A transient backing-store failure
+                    // must not disconnect a provider that Windows already registered successfully.
+                    runCatching { clearStaleWindowsCloudFilesPreferences(preferences, accountId) }
                     preferences.remove(KEY_WINDOWS_CLOUD_FILES_ROOT)
                     preferences.putBoolean(virtualFileProviderPreferenceKey(accountId), true)
                 } catch (failure: Throwable) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -159,6 +159,8 @@ private const val VIRTUAL_FOLDER_REFRESH_INTERVAL_MILLIS = 6L * 60L * 60L * 1_00
 private const val VIRTUAL_FOLDER_REFRESH_RETRY_MILLIS = 30L * 60L * 1_000L
 private const val KEY_WINDOWS_CLOUD_FILES_ROOT = "windows-cloud-files-root"
 private const val KEY_WINDOWS_CLOUD_FILES_ROOT_PREFIX = "wcfr."
+private const val KEY_WINDOWS_CLOUD_FILES_RECOVERY_CURSOR = "windows-cloud-files-recovery-cursor"
+private const val MAX_WINDOWS_CLOUD_FILES_RECOVERY_ROOTS_PER_ATTEMPT = 16
 private const val KEY_VIRTUAL_FILE_ROOT_PREFIX = "vfp-root."
 private const val WINDOWS_CLOUD_FILES_ROOT_SUFFIX = "-v2"
 
@@ -298,6 +300,38 @@ internal fun persistedWindowsCloudFilesRecoveryRoots(
         accountId to path
     }
     .toMap()
+
+internal fun pageWindowsCloudFilesRecoveryRoots(
+    roots: Map<String, Path>,
+    startAfterAccountId: String?,
+    limit: Int = MAX_WINDOWS_CLOUD_FILES_RECOVERY_ROOTS_PER_ATTEMPT,
+): Map<String, Path> {
+    require(limit > 0)
+    if (roots.isEmpty()) return emptyMap()
+    val ordered = roots.entries.sortedBy(Map.Entry<String, Path>::key)
+    val startIndex = startAfterAccountId
+        ?.let { cursor -> ordered.indexOfFirst { it.key > cursor } }
+        ?.takeIf { it >= 0 }
+        ?: 0
+    return (0 until minOf(limit, ordered.size))
+        .map { offset -> ordered[(startIndex + offset) % ordered.size] }
+        .associate(Map.Entry<String, Path>::toPair)
+}
+
+internal fun pagedPersistedWindowsCloudFilesRecoveryRoots(
+    preferences: Preferences = Preferences.userRoot().node("dev/obiente/nextcloudnative"),
+): Map<String, Path> {
+    val page = pageWindowsCloudFilesRecoveryRoots(
+        roots = persistedWindowsCloudFilesRecoveryRoots(preferences),
+        startAfterAccountId = preferences.get(KEY_WINDOWS_CLOUD_FILES_RECOVERY_CURSOR, null),
+    )
+    if (page.isEmpty()) {
+        preferences.remove(KEY_WINDOWS_CLOUD_FILES_RECOVERY_CURSOR)
+    } else {
+        preferences.put(KEY_WINDOWS_CLOUD_FILES_RECOVERY_CURSOR, page.keys.last())
+    }
+    return page
+}
 
 private fun desktopLegacyWindowsCloudFilesRoot(accountId: String, userHome: File): File =
     File(File(userHome, "Nextcloud Native"), accountId)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
@@ -33,7 +33,7 @@ internal enum class WindowsShellUnregistrationResult {
 internal class PackagedWindowsCloudShellRegistrar(
     launcherPath: String? = packagedDesktopLauncherPath(),
     private val recoveryRootsProvider: () -> Map<String, Path> = {
-        runCatching(::persistedWindowsCloudFilesRecoveryRoots).getOrDefault(emptyMap())
+        runCatching(::pagedPersistedWindowsCloudFilesRecoveryRoots).getOrDefault(emptyMap())
     },
     private val processRunner: (List<String>, Long) -> Int? = ::runWindowsShellRegistrar,
 ) : WindowsCloudShellRegistrar {
@@ -80,7 +80,6 @@ internal class PackagedWindowsCloudShellRegistrar(
                     !Files.isSymbolicLink(recoveryRoot)
             }
             .sortedBy(Map.Entry<String, Path>::key)
-            .take(MAX_RECOVERY_ROOTS)
             .forEach { (recoveryAccountId, recoveryRoot) ->
                 command += listOf(
                     RECOVERABLE_ROOT_ARGUMENT,
@@ -121,7 +120,6 @@ internal class PackagedWindowsCloudShellRegistrar(
 
     private companion object {
         const val MAX_SYNC_ROOT_IDENTITY_BYTES = 4_096
-        const val MAX_RECOVERY_ROOTS = 16
         const val MAX_RECOVERY_ROOT_PATH_CHARACTERS = 1_024
         const val REGISTRATION_TIMEOUT_SECONDS = 30L
         const val RECOVERABLE_ROOT_ARGUMENT = "--recoverable-root"

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrar.kt
@@ -32,6 +32,9 @@ internal enum class WindowsShellUnregistrationResult {
 
 internal class PackagedWindowsCloudShellRegistrar(
     launcherPath: String? = packagedDesktopLauncherPath(),
+    private val recoveryRootsProvider: () -> Map<String, Path> = {
+        runCatching(::persistedWindowsCloudFilesRecoveryRoots).getOrDefault(emptyMap())
+    },
     private val processRunner: (List<String>, Long) -> Int? = ::runWindowsShellRegistrar,
 ) : WindowsCloudShellRegistrar {
     private val installationDirectory = launcherPath
@@ -57,17 +60,37 @@ internal class PackagedWindowsCloudShellRegistrar(
         require(Files.isDirectory(normalizedRoot) && !Files.isSymbolicLink(normalizedRoot))
         val executable = helper?.takeIf(File::isFile) ?: return WindowsShellRegistrationResult.Failed
         val iconResource = icon?.takeIf(File::isFile) ?: return WindowsShellRegistrationResult.Failed
+        val command = mutableListOf(
+            executable.absolutePath,
+            "register",
+            normalizedRoot.toString(),
+            accountId,
+            displayName,
+            iconResource.absolutePath,
+            syncRootIdentity.lowercaseHex(),
+        )
+        recoveryRootsProvider()
+            .asSequence()
+            .filter { (recoveryAccountId, recoveryRoot) ->
+                recoveryAccountId != accountId &&
+                    isWindowsShellAccountId(recoveryAccountId) &&
+                    recoveryRoot.isAbsolute &&
+                    recoveryRoot.toString().length <= MAX_RECOVERY_ROOT_PATH_CHARACTERS &&
+                    Files.isDirectory(recoveryRoot, java.nio.file.LinkOption.NOFOLLOW_LINKS) &&
+                    !Files.isSymbolicLink(recoveryRoot)
+            }
+            .sortedBy(Map.Entry<String, Path>::key)
+            .take(MAX_RECOVERY_ROOTS)
+            .forEach { (recoveryAccountId, recoveryRoot) ->
+                command += listOf(
+                    RECOVERABLE_ROOT_ARGUMENT,
+                    recoveryAccountId,
+                    recoveryRoot.normalize().toString(),
+                )
+            }
         val exitCode = runCatching {
             processRunner(
-                listOf(
-                    executable.absolutePath,
-                    "register",
-                    normalizedRoot.toString(),
-                    accountId,
-                    displayName,
-                    iconResource.absolutePath,
-                    syncRootIdentity.lowercaseHex(),
-                ),
+                command,
                 REGISTRATION_TIMEOUT_SECONDS,
             )
         }.getOrNull()
@@ -98,7 +121,10 @@ internal class PackagedWindowsCloudShellRegistrar(
 
     private companion object {
         const val MAX_SYNC_ROOT_IDENTITY_BYTES = 4_096
+        const val MAX_RECOVERY_ROOTS = 16
+        const val MAX_RECOVERY_ROOT_PATH_CHARACTERS = 1_024
         const val REGISTRATION_TIMEOUT_SECONDS = 30L
+        const val RECOVERABLE_ROOT_ARGUMENT = "--recoverable-root"
     }
 }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
@@ -53,6 +53,52 @@ class WindowsCloudShellRegistrarTest {
     }
 
     @Test
+    fun passesOnlyDurablyRecordedLiveRecoveryRoots() {
+        val installation = createTempDirectory("nextcloud-shell-recovery-roots").toFile()
+        val launcher = installation.resolve("NextcloudNative.exe").apply { writeText("launcher") }
+        installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).writeText("helper")
+        installation.resolve(WINDOWS_SHELL_ICON_NAME).writeText("icon")
+        val root = installation.resolve("Current root").toPath().createDirectories()
+        val recoveryRoot = installation.resolve("Previous root").toPath().createDirectories()
+        val currentAccountId = "a5".repeat(32)
+        val recoveryAccountId = "b6".repeat(32)
+        var invocation = emptyList<String>()
+        val registrar = PackagedWindowsCloudShellRegistrar(
+            launcherPath = launcher.absolutePath,
+            recoveryRootsProvider = {
+                mapOf(
+                    recoveryAccountId to recoveryRoot,
+                    currentAccountId to root,
+                    "invalid" to recoveryRoot,
+                )
+            },
+        ) { command, _ ->
+            invocation = command
+            0
+        }
+
+        assertEquals(
+            WindowsShellRegistrationResult.Registered,
+            registrar.register(root, currentAccountId, "Nextcloud Native", byteArrayOf(1)),
+        )
+        assertEquals(
+            listOf(
+                installation.resolve(WINDOWS_SHELL_REGISTRAR_NAME).absolutePath,
+                "register",
+                root.toAbsolutePath().normalize().toString(),
+                currentAccountId,
+                "Nextcloud Native",
+                installation.resolve(WINDOWS_SHELL_ICON_NAME).absolutePath,
+                "01",
+                "--recoverable-root",
+                recoveryAccountId,
+                recoveryRoot.normalize().toString(),
+            ),
+            invocation,
+        )
+    }
+
+    @Test
     fun missingPackagedFilesDoNotAttemptRegistration() {
         val installation = createTempDirectory("nextcloud-shell-missing").toFile()
         val launcher = installation.resolve("NextcloudNative.exe").apply { writeText("launcher") }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -11,6 +11,31 @@ import kotlin.test.assertTrue
 
 class WindowsUninstallCleanupTest {
     @Test
+    fun loadsOnlyLiveAccountScopedRecoveryRoots() {
+        val preferences = Preferences.userRoot().node("windows-recovery-root-test-${UUID.randomUUID()}")
+        val home = Files.createTempDirectory("windows-recovery-root-home").toFile()
+        val liveAccountId = "a".repeat(64)
+        val missingAccountId = "b".repeat(64)
+        val liveRoot = home.resolve("live").apply { assertTrue(mkdirs()) }
+        try {
+            preferences.put(windowsCloudFilesRootPreferenceKey(liveAccountId), liveRoot.absolutePath)
+            preferences.put(
+                windowsCloudFilesRootPreferenceKey(missingAccountId),
+                home.resolve("missing").absolutePath,
+            )
+            preferences.put("wcfr.future-format", liveRoot.absolutePath)
+
+            assertEquals(
+                mapOf(liveAccountId to liveRoot.toPath()),
+                persistedWindowsCloudFilesRecoveryRoots(preferences),
+            )
+        } finally {
+            preferences.removeNode()
+            home.deleteRecursively()
+        }
+    }
+
+    @Test
     fun cloudFilesCleanupTreatsOnlyMissingRootsAsAlreadyAbsent() {
         assertTrue(isWindowsCloudFilesRootAbsentResult(0xC000CF13.toInt(), rootMissing = false))
         assertTrue(isWindowsCloudFilesRootAbsentResult(0xD000CF13.toInt(), rootMissing = false))

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -1,5 +1,6 @@
 package dev.obiente.nextcloudnative.app
 
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
@@ -33,6 +34,24 @@ class WindowsUninstallCleanupTest {
             preferences.removeNode()
             home.deleteRecursively()
         }
+    }
+
+    @Test
+    fun pagesAcrossAllRecoveryRootsInsteadOfRepeatingTheFirstPage() {
+        val roots = (0 until 18).associate { index ->
+            index.toString(16).padStart(64, '0') to File("C:/recovery/$index").toPath()
+        }
+
+        val first = pageWindowsCloudFilesRecoveryRoots(roots, startAfterAccountId = null)
+        val second = pageWindowsCloudFilesRecoveryRoots(
+            roots,
+            startAfterAccountId = first.keys.last(),
+        )
+
+        assertEquals(16, first.size)
+        assertEquals(16, second.size)
+        assertTrue(roots.keys.drop(16).all(second::containsKey))
+        assertFalse(first.keys == second.keys)
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -43,6 +43,45 @@ class WindowsUninstallCleanupTest {
     }
 
     @Test
+    fun successfulActivationClearsOnlyStaleAccountPreferencesAndKeepsLocalFiles() {
+        val preferences = Preferences.userRoot().node("windows-stale-account-test-${UUID.randomUUID()}")
+        val home = Files.createTempDirectory("windows-stale-account-home").toFile()
+        val activeAccountId = "a".repeat(64)
+        val staleAccountId = "b".repeat(64)
+        val staleRoot = desktopWindowsCloudFilesRoot(staleAccountId, home).apply {
+            assertTrue(mkdirs())
+        }
+        val localFile = staleRoot.resolve("kept-local-file.txt").apply { writeText("local data") }
+        val activeRootKey = windowsCloudFilesRootPreferenceKey(activeAccountId)
+        val staleRootKey = windowsCloudFilesRootPreferenceKey(staleAccountId)
+        val activeStateKey = virtualFileProviderPreferenceKey(activeAccountId)
+        val staleStateKey = virtualFileProviderPreferenceKey(staleAccountId)
+        try {
+            preferences.put(activeRootKey, desktopWindowsCloudFilesRoot(activeAccountId, home).absolutePath)
+            preferences.put(staleRootKey, staleRoot.absolutePath)
+            preferences.putBoolean(activeStateKey, true)
+            preferences.putBoolean(staleStateKey, true)
+            preferences.put("wcfr.future-format", "keep")
+
+            clearStaleWindowsCloudFilesPreferences(preferences, activeAccountId)
+
+            assertEquals(
+                desktopWindowsCloudFilesRoot(activeAccountId, home).absolutePath,
+                preferences.get(activeRootKey, null),
+            )
+            assertTrue(preferences.getBoolean(activeStateKey, false))
+            assertEquals(null, preferences.get(staleRootKey, null))
+            assertEquals(null, preferences.get(staleStateKey, null))
+            assertEquals("keep", preferences.get("wcfr.future-format", null))
+            assertTrue(localFile.isFile)
+            assertEquals("local data", localFile.readText())
+        } finally {
+            preferences.removeNode()
+            home.deleteRecursively()
+        }
+    }
+
+    @Test
     fun uninstallUnregistersThePersistedAccountsCloudFilesRoot() {
         val preferences = Preferences.userRoot().node("windows-uninstall-test-${UUID.randomUUID()}")
         val home = Files.createTempDirectory("windows-uninstall-home").toFile()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsUninstallCleanupTest.kt
@@ -43,45 +43,6 @@ class WindowsUninstallCleanupTest {
     }
 
     @Test
-    fun successfulActivationClearsOnlyStaleAccountPreferencesAndKeepsLocalFiles() {
-        val preferences = Preferences.userRoot().node("windows-stale-account-test-${UUID.randomUUID()}")
-        val home = Files.createTempDirectory("windows-stale-account-home").toFile()
-        val activeAccountId = "a".repeat(64)
-        val staleAccountId = "b".repeat(64)
-        val staleRoot = desktopWindowsCloudFilesRoot(staleAccountId, home).apply {
-            assertTrue(mkdirs())
-        }
-        val localFile = staleRoot.resolve("kept-local-file.txt").apply { writeText("local data") }
-        val activeRootKey = windowsCloudFilesRootPreferenceKey(activeAccountId)
-        val staleRootKey = windowsCloudFilesRootPreferenceKey(staleAccountId)
-        val activeStateKey = virtualFileProviderPreferenceKey(activeAccountId)
-        val staleStateKey = virtualFileProviderPreferenceKey(staleAccountId)
-        try {
-            preferences.put(activeRootKey, desktopWindowsCloudFilesRoot(activeAccountId, home).absolutePath)
-            preferences.put(staleRootKey, staleRoot.absolutePath)
-            preferences.putBoolean(activeStateKey, true)
-            preferences.putBoolean(staleStateKey, true)
-            preferences.put("wcfr.future-format", "keep")
-
-            clearStaleWindowsCloudFilesPreferences(preferences, activeAccountId)
-
-            assertEquals(
-                desktopWindowsCloudFilesRoot(activeAccountId, home).absolutePath,
-                preferences.get(activeRootKey, null),
-            )
-            assertTrue(preferences.getBoolean(activeStateKey, false))
-            assertEquals(null, preferences.get(staleRootKey, null))
-            assertEquals(null, preferences.get(staleStateKey, null))
-            assertEquals("keep", preferences.get("wcfr.future-format", null))
-            assertTrue(localFile.isFile)
-            assertEquals("local data", localFile.readText())
-        } finally {
-            preferences.removeNode()
-            home.deleteRecursively()
-        }
-    }
-
-    @Test
     fun uninstallUnregistersThePersistedAccountsCloudFilesRoot() {
         val preferences = Preferences.userRoot().node("windows-uninstall-test-${UUID.randomUUID()}")
         val home = Files.createTempDirectory("windows-uninstall-home").toFile()


### PR DESCRIPTION
## Summary

- remove obsolete owned registrations when their directory is gone or its live path has an exact durable account-scoped recovery record
- repair owned current-account metadata only when its root is missing or still resolves to the requested directory
- preserve all root contents, reject unproven ownership, and retain recovery paths and preferences after virtual-provider cleanup

## Root cause

The shell registrar previously reconciled only the current stable registration ID and returned a conflict when another Nextcloud Native account still had an obsolete registration. Those registrations could therefore remain in File Explorer without a running provider. The follow-up recovery on `main` avoided one terminal exception but did not enumerate obsolete owned registrations, and its missing changelog fragment prevented that recovery from reaching a nightly.

## Safety and limitations

- Cleanup requires the Nextcloud Native provider GUID before unregistering anything.
- A registration using a foreign provider identity is never changed.
- A live non-current registration is removed only when its stable account ID and canonical path match an existing account-scoped recovery preference.
- A current registration pointing to a different existing directory is retained for explicit recovery.
- Unregistration does not delete, rename, recursively traverse, dehydrate, or convert any file or directory.
- Account-scoped root preferences remain as durable recovery pointers; exact-root cleanup removes them only after confirmed unregistration.

## Validation

- `cargo test --locked`
- `cargo clippy --locked --target x86_64-pc-windows-msvc --bin nextcloud-native-shell-registrar -- -D warnings`
- `cargo check --locked --target x86_64-pc-windows-msvc --bin nextcloud-native-shell-registrar`
- `./gradlew --no-daemon :ui:desktopTest`
- `bash tools/check-repository.sh`
- `cargo fmt --check`
- `git diff --check`

## Relationships

- Closes #312
- Advances #11
- Follow-up to #296
- Follow-up to #300
