### PR TITLE
fix(windows): serialize initial placeholder population

### DIFF
--- a/changes/unreleased/324-windows-placeholder-population.md
+++ b/changes/unreleased/324-windows-placeholder-population.md
@@ -1,0 +1,7 @@
+category: fix
+issue: none
+pull: 324
+platforms: desktop, windows
+user-facing: yes
+
+Windows virtual files now serialize initial and on-demand placeholder population so concurrent File Explorer requests cannot abort activation with a name collision.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -457,6 +457,9 @@ internal class WindowsCloudFilesProvider(
         Thread(work, "nextcloud-windows-local-changes").apply { isDaemon = true }
     }
     private val pendingLocalChanges = ConcurrentHashMap<Path, ScheduledFuture<*>>()
+    private val initialPopulationStarted = AtomicBoolean(false)
+    private val initialPopulationFinished = CountDownLatch(1)
+    @Volatile private var initialPopulationSucceeded = false
     private val initialRecoveryFinished = CountDownLatch(1)
     @Volatile private var initialRecoveryFailure: WindowsCloudFilesStartupRecoveryException? = null
     @Volatile var preservedRecoveryRoot: Path? = null
@@ -466,6 +469,9 @@ internal class WindowsCloudFilesProvider(
 
     fun start() {
         check(connection.get() == 0L) { "The Windows Cloud Files provider is already connected." }
+        check(initialPopulationStarted.compareAndSet(false, true)) {
+            "The Windows Cloud Files provider startup has already been attempted."
+        }
         prepareRootDirectory()
         val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
         val encodedRootIdentity = WindowsCloudFileIdentityCodec.encode(rootIdentity)
@@ -477,6 +483,8 @@ internal class WindowsCloudFilesProvider(
             } catch (corruption: WindowsCloudFilesCorruptEntryException) {
                 recoverCorruptRoot(encodedRootIdentity, corruption)
             }
+            initialPopulationSucceeded = true
+            initialPopulationFinished.countDown()
             startLocalWatcher()
             executor.execute {
                 try {
@@ -489,6 +497,7 @@ internal class WindowsCloudFilesProvider(
             }
         } catch (failure: Throwable) {
             callbacksPaused.set(true)
+            initialPopulationFinished.countDown()
             val key = connection.get()
             if (key != 0L && runCatching { api.disconnect(key) }.isSuccess) {
                 connection.compareAndSet(key, 0L)
@@ -741,6 +750,18 @@ internal class WindowsCloudFilesProvider(
         cancelledRequests[info.requestKey] = cancellation
         executor.execute {
             try {
+                if (initialPopulationStarted.get()) {
+                    check(
+                        initialPopulationFinished.await(
+                            DEFAULT_INITIAL_POPULATION_TIMEOUT_SECONDS,
+                            TimeUnit.SECONDS,
+                        ),
+                    ) { "Timed out while waiting for the initial Windows Cloud Files population." }
+                    check(initialPopulationSucceeded && !callbacksPaused.get()) {
+                        "The initial Windows Cloud Files population did not complete successfully."
+                    }
+                }
+                if (cancellation.get()) return@execute
                 val directory = requireIdentity(info, expectDirectory = true)
                 // CFAPI permits returning entries beyond the requested pattern. Returning the complete
                 // directory lets this transfer safely mark on-demand population as finished.
@@ -1855,6 +1876,7 @@ private fun String.windowsCloudPath(): String {
 private const val WINDOWS_CLOUD_ALIGNMENT = 4 * 1024L
 private const val MAX_WINDOWS_WRITEBACK_ATTEMPTS = 5
 private const val DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS = 120L
+private const val DEFAULT_INITIAL_POPULATION_TIMEOUT_SECONDS = 120L
 
 private fun windowsWritebackRetryDelayMillis(attempt: Int): Long {
     require(attempt in 1 until MAX_WINDOWS_WRITEBACK_ATTEMPTS)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -300,6 +300,46 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun placeholderFetchWaitsForInitialPopulation() {
+        val root = createTempDirectory("windows-cloud-initial-population")
+        val child = WindowsCloudFileIdentity("account-01", "Apps", "revision", 0L, true)
+        val rootIdentity = child.copy(path = "", remoteRevision = "root")
+        val createStarted = CountDownLatch(1)
+        val releaseCreate = CountDownLatch(1)
+        val api = FakeApi(expectedPlaceholderFetches = 1).apply {
+            createPlaceholdersHook = { _, _ ->
+                createStarted.countDown()
+                check(releaseCreate.await(5, TimeUnit.SECONDS))
+            }
+        }
+        val provider = WindowsCloudFilesProvider(root, FakeBackend(ByteArray(0), listOf(child)), api)
+        val startupFailure = AtomicReference<Throwable?>()
+        val startup = Thread {
+            runCatching(provider::start).exceptionOrNull()?.let(startupFailure::set)
+        }
+
+        try {
+            startup.start()
+            assertTrue(createStarted.await(5, TimeUnit.SECONDS))
+
+            provider.fetchPlaceholders(callbackInfo(root, rootIdentity), pattern = null)
+
+            assertFalse(api.awaitPlaceholderFetches(100))
+            releaseCreate.countDown()
+            startup.join(TimeUnit.SECONDS.toMillis(5))
+            assertFalse(startup.isAlive)
+            startupFailure.get()?.let { throw it }
+            assertTrue(api.awaitPlaceholderFetches())
+            assertEquals(listOf("Apps"), api.completedPlaceholders.map(WindowsCloudPlaceholder::name))
+        } finally {
+            releaseCreate.countDown()
+            startup.join(TimeUnit.SECONDS.toMillis(5))
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun collisionRecoveryPreservesTheAuthoritativeNewerGeneration() {
         val root = createTempDirectory("windows-cloud-placeholder-generation")
         val old = WindowsCloudFileIdentity("account-01", "report.txt", "old", 5L, false)
@@ -1879,7 +1919,8 @@ class WindowsCloudFilesProviderTest {
         fun awaitConversions(): Boolean = conversionLatch.await(5, TimeUnit.SECONDS)
         fun awaitRenames(): Boolean = renameLatch.await(5, TimeUnit.SECONDS)
         fun awaitIdentityReads(): Boolean = identityReadLatch.await(5, TimeUnit.SECONDS)
-        fun awaitPlaceholderFetches(): Boolean = placeholderFetchLatch.await(5, TimeUnit.SECONDS)
+        fun awaitPlaceholderFetches(timeoutMillis: Long = TimeUnit.SECONDS.toMillis(5)): Boolean =
+            placeholderFetchLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)
 
         fun decodedIdentity(path: Path): WindowsCloudFileIdentity? =
             placeholderIdentity(path)?.let(WindowsCloudFileIdentityCodec::decode)


### PR DESCRIPTION
## Summary

- serialize the initial Windows Cloud Files root population with on-demand placeholder fetches
- fail queued placeholder fetches safely when initial population does not complete
- add a regression test that holds a concurrent fetch until startup finishes

## Root cause

The provider connected Cloud Files callbacks before its initial root population completed. File Explorer could request on-demand population during that window, allowing startup and the callback to create the same placeholder concurrently. Windows then returned `ERROR_ALREADY_EXISTS`, and repeated collisions could abort virtual-file activation.

## User impact

Windows virtual files can activate without a concurrent File Explorer population request racing the initial placeholder batch. Existing collision reconciliation, local-entry preservation, corrupt-root recovery, and writeback behavior remain unchanged.

## Validation

- `./gradlew --no-daemon :ui:desktopTest --tests dev.obiente.nextcloudnative.app.WindowsCloudFilesProviderTest`
- `./gradlew --no-daemon :ui:desktopTest :ui:createDistributable`
- `bash tools/check-repository.sh`
- `node tools/changelog-fragments.mjs validate`
- `node tools/changelog-fragments.mjs check-diff --base origin/main --head HEAD`
- `git diff --check`

Native Windows packaging and Cloud Files verification remain required from hosted CI and the resulting MSI.
