### PR TITLE
fix(windows): recover placeholder creation collisions

### DIFF
--- a/changes/unreleased/315-windows-placeholder-collision.md
+++ b/changes/unreleased/315-windows-placeholder-collision.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 315
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows filesync now recovers when Explorer creates the same placeholder concurrently, while preserving ordinary local entries for safe recovery.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -647,6 +647,9 @@ internal fun isWindowsCloudFilesRegistrationMissingResult(result: Int): Boolean 
 internal fun isWindowsCloudFilesConnectionAbsentResult(result: Int): Boolean =
     result == 0x80070057.toInt() // HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER)
 
+internal fun isWindowsCloudFilesPlaceholderAlreadyExistsResult(result: Int): Boolean =
+    result == 0x800700B7.toInt() // HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)
+
 internal class WindowsCloudFilesOperationException(
     operation: String,
     val hResult: Int,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -723,11 +723,14 @@ internal class WindowsCloudFilesProvider(
     ) {
         val localPath = localDirectory.resolve(identity.path.substringAfterLast('/'))
         var collision = initialFailure
+        var identityUnavailable = false
         repeat(MAX_PLACEHOLDER_COLLISION_RETRIES) {
             val state = api.placeholderState(localPath)
             if (state != WindowsCloudPlaceholderState.Absent) {
-                reconcileExistingPlaceholder(identity, localPath, state)
-                return
+                if (reconcileCollidedPlaceholder(identity, localPath, state)) return
+                identityUnavailable = true
+                Thread.sleep(PLACEHOLDER_COLLISION_RETRY_DELAY_MILLIS)
+                return@repeat
             }
             if (Files.exists(localPath, LinkOption.NOFOLLOW_LINKS)) {
                 // Preserve an ordinary local entry. Startup recovery will import it with
@@ -743,7 +746,45 @@ internal class WindowsCloudFilesProvider(
                 collision = failure
             }
         }
+        if (identityUnavailable) {
+            throw IllegalStateException(
+                "Could not verify the existing Windows Cloud Files placeholder after a creation collision.",
+                collision,
+            )
+        }
         throw collision
+    }
+
+    private fun reconcileCollidedPlaceholder(
+        listedIdentity: WindowsCloudFileIdentity,
+        localPath: Path,
+        state: WindowsCloudPlaceholderState,
+    ): Boolean {
+        val existing = api.placeholderIdentity(localPath)
+            ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
+            ?: return false
+        check(existing.accountId == backend.accountId && existing.path == listedIdentity.path) {
+            "The Windows Cloud Files directory contains remote entries that resolve to the same Windows path."
+        }
+        if (state == WindowsCloudPlaceholderState.Dirty) {
+            knownIdentities[existing.path] = existing
+            return true
+        }
+        check(state == WindowsCloudPlaceholderState.InSync)
+        val authoritative = if (existing == listedIdentity) {
+            existing
+        } else {
+            resolveAuthoritativePlaceholderIdentity(listedIdentity)
+        }
+        if (existing != authoritative) {
+            api.updatePlaceholder(
+                localPath,
+                placeholder(authoritative),
+                invalidateContent = !authoritative.directory,
+            )
+        }
+        knownIdentities[authoritative.path] = authoritative
+        return true
     }
 
     private fun reconcileExistingPlaceholder(
@@ -755,25 +796,45 @@ internal class WindowsCloudFilesProvider(
             ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
         when (state) {
             WindowsCloudPlaceholderState.InSync -> {
+                check(previous == null || previous.accountId == backend.accountId && previous.path == identity.path) {
+                    "The Windows Cloud Files directory contains remote entries that resolve to the same Windows path."
+                }
+                val authoritative = when {
+                    previous == null || previous == identity -> identity
+                    else -> resolveAuthoritativePlaceholderIdentity(identity)
+                }
                 val changed = previous == null ||
-                    previous.accountId != identity.accountId ||
-                    previous.path != identity.path ||
-                    previous.remoteRevision != identity.remoteRevision ||
-                    previous.size != identity.size ||
-                    previous.directory != identity.directory
+                    previous.remoteRevision != authoritative.remoteRevision ||
+                    previous.size != authoritative.size ||
+                    previous.directory != authoritative.directory ||
+                    previous.lastModifiedEpochMillis != authoritative.lastModifiedEpochMillis
                 api.updatePlaceholder(
                     localPath,
-                    placeholder(identity),
-                    invalidateContent = changed && !identity.directory,
+                    placeholder(authoritative),
+                    invalidateContent = changed && !authoritative.directory,
                 )
-                knownIdentities[identity.path] = identity
+                knownIdentities[authoritative.path] = authoritative
             }
             WindowsCloudPlaceholderState.Dirty -> {
-                if (previous != null && previous.accountId == backend.accountId && previous.path == identity.path) {
-                    knownIdentities[identity.path] = previous
+                check(previous != null && previous.accountId == backend.accountId && previous.path == identity.path) {
+                    "The dirty Windows Cloud Files placeholder does not have a verified identity."
                 }
+                knownIdentities[identity.path] = previous
             }
             WindowsCloudPlaceholderState.Absent -> Unit
+        }
+    }
+
+    private fun resolveAuthoritativePlaceholderIdentity(
+        listedIdentity: WindowsCloudFileIdentity,
+    ): WindowsCloudFileIdentity {
+        val resolved = backend.resolve(listedIdentity.path)
+        return requireNotNull(resolved) {
+            "The remote item disappeared while reconciling a Windows placeholder."
+        }.also { current ->
+            require(current.accountId == backend.accountId && current.path == listedIdentity.path) {
+                "The resolved Windows placeholder identity does not match the requested remote item."
+            }
         }
     }
 
@@ -1173,6 +1234,7 @@ internal class WindowsCloudFilesProvider(
         const val LOCAL_CHANGE_SETTLE_MILLIS = 750L
         const val MAX_PLACEHOLDER_COLLISION_RETRIES = 3
         const val MAX_RECOVERY_IDENTITIES = 20_000
+        const val PLACEHOLDER_COLLISION_RETRY_DELAY_MILLIS = 25L
         const val RECONCILIATION_CHUNK_BYTES = 1024 * 1024
     }
 }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -788,12 +788,25 @@ internal class WindowsCloudFilesProvider(
             return true
         }
         check(state == WindowsCloudPlaceholderState.InSync)
-        val authoritative = requireNotNull(authoritativeIdentity) {
+        var authoritative = requireNotNull(authoritativeIdentity) {
             "The remote item disappeared while reconciling a Windows placeholder collision."
         }.also { current ->
             require(current.accountId == backend.accountId && current.path == listedIdentity.path) {
                 "The resolved Windows placeholder identity does not match the requested remote item."
             }
+        }
+        if (existing != authoritative) {
+            authoritative = requireNotNull(backend.resolve(listedIdentity.path)) {
+                "The remote item disappeared while revalidating a Windows placeholder collision."
+            }.also { current ->
+                require(current.accountId == backend.accountId && current.path == listedIdentity.path) {
+                    "The revalidated Windows placeholder identity does not match the requested remote item."
+                }
+            }
+            val rechecked = api.placeholderIdentity(localPath)
+                ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
+                ?: return false
+            if (rechecked != existing) return false
         }
         val contentChanged = existing.remoteRevision != authoritative.remoteRevision ||
             existing.size != authoritative.size ||

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -686,42 +686,95 @@ internal class WindowsCloudFilesProvider(
 
     private fun populateDirectory(relativePath: String, localDirectory: Path) {
         val identities = backend.list(relativePath)
-        val missing = ArrayList<WindowsCloudPlaceholder>()
+        val missing = ArrayList<WindowsCloudFileIdentity>()
         identities.forEach { identity ->
             val localPath = localDirectory.resolve(identity.path.substringAfterLast('/'))
-            when (api.placeholderState(localPath)) {
+            val state = api.placeholderState(localPath)
+            when (state) {
                 WindowsCloudPlaceholderState.Absent -> {
-                    if (!Files.exists(localPath)) {
-                        missing += placeholder(identity)
-                        knownIdentities[identity.path] = identity
-                    }
+                    if (!Files.exists(localPath, LinkOption.NOFOLLOW_LINKS)) missing += identity
                 }
-                WindowsCloudPlaceholderState.InSync -> {
-                    val previous = api.placeholderIdentity(localPath)
-                        ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
-                    val changed = previous == null ||
-                        previous.accountId != identity.accountId ||
-                        previous.path != identity.path ||
-                        previous.remoteRevision != identity.remoteRevision ||
-                        previous.size != identity.size ||
-                        previous.directory != identity.directory
-                    api.updatePlaceholder(
-                        localPath,
-                        placeholder(identity),
-                        invalidateContent = changed && !identity.directory,
-                    )
-                    knownIdentities[identity.path] = identity
-                }
-                WindowsCloudPlaceholderState.Dirty -> {
-                    val previous = api.placeholderIdentity(localPath)
-                        ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
-                    if (previous != null && previous.accountId == backend.accountId && previous.path == identity.path) {
-                        knownIdentities[identity.path] = previous
-                    }
-                }
+                else -> reconcileExistingPlaceholder(identity, localPath, state)
             }
         }
-        api.createPlaceholders(localDirectory, missing)
+        createMissingPlaceholders(localDirectory, missing)
+    }
+
+    private fun createMissingPlaceholders(
+        localDirectory: Path,
+        identities: List<WindowsCloudFileIdentity>,
+    ) {
+        if (identities.isEmpty()) return
+        try {
+            api.createPlaceholders(localDirectory, identities.map(::placeholder))
+            identities.forEach { identity -> knownIdentities[identity.path] = identity }
+        } catch (failure: WindowsCloudFilesOperationException) {
+            if (!isWindowsCloudFilesPlaceholderAlreadyExistsResult(failure.hResult)) throw failure
+            identities.forEach { identity ->
+                reconcilePlaceholderCreationCollision(localDirectory, identity, failure)
+            }
+        }
+    }
+
+    private fun reconcilePlaceholderCreationCollision(
+        localDirectory: Path,
+        identity: WindowsCloudFileIdentity,
+        initialFailure: WindowsCloudFilesOperationException,
+    ) {
+        val localPath = localDirectory.resolve(identity.path.substringAfterLast('/'))
+        var collision = initialFailure
+        repeat(MAX_PLACEHOLDER_COLLISION_RETRIES) {
+            val state = api.placeholderState(localPath)
+            if (state != WindowsCloudPlaceholderState.Absent) {
+                reconcileExistingPlaceholder(identity, localPath, state)
+                return
+            }
+            if (Files.exists(localPath, LinkOption.NOFOLLOW_LINKS)) {
+                // Preserve an ordinary local entry. Startup recovery will import it with
+                // create-only remote semantics instead of replacing either copy.
+                return
+            }
+            try {
+                api.createPlaceholders(localDirectory, listOf(placeholder(identity)))
+                knownIdentities[identity.path] = identity
+                return
+            } catch (failure: WindowsCloudFilesOperationException) {
+                if (!isWindowsCloudFilesPlaceholderAlreadyExistsResult(failure.hResult)) throw failure
+                collision = failure
+            }
+        }
+        throw collision
+    }
+
+    private fun reconcileExistingPlaceholder(
+        identity: WindowsCloudFileIdentity,
+        localPath: Path,
+        state: WindowsCloudPlaceholderState,
+    ) {
+        val previous = api.placeholderIdentity(localPath)
+            ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
+        when (state) {
+            WindowsCloudPlaceholderState.InSync -> {
+                val changed = previous == null ||
+                    previous.accountId != identity.accountId ||
+                    previous.path != identity.path ||
+                    previous.remoteRevision != identity.remoteRevision ||
+                    previous.size != identity.size ||
+                    previous.directory != identity.directory
+                api.updatePlaceholder(
+                    localPath,
+                    placeholder(identity),
+                    invalidateContent = changed && !identity.directory,
+                )
+                knownIdentities[identity.path] = identity
+            }
+            WindowsCloudPlaceholderState.Dirty -> {
+                if (previous != null && previous.accountId == backend.accountId && previous.path == identity.path) {
+                    knownIdentities[identity.path] = previous
+                }
+            }
+            WindowsCloudPlaceholderState.Absent -> Unit
+        }
     }
 
     private fun requireIdentity(
@@ -1118,6 +1171,7 @@ internal class WindowsCloudFilesProvider(
 
     private companion object {
         const val LOCAL_CHANGE_SETTLE_MILLIS = 750L
+        const val MAX_PLACEHOLDER_COLLISION_RETRIES = 3
         const val MAX_RECOVERY_IDENTITIES = 20_000
         const val RECONCILIATION_CHUNK_BYTES = 1024 * 1024
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -697,10 +697,11 @@ internal class WindowsCloudFilesProvider(
                 else -> reconcileExistingPlaceholder(identity, localPath, state)
             }
         }
-        createMissingPlaceholders(localDirectory, missing)
+        createMissingPlaceholders(relativePath, localDirectory, missing)
     }
 
     private fun createMissingPlaceholders(
+        relativePath: String,
         localDirectory: Path,
         identities: List<WindowsCloudFileIdentity>,
     ) {
@@ -710,24 +711,38 @@ internal class WindowsCloudFilesProvider(
             identities.forEach { identity -> knownIdentities[identity.path] = identity }
         } catch (failure: WindowsCloudFilesOperationException) {
             if (!isWindowsCloudFilesPlaceholderAlreadyExistsResult(failure.hResult)) throw failure
+            val refreshed = backend.list(relativePath).associateBy { identity -> identity.path }
             identities.forEach { identity ->
-                reconcilePlaceholderCreationCollision(localDirectory, identity, failure)
+                reconcilePlaceholderCreationCollision(
+                    localDirectory = localDirectory,
+                    listedIdentity = identity,
+                    authoritativeIdentity = refreshed[identity.path],
+                    initialFailure = failure,
+                )
             }
         }
     }
 
     private fun reconcilePlaceholderCreationCollision(
         localDirectory: Path,
-        identity: WindowsCloudFileIdentity,
+        listedIdentity: WindowsCloudFileIdentity,
+        authoritativeIdentity: WindowsCloudFileIdentity?,
         initialFailure: WindowsCloudFilesOperationException,
     ) {
-        val localPath = localDirectory.resolve(identity.path.substringAfterLast('/'))
+        val localPath = localDirectory.resolve(listedIdentity.path.substringAfterLast('/'))
         var collision = initialFailure
         var identityUnavailable = false
         repeat(MAX_PLACEHOLDER_COLLISION_RETRIES) {
             val state = api.placeholderState(localPath)
             if (state != WindowsCloudPlaceholderState.Absent) {
-                if (reconcileCollidedPlaceholder(identity, localPath, state)) return
+                if (
+                    reconcileCollidedPlaceholder(
+                        listedIdentity,
+                        authoritativeIdentity,
+                        localPath,
+                        state,
+                    )
+                ) return
                 identityUnavailable = true
                 Thread.sleep(PLACEHOLDER_COLLISION_RETRY_DELAY_MILLIS)
                 return@repeat
@@ -737,9 +752,10 @@ internal class WindowsCloudFilesProvider(
                 // create-only remote semantics instead of replacing either copy.
                 return
             }
+            val creationIdentity = authoritativeIdentity ?: return
             try {
-                api.createPlaceholders(localDirectory, listOf(placeholder(identity)))
-                knownIdentities[identity.path] = identity
+                api.createPlaceholders(localDirectory, listOf(placeholder(creationIdentity)))
+                knownIdentities[creationIdentity.path] = creationIdentity
                 return
             } catch (failure: WindowsCloudFilesOperationException) {
                 if (!isWindowsCloudFilesPlaceholderAlreadyExistsResult(failure.hResult)) throw failure
@@ -757,6 +773,7 @@ internal class WindowsCloudFilesProvider(
 
     private fun reconcileCollidedPlaceholder(
         listedIdentity: WindowsCloudFileIdentity,
+        authoritativeIdentity: WindowsCloudFileIdentity?,
         localPath: Path,
         state: WindowsCloudPlaceholderState,
     ): Boolean {
@@ -771,16 +788,21 @@ internal class WindowsCloudFilesProvider(
             return true
         }
         check(state == WindowsCloudPlaceholderState.InSync)
-        val authoritative = if (existing == listedIdentity) {
-            existing
-        } else {
-            resolveAuthoritativePlaceholderIdentity(listedIdentity)
+        val authoritative = requireNotNull(authoritativeIdentity) {
+            "The remote item disappeared while reconciling a Windows placeholder collision."
+        }.also { current ->
+            require(current.accountId == backend.accountId && current.path == listedIdentity.path) {
+                "The resolved Windows placeholder identity does not match the requested remote item."
+            }
         }
-        if (existing != authoritative) {
+        val contentChanged = existing.remoteRevision != authoritative.remoteRevision ||
+            existing.size != authoritative.size ||
+            existing.directory != authoritative.directory
+        if (existing != authoritative || authoritative.directory) {
             api.updatePlaceholder(
                 localPath,
                 placeholder(authoritative),
-                invalidateContent = !authoritative.directory,
+                invalidateContent = contentChanged && !authoritative.directory,
             )
         }
         knownIdentities[authoritative.path] = authoritative
@@ -799,21 +821,16 @@ internal class WindowsCloudFilesProvider(
                 check(previous == null || previous.accountId == backend.accountId && previous.path == identity.path) {
                     "The Windows Cloud Files directory contains remote entries that resolve to the same Windows path."
                 }
-                val authoritative = when {
-                    previous == null || previous == identity -> identity
-                    else -> resolveAuthoritativePlaceholderIdentity(identity)
-                }
-                val changed = previous == null ||
-                    previous.remoteRevision != authoritative.remoteRevision ||
-                    previous.size != authoritative.size ||
-                    previous.directory != authoritative.directory ||
-                    previous.lastModifiedEpochMillis != authoritative.lastModifiedEpochMillis
+                val contentChanged = previous == null ||
+                    previous.remoteRevision != identity.remoteRevision ||
+                    previous.size != identity.size ||
+                    previous.directory != identity.directory
                 api.updatePlaceholder(
                     localPath,
-                    placeholder(authoritative),
-                    invalidateContent = changed && !authoritative.directory,
+                    placeholder(identity),
+                    invalidateContent = contentChanged && !identity.directory,
                 )
-                knownIdentities[authoritative.path] = authoritative
+                knownIdentities[identity.path] = identity
             }
             WindowsCloudPlaceholderState.Dirty -> {
                 check(previous != null && previous.accountId == backend.accountId && previous.path == identity.path) {
@@ -822,19 +839,6 @@ internal class WindowsCloudFilesProvider(
                 knownIdentities[identity.path] = previous
             }
             WindowsCloudPlaceholderState.Absent -> Unit
-        }
-    }
-
-    private fun resolveAuthoritativePlaceholderIdentity(
-        listedIdentity: WindowsCloudFileIdentity,
-    ): WindowsCloudFileIdentity {
-        val resolved = backend.resolve(listedIdentity.path)
-        return requireNotNull(resolved) {
-            "The remote item disappeared while reconciling a Windows placeholder."
-        }.also { current ->
-            require(current.accountId == backend.accountId && current.path == listedIdentity.path) {
-                "The resolved Windows placeholder identity does not match the requested remote item."
-            }
         }
     }
 
@@ -1028,6 +1032,11 @@ internal class WindowsCloudFilesProvider(
                     .joinToString("/") { it.toString() }.windowsCloudPath()
                 if (failClosed) uploadLocalEntry(path, relative)
                 else runCatching { uploadLocalEntry(path, relative) }
+                    .onFailure {
+                        // The ordinary entry is the durable recovery copy. Rebuild its
+                        // visible failure state on every startup until reconciliation succeeds.
+                        failedWritebacks += relative
+                    }
             }
         }
         if (failClosed) recover() else runCatching(recover)
@@ -1144,6 +1153,7 @@ internal class WindowsCloudFilesProvider(
         require(Files.isDirectory(localPath) || Files.isRegularFile(localPath)) {
             "Windows Cloud Files only imports regular files and folders."
         }
+        failedWritebacks -= relativePath
         pendingWritebacks += relativePath
         var completed = false
         try {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -189,6 +189,96 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun collisionRecoveryPreservesTheAuthoritativeNewerGeneration() {
+        val root = createTempDirectory("windows-cloud-placeholder-generation")
+        val old = WindowsCloudFileIdentity("account-01", "report.txt", "old", 5L, false)
+        val current = old.copy(remoteRevision = "current")
+        val backend = FakeBackend("fresh".encodeToByteArray(), listOf(old)).apply { seedRemote(current) }
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { baseDirectory, placeholders ->
+                seed(
+                    baseDirectory.resolve(placeholders.single().name),
+                    WindowsCloudPlaceholderState.InSync,
+                    current,
+                )
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, backend, api)
+
+        try {
+            provider.start()
+
+            assertEquals(current, api.decodedIdentity(root.resolve("report.txt")))
+            assertTrue(api.invalidatedUpdates.isEmpty())
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun collisionWithAnotherRemotePathFailsClosed() {
+        val root = createTempDirectory("windows-cloud-placeholder-name-conflict")
+        val listed = WindowsCloudFileIdentity("account-01", "Report", "listed", 0L, true)
+        val conflicting = listed.copy(path = "report", remoteRevision = "conflicting")
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { baseDirectory, placeholders ->
+                seed(
+                    baseDirectory.resolve(placeholders.single().name),
+                    WindowsCloudPlaceholderState.InSync,
+                    conflicting,
+                )
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(ByteArray(0), listOf(listed)), api)
+
+        try {
+            val failure = assertFailsWith<IllegalStateException> { provider.start() }
+            assertTrue(failure.message.orEmpty().contains("same Windows path"))
+            assertEquals(listOf(1L), api.disconnectAttempts)
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun dirtyCollisionWithoutAReadableIdentityFailsClosed() {
+        val root = createTempDirectory("windows-cloud-placeholder-dirty-identity")
+        val identity = WindowsCloudFileIdentity("account-01", "edit.txt", "revision", 5L, false)
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { baseDirectory, placeholders ->
+                seedState(
+                    baseDirectory.resolve(placeholders.single().name),
+                    WindowsCloudPlaceholderState.Dirty,
+                )
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend("local".encodeToByteArray(), listOf(identity)), api)
+
+        try {
+            val failure = assertFailsWith<IllegalStateException> { provider.start() }
+            assertTrue(failure.message.orEmpty().contains("Could not verify the existing"))
+            assertEquals(listOf(1L), api.disconnectAttempts)
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun ordinaryLocalEntryCreatedDuringPlaceholderRaceIsPreserved() {
         val root = createTempDirectory("windows-cloud-local-placeholder-race")
         val localBytes = "local recovery data".encodeToByteArray()
@@ -862,7 +952,7 @@ class WindowsCloudFilesProviderTest {
         val uploadExpectedRevisions = mutableListOf<String?>()
         val operations = mutableListOf<String>()
         val listedPaths = CopyOnWriteArrayList<String>()
-        private val remoteIdentities = mutableMapOf<String, WindowsCloudFileIdentity>()
+        private val remoteIdentities = listed.associateBy { identity -> identity.path }.toMutableMap()
         private val remoteContents = mutableMapOf<String, ByteArray>()
 
         override fun resolve(path: String): WindowsCloudFileIdentity? = synchronized(this) {
@@ -931,6 +1021,10 @@ class WindowsCloudFilesProviderTest {
         fun awaitUploads(): Boolean = uploadLatch.await(5, TimeUnit.SECONDS)
         fun awaitFirstUploadStarted(): Boolean = firstUploadStarted.await(5, TimeUnit.SECONDS)
         fun releaseFirstUpload() = firstUploadRelease.countDown()
+
+        fun seedRemote(identity: WindowsCloudFileIdentity) = synchronized(this) {
+            remoteIdentities[identity.path] = identity
+        }
     }
 
     private class FakeApi(
@@ -1048,6 +1142,11 @@ class WindowsCloudFilesProviderTest {
         fun seed(path: Path, state: WindowsCloudPlaceholderState, identity: WindowsCloudFileIdentity) {
             states[path] = state
             identities[path] = WindowsCloudFileIdentityCodec.encode(identity)
+        }
+
+        fun seedState(path: Path, state: WindowsCloudPlaceholderState) {
+            states[path] = state
+            identities.remove(path)
         }
     }
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -157,6 +157,93 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun concurrentCallbackPlaceholderCreationDoesNotFailStartup() {
+        val root = createTempDirectory("windows-cloud-placeholder-race")
+        val identity = WindowsCloudFileIdentity("account-01", "Apps", "revision", 0L, true)
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { baseDirectory, placeholders ->
+                placeholders.forEach { created ->
+                    seed(
+                        baseDirectory.resolve(created.name),
+                        WindowsCloudPlaceholderState.InSync,
+                        WindowsCloudFileIdentityCodec.decode(created.identity),
+                    )
+                }
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(ByteArray(0), listOf(identity)), api)
+
+        try {
+            provider.start()
+
+            assertEquals(identity, api.decodedIdentity(root.resolve("Apps")))
+            assertTrue(api.disconnectAttempts.isEmpty())
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun ordinaryLocalEntryCreatedDuringPlaceholderRaceIsPreserved() {
+        val root = createTempDirectory("windows-cloud-local-placeholder-race")
+        val localBytes = "local recovery data".encodeToByteArray()
+        val identity = WindowsCloudFileIdentity(
+            "account-01",
+            "draft.txt",
+            "revision",
+            localBytes.size.toLong(),
+            false,
+        )
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { baseDirectory, placeholders ->
+                baseDirectory.resolve(placeholders.single().name).writeBytes(localBytes)
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(localBytes, listOf(identity)), api)
+
+        try {
+            provider.start()
+
+            assertContentEquals(localBytes, root.resolve("draft.txt").toFile().readBytes())
+            assertTrue(api.disconnectAttempts.isEmpty())
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun unrelatedPlaceholderCreationFailureStillStopsStartup() {
+        val root = createTempDirectory("windows-cloud-placeholder-failure")
+        val identity = WindowsCloudFileIdentity("account-01", "Apps", "revision", 0L, true)
+        val failure = WindowsCloudFilesOperationException(
+            "create Windows Cloud Files placeholders",
+            0x80070005.toInt(),
+        )
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { _, _ -> throw failure }
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(ByteArray(0), listOf(identity)), api)
+
+        try {
+            assertEquals(failure, assertFailsWith<WindowsCloudFilesOperationException> { provider.start() })
+            assertEquals(listOf(1L), api.disconnectAttempts)
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun missingRegistrationDuringConnectIsRepairedAndRetriedOnce() {
         val root = createTempDirectory("windows-cloud-connect-repair")
         val api = FakeApi().apply {
@@ -869,6 +956,7 @@ class WindowsCloudFilesProviderTest {
         val connectFailures = mutableListOf<WindowsCloudFilesOperationException>()
         val disconnectAttempts = mutableListOf<Long>()
         var disconnectFailure: RuntimeException? = null
+        var createPlaceholdersHook: ((Path, List<WindowsCloudPlaceholder>) -> Unit)? = null
         var closed = false
         val lifecycleEvents = mutableListOf<String>()
 
@@ -891,6 +979,10 @@ class WindowsCloudFilesProviderTest {
         }
         override fun createPlaceholders(baseDirectory: Path, placeholders: List<WindowsCloudPlaceholder>) {
             lifecycleEvents += "create"
+            createPlaceholdersHook?.also { hook ->
+                createPlaceholdersHook = null
+                hook(baseDirectory, placeholders)
+            }
         }
         override fun transferData(info: WindowsCloudCallbackInfo, offset: Long, bytes: ByteArray) {
             synchronized(transfers) { transfers += offset to bytes.copyOf() }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -181,6 +181,7 @@ class WindowsCloudFilesProviderTest {
             provider.start()
 
             assertEquals(identity, api.decodedIdentity(root.resolve("Apps")))
+            assertEquals(listOf(root.resolve("Apps")), api.updatedPaths)
             assertTrue(api.disconnectAttempts.isEmpty())
         } finally {
             provider.removeSyncRoot()
@@ -214,6 +215,43 @@ class WindowsCloudFilesProviderTest {
 
             assertEquals(current, api.decodedIdentity(root.resolve("report.txt")))
             assertTrue(api.invalidatedUpdates.isEmpty())
+            assertEquals(listOf("", ""), backend.listedPaths.take(2))
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun partialBatchRetryUsesTheRefreshedRemoteGeneration() {
+        val root = createTempDirectory("windows-cloud-placeholder-partial-batch")
+        val first = WindowsCloudFileIdentity("account-01", "Apps", "apps", 0L, true)
+        val oldSecond = WindowsCloudFileIdentity("account-01", "report.txt", "old", 5L, false)
+        val currentSecond = oldSecond.copy(remoteRevision = "current")
+        val backend = FakeBackend("fresh".encodeToByteArray(), listOf(first, oldSecond)).apply {
+            seedRemote(currentSecond)
+        }
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { baseDirectory, placeholders ->
+                val created = placeholders.first()
+                seed(
+                    baseDirectory.resolve(created.name),
+                    WindowsCloudPlaceholderState.InSync,
+                    WindowsCloudFileIdentityCodec.decode(created.identity),
+                )
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, backend, api)
+
+        try {
+            provider.start()
+
+            val retried = api.createdPlaceholderBatches.last().single()
+            assertEquals(currentSecond, WindowsCloudFileIdentityCodec.decode(retried.identity))
         } finally {
             provider.removeSyncRoot()
             root.toFile().deleteRecursively()
@@ -298,12 +336,17 @@ class WindowsCloudFilesProviderTest {
                 )
             }
         }
-        val provider = WindowsCloudFilesProvider(root, FakeBackend(localBytes, listOf(identity)), api)
+        val backend = FakeBackend("different remote bytes".encodeToByteArray(), listOf(identity))
+        val provider = WindowsCloudFilesProvider(root, backend, api)
 
         try {
             provider.start()
 
             assertContentEquals(localBytes, root.resolve("draft.txt").toFile().readBytes())
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (provider.summary().failedWritebackCount == 0 && System.nanoTime() < deadline) Thread.yield()
+            assertEquals(1, provider.summary().failedWritebackCount)
+            assertEquals(1, provider.summary().pendingWritebackCount)
             assertTrue(api.disconnectAttempts.isEmpty())
         } finally {
             provider.removeSyncRoot()
@@ -679,6 +722,24 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `startup retains hydrated bytes for metadata-only placeholder updates`() {
+        val root = createTempDirectory("windows-cloud-metadata-refresh-")
+        val local = root.resolve("example.raf")
+        local.writeBytes("cached bytes".encodeToByteArray())
+        val old = fixtureIdentity(size = local.toFile().length()).copy(path = "example.raf")
+        val fresh = old.copy(lastModifiedEpochMillis = 1_000L)
+        val backend = FakeBackend("cached bytes".encodeToByteArray(), listed = listOf(fresh))
+        val api = FakeApi().apply { seed(local, WindowsCloudPlaceholderState.InSync, old) }
+        val provider = WindowsCloudFilesProvider(root, backend, api)
+
+        provider.start()
+
+        assertTrue(api.invalidatedUpdates.isEmpty())
+        assertEquals(fresh, api.decodedIdentity(local))
+        provider.close()
+    }
+
+    @Test
     fun `recovery uploads against the dirty placeholder revision`() {
         val root = createTempDirectory("windows-cloud-recovery-")
         val local = root.resolve("edit.txt")
@@ -958,9 +1019,10 @@ class WindowsCloudFilesProviderTest {
         override fun resolve(path: String): WindowsCloudFileIdentity? = synchronized(this) {
             remoteIdentities[path]
         }
-        override fun list(path: String): List<WindowsCloudFileIdentity> {
+        override fun list(path: String): List<WindowsCloudFileIdentity> = synchronized(this) {
             listedPaths += path
-            return listed.filter { it.path.substringBeforeLast('/', "") == path }
+            listed.mapNotNull { identity -> remoteIdentities[identity.path] }
+                .filter { identity -> identity.path.substringBeforeLast('/', "") == path }
         }
 
         override fun open(identity: WindowsCloudFileIdentity): WindowsCloudFileReadHandle {
@@ -979,6 +1041,9 @@ class WindowsCloudFilesProviderTest {
             expectedRemoteRevision: String?,
         ): WindowsCloudFileIdentity {
             synchronized(this) {
+                check(expectedRemoteRevision != null || remoteIdentities[path] == null) {
+                    "The server file appeared after the sync scan."
+                }
                 if (uploadFailuresRemaining > 0) {
                     uploadFailuresRemaining -= 1
                     error("Simulated transient upload failure")
@@ -1008,6 +1073,7 @@ class WindowsCloudFilesProviderTest {
         }
 
         override fun createDirectory(path: String): WindowsCloudFileIdentity = synchronized(this) {
+            check(remoteIdentities[path] == null) { "The server folder appeared after the sync scan." }
             WindowsCloudFileIdentity(accountId, path, "\"directory\"", 0L, true).also { created ->
                 operations += "mkdir:$path"
                 remoteIdentities[path] = created
@@ -1042,7 +1108,9 @@ class WindowsCloudFilesProviderTest {
         private val states = HashMap<Path, WindowsCloudPlaceholderState>()
         private val identities = HashMap<Path, ByteArray>()
         val transfers = mutableListOf<Pair<Long, ByteArray>>()
+        val createdPlaceholderBatches = mutableListOf<List<WindowsCloudPlaceholder>>()
         val invalidatedUpdates = mutableListOf<Path>()
+        val updatedPaths = mutableListOf<Path>()
         var completedPlaceholders = emptyList<WindowsCloudPlaceholder>()
         var lastRenameAccepted = false
         var unregisteredRoot: Path? = null
@@ -1073,6 +1141,7 @@ class WindowsCloudFilesProviderTest {
         }
         override fun createPlaceholders(baseDirectory: Path, placeholders: List<WindowsCloudPlaceholder>) {
             lifecycleEvents += "create"
+            createdPlaceholderBatches.add(placeholders)
             createPlaceholdersHook?.also { hook ->
                 createPlaceholdersHook = null
                 hook(baseDirectory, placeholders)
@@ -1114,6 +1183,7 @@ class WindowsCloudFilesProviderTest {
             invalidateContent: Boolean,
             preserveSyncState: Boolean,
         ) {
+            updatedPaths.add(path)
             if (!preserveSyncState) states[path] = WindowsCloudPlaceholderState.InSync
             identities[path] = placeholder.identity.copyOf()
             if (invalidateContent) invalidatedUpdates.add(path)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -259,6 +259,43 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun collisionRevalidatesAPlaceholderGenerationThatAdvancedAfterRefresh() {
+        val root = createTempDirectory("windows-cloud-placeholder-revalidation")
+        val old = WindowsCloudFileIdentity("account-01", "report.txt", "old", 5L, false)
+        val intermediate = old.copy(remoteRevision = "intermediate")
+        val current = old.copy(remoteRevision = "current")
+        val backend = FakeBackend("fresh".encodeToByteArray(), listOf(old)).apply {
+            queueList(listOf(old), listOf(intermediate))
+            seedRemote(current)
+        }
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { baseDirectory, placeholders ->
+                seed(
+                    baseDirectory.resolve(placeholders.single().name),
+                    WindowsCloudPlaceholderState.InSync,
+                    current,
+                )
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, backend, api)
+
+        try {
+            provider.start()
+
+            assertEquals(current, api.decodedIdentity(root.resolve("report.txt")))
+            assertEquals(listOf("report.txt"), backend.resolvedPaths)
+            assertTrue(api.invalidatedUpdates.isEmpty())
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun collisionWithAnotherRemotePathFailsClosed() {
         val root = createTempDirectory("windows-cloud-placeholder-name-conflict")
         val listed = WindowsCloudFileIdentity("account-01", "Report", "listed", 0L, true)
@@ -1013,14 +1050,18 @@ class WindowsCloudFilesProviderTest {
         val uploadExpectedRevisions = mutableListOf<String?>()
         val operations = mutableListOf<String>()
         val listedPaths = CopyOnWriteArrayList<String>()
+        val resolvedPaths = CopyOnWriteArrayList<String>()
         private val remoteIdentities = listed.associateBy { identity -> identity.path }.toMutableMap()
         private val remoteContents = mutableMapOf<String, ByteArray>()
+        private val scriptedLists = ArrayDeque<List<WindowsCloudFileIdentity>>()
 
         override fun resolve(path: String): WindowsCloudFileIdentity? = synchronized(this) {
+            resolvedPaths += path
             remoteIdentities[path]
         }
         override fun list(path: String): List<WindowsCloudFileIdentity> = synchronized(this) {
             listedPaths += path
+            if (scriptedLists.isNotEmpty()) return@synchronized scriptedLists.removeFirst()
             listed.mapNotNull { identity -> remoteIdentities[identity.path] }
                 .filter { identity -> identity.path.substringBeforeLast('/', "") == path }
         }
@@ -1090,6 +1131,10 @@ class WindowsCloudFilesProviderTest {
 
         fun seedRemote(identity: WindowsCloudFileIdentity) = synchronized(this) {
             remoteIdentities[identity.path] = identity
+        }
+
+        fun queueList(vararg responses: List<WindowsCloudFileIdentity>) = synchronized(this) {
+            scriptedLists.addAll(responses)
         }
     }
 


### PR DESCRIPTION
## Summary

- recover when initial Cloud Files population races with an Explorer-triggered placeholder callback
- re-inspect partially populated batches and retry only entries that remain missing
- preserve ordinary local files and folders for create-only recovery instead of replacing them
- retain fail-closed behavior for unrelated Windows Cloud Files errors

## Root cause

The provider connects before its initial placeholder population so Cloud Files callbacks can be served immediately. Explorer can request on-demand population during that window, causing the callback and the initial `CfCreatePlaceholders` call to create the same entry. Windows reports `HRESULT 0x800700B7` (`ERROR_ALREADY_EXISTS`), which previously stopped startup even when the matching placeholder had already been created successfully.

## Validation

- `./gradlew --no-daemon :ui:desktopTest --tests dev.obiente.nextcloudnative.app.WindowsCloudFilesProviderTest`
- `./gradlew --no-daemon :ui:desktopTest`
- `bash tools/check-repository.sh`

Deterministic coverage verifies matching callback races, preservation of ordinary local bytes, and fail-closed handling for unrelated HRESULTs. Native Windows packaging and device verification remain required.

Closes #315
