### PR TITLE
fix(linux): restore tray controls and clean shutdown

### DIFF
--- a/changes/unreleased/286-linux-tray-shutdown.md
+++ b/changes/unreleased/286-linux-tray-shutdown.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 286
+pull: 325
+platforms: linux
+user-facing: yes
+
+Linux tray menus now provide activity, app, and quit controls, and quitting cleanly releases the virtual-files mount without leaving the background service stuck.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -2469,16 +2469,19 @@ class DesktopNextcloudServices(
         synchronized(virtualRangeCaches) {
             virtualRangeCaches.values.forEach { cache -> runCatching(cache::flushAccessTimes) }
         }
-        synchronized(virtualFileProviderLock) {
-            if (runCatching { linuxVirtualFileSystem?.unmount() }.isSuccess) {
+        val providersToClose = synchronized(virtualFileProviderLock) {
+            (linuxVirtualFileSystem to windowsCloudFilesProvider).also {
                 linuxVirtualFileSystem = null
                 linuxVirtualMetadataBackend = null
                 linuxVirtualFileMountIdentity = null
+                windowsCloudFilesProvider = null
+                windowsCloudFilesIdentity = null
             }
-            runCatching { windowsCloudFilesProvider?.close() }
-            windowsCloudFilesProvider = null
-            windowsCloudFilesIdentity = null
         }
+        // A retained-metadata persistence callback can briefly enter virtualFileProviderLock.
+        // Closing its backend while holding the same lock reverses that order and deadlocks.
+        runCatching { providersToClose.first?.unmount() }
+        runCatching { providersToClose.second?.close() }
         supportDiagnostics.close()
         if (ownsTemporarySupportDiagnosticsRoot) requireNotNull(resolvedSupportDiagnosticsRoot).deleteRecursively()
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLogin.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLogin.kt
@@ -287,13 +287,17 @@ internal fun handoffLinuxForegroundLaunchToUserService(
 }
 
 /**
- * Cancels a configured supervised instance before an explicit application quit releases the
- * single-instance lock. `--no-block` is required when the caller is itself owned by the unit.
+ * Stops a separate supervised instance before an explicit application quit releases the
+ * single-instance lock. A process already owned by the unit must exit cleanly by itself so
+ * systemd cannot interrupt Compose and FUSE teardown with SIGTERM.
  */
 internal fun stopLinuxUserServiceForExplicitQuit(
     osName: String = System.getProperty("os.name").orEmpty(),
     userHome: File = File(System.getProperty("user.home")),
     linuxConfigHome: File = linuxDesktopConfigHome(userHome),
+    currentProcessIsLinuxUserService: () -> Boolean = {
+        isCurrentProcessOwnedByLinuxUserService()
+    },
     processRunner: (List<String>) -> Int = { command ->
         ProcessBuilder(command).redirectErrorStream(true).start().also { process ->
             process.inputStream.bufferedReader().use { it.readText() }
@@ -301,6 +305,7 @@ internal fun stopLinuxUserServiceForExplicitQuit(
     },
 ): Boolean {
     if (!osName.lowercase().contains("linux")) return false
+    if (currentProcessIsLinuxUserService()) return true
     return runCatching {
         processRunner(
             listOf("systemctl", "--user", "--no-block", "stop", LINUX_USER_SERVICE_NAME),

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
@@ -1,5 +1,7 @@
 package dev.obiente.nextcloudnative.app
 
+import java.awt.MenuItem
+import java.awt.PopupMenu
 import java.awt.SystemTray
 import java.awt.TrayIcon
 import java.awt.event.MouseAdapter
@@ -45,7 +47,7 @@ internal fun registerDesktopTray(
     if (osName.contains("linux", ignoreCase = true)) {
         LinuxStatusNotifierTray.register(tooltip, onAction)?.let { return it }
     }
-    return AwtDesktopTray.register(tooltip) { onAction(DesktopTrayAction.ShowActivity) }
+    return AwtDesktopTray.register(tooltip, onAction)
 }
 
 private class AwtDesktopTray private constructor(
@@ -70,21 +72,29 @@ private class AwtDesktopTray private constructor(
     }
 
     companion object {
-        fun register(tooltip: String, onActivated: () -> Unit): DesktopTrayRegistration? {
+        fun register(
+            tooltip: String,
+            onAction: (DesktopTrayAction) -> Unit,
+        ): DesktopTrayRegistration? {
             if (!SystemTray.isSupported()) return null
             return runCatching {
                 val resource = requireNotNull(
                     Thread.currentThread().contextClassLoader.getResource("nextcloud-native.png"),
                 )
-                val icon = TrayIcon(ImageIO.read(resource), tooltip).apply { isImageAutoSize = true }
+                val popup = PopupMenu().apply {
+                    MENU_ITEMS.forEach { (id, label) ->
+                        add(MenuItem(label).apply {
+                            addActionListener { menuAction(id)?.let(onAction) }
+                        })
+                    }
+                }
+                val icon = TrayIcon(ImageIO.read(resource), tooltip, popup).apply {
+                    isImageAutoSize = true
+                }
                 val listener = object : MouseAdapter() {
                     override fun mouseReleased(event: MouseEvent) {
-                        if (
-                            event.button == MouseEvent.BUTTON1 ||
-                            event.button == MouseEvent.BUTTON3 ||
-                            event.isPopupTrigger
-                        ) {
-                            onActivated()
+                        if (event.button == MouseEvent.BUTTON1 && !event.isPopupTrigger) {
+                            onAction(DesktopTrayAction.ShowActivity)
                         }
                     }
                 }
@@ -441,7 +451,7 @@ private class LinuxTrayContextMenu(
             closeNow()
             val window = JWindow().apply {
                 isAlwaysOnTop = true
-                setLocation(x.coerceAtLeast(0), y.coerceAtLeast(0))
+                setLocation(x, y)
                 setSize(1, 1)
                 isVisible = true
             }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
@@ -7,13 +7,24 @@ import java.awt.event.MouseEvent
 import javax.imageio.ImageIO
 import org.freedesktop.dbus.annotations.DBusInterfaceName
 import org.freedesktop.dbus.annotations.DBusProperty
+import org.freedesktop.dbus.annotations.Position
 import org.freedesktop.dbus.connections.impl.DBusConnection
 import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.dbus.DBusPath
+import org.freedesktop.dbus.Struct
+import org.freedesktop.dbus.Tuple
 import org.freedesktop.dbus.interfaces.DBus
 import org.freedesktop.dbus.interfaces.DBusInterface
 import org.freedesktop.dbus.interfaces.Properties
 import org.freedesktop.dbus.messages.DBusSignal
 import org.freedesktop.dbus.types.Variant
+import org.freedesktop.dbus.types.UInt32
+
+internal enum class DesktopTrayAction {
+    ShowActivity,
+    OpenApp,
+    Quit,
+}
 
 internal interface DesktopTrayRegistration : AutoCloseable {
     fun updateTooltip(tooltip: String)
@@ -22,13 +33,13 @@ internal interface DesktopTrayRegistration : AutoCloseable {
 
 internal fun registerDesktopTray(
     tooltip: String,
-    onActivated: () -> Unit,
+    onAction: (DesktopTrayAction) -> Unit,
     osName: String = System.getProperty("os.name").orEmpty(),
 ): DesktopTrayRegistration? {
     if (osName.contains("linux", ignoreCase = true)) {
-        LinuxStatusNotifierTray.register(tooltip, onActivated)?.let { return it }
+        LinuxStatusNotifierTray.register(tooltip, onAction)?.let { return it }
     }
-    return AwtDesktopTray.register(tooltip, onActivated)
+    return AwtDesktopTray.register(tooltip) { onAction(DesktopTrayAction.ShowActivity) }
 }
 
 private class AwtDesktopTray private constructor(
@@ -92,6 +103,7 @@ internal interface StatusNotifierWatcher : DBusInterface {
 @DBusProperty(name = "Status", type = String::class)
 @DBusProperty(name = "IconName", type = String::class)
 @DBusProperty(name = "ItemIsMenu", type = Boolean::class)
+@DBusProperty(name = "Menu", type = DBusPath::class)
 internal interface StatusNotifierItem : DBusInterface {
     class NewTitle(path: String) : DBusSignal(path)
 
@@ -110,7 +122,7 @@ internal interface StatusNotifierItem : DBusInterface {
 
 internal class LinuxStatusNotifierItem(
     initialTooltip: String,
-    private val onActivated: () -> Unit,
+    private val onAction: (DesktopTrayAction) -> Unit,
     private val onTitleChanged: () -> Unit = {},
 ) : StatusNotifierItem, Properties {
     @Volatile
@@ -125,12 +137,12 @@ internal class LinuxStatusNotifierItem(
     override fun getObjectPath(): String = STATUS_NOTIFIER_ITEM_PATH
 
     override fun Activate(x: Int, y: Int) {
-        onActivated()
+        onAction(DesktopTrayAction.ShowActivity)
     }
 
-    override fun SecondaryActivate(x: Int, y: Int) = onActivated()
+    override fun SecondaryActivate(x: Int, y: Int) = onAction(DesktopTrayAction.ShowActivity)
 
-    override fun ContextMenu(x: Int, y: Int) = onActivated()
+    override fun ContextMenu(x: Int, y: Int) = onAction(DesktopTrayAction.ShowActivity)
 
     override fun Scroll(delta: Int, orientation: String) = Unit
 
@@ -155,7 +167,181 @@ internal class LinuxStatusNotifierItem(
             "Status" to Variant("Active"),
             "IconName" to Variant("dev.obiente.nextcloudnative"),
             "ItemIsMenu" to Variant(false),
+            "Menu" to Variant(DBusPath(STATUS_NOTIFIER_MENU_PATH)),
         )
+    }
+}
+
+@DBusInterfaceName(DBUS_MENU_INTERFACE)
+@DBusProperty(name = "Version", type = UInt32::class)
+@DBusProperty(name = "TextDirection", type = String::class)
+@DBusProperty(name = "Status", type = String::class)
+@DBusProperty(name = "IconThemePath", type = List::class)
+internal interface DBusMenu : DBusInterface {
+    @Suppress("FunctionName")
+    fun GetLayout(
+        parentId: Int,
+        recursionDepth: Int,
+        propertyNames: List<String>,
+    ): DBusMenuLayoutResult<UInt32, DBusMenuLayout>
+
+    @Suppress("FunctionName")
+    fun GetGroupProperties(ids: List<Int>, propertyNames: List<String>): List<DBusMenuItemProperties>
+
+    @Suppress("FunctionName")
+    fun GetProperty(id: Int, name: String): Variant<*>
+
+    @Suppress("FunctionName")
+    fun Event(id: Int, eventId: String, data: Variant<*>, timestamp: UInt32)
+
+    @Suppress("FunctionName")
+    fun EventGroup(events: List<DBusMenuEvent>): List<Int>
+
+    @Suppress("FunctionName")
+    fun AboutToShow(id: Int): Boolean
+
+    @Suppress("FunctionName")
+    fun AboutToShowGroup(ids: List<Int>): DBusMenuAboutToShowResult<List<Int>, List<Int>>
+}
+
+internal class DBusMenuLayout(
+    @field:Position(0) @JvmField val id: Int,
+    @field:Position(1) @JvmField val properties: Map<String, Variant<*>>,
+    @field:Position(2) @JvmField val children: List<Variant<DBusMenuLayout>>,
+) : Struct()
+
+internal class DBusMenuLayoutResult<A, B>(
+    @field:Position(0) @JvmField val revision: A,
+    @field:Position(1) @JvmField val layout: B,
+) : Tuple()
+
+internal class DBusMenuItemProperties(
+    @field:Position(0) @JvmField val id: Int,
+    @field:Position(1) @JvmField val properties: Map<String, Variant<*>>,
+) : Struct()
+
+internal class DBusMenuEvent(
+    @field:Position(0) @JvmField val id: Int,
+    @field:Position(1) @JvmField val eventId: String,
+    @field:Position(2) @JvmField val data: Variant<*>,
+    @field:Position(3) @JvmField val timestamp: UInt32,
+) : Struct()
+
+internal class DBusMenuAboutToShowResult<A, B>(
+    @field:Position(0) @JvmField val updatesNeeded: A,
+    @field:Position(1) @JvmField val idErrors: B,
+) : Tuple()
+
+internal class LinuxDBusMenu(
+    private val onAction: (DesktopTrayAction) -> Unit,
+) : DBusMenu, Properties {
+    override fun getObjectPath(): String = STATUS_NOTIFIER_MENU_PATH
+
+    override fun GetLayout(
+        parentId: Int,
+        recursionDepth: Int,
+        propertyNames: List<String>,
+    ): DBusMenuLayoutResult<UInt32, DBusMenuLayout> = DBusMenuLayoutResult(
+        UInt32(1),
+        menuLayout(parentId, recursionDepth, propertyNames),
+    )
+
+    override fun GetGroupProperties(
+        ids: List<Int>,
+        propertyNames: List<String>,
+    ): List<DBusMenuItemProperties> = ids.mapNotNull { id ->
+        menuItemProperties(id, propertyNames)?.let { DBusMenuItemProperties(id, it) }
+    }
+
+    override fun GetProperty(id: Int, name: String): Variant<*> =
+        requireNotNull(menuItemProperties(id, listOf(name))?.get(name)) {
+            "Unknown D-Bus menu property: $id/$name"
+        }
+
+    override fun Event(id: Int, eventId: String, data: Variant<*>, timestamp: UInt32) {
+        if (eventId != "clicked") return
+        when (id) {
+            MENU_SHOW_ACTIVITY_ID -> onAction(DesktopTrayAction.ShowActivity)
+            MENU_OPEN_APP_ID -> onAction(DesktopTrayAction.OpenApp)
+            MENU_QUIT_ID -> onAction(DesktopTrayAction.Quit)
+        }
+    }
+
+    override fun EventGroup(events: List<DBusMenuEvent>): List<Int> {
+        events.forEach { event -> Event(event.id, event.eventId, event.data, event.timestamp) }
+        return events.mapNotNull { event -> event.id.takeUnless(::isKnownMenuId) }
+    }
+
+    override fun AboutToShow(id: Int): Boolean = false
+
+    override fun AboutToShowGroup(
+        ids: List<Int>,
+    ): DBusMenuAboutToShowResult<List<Int>, List<Int>> = DBusMenuAboutToShowResult(
+        updatesNeeded = emptyList(),
+        idErrors = ids.filterNot(::isKnownMenuId),
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <A : Any?> Get(interfaceName: String, propertyName: String): A =
+        requireNotNull(menuProperties(interfaceName)[propertyName]) {
+            "Unknown D-Bus menu property: $propertyName"
+        }.value as A
+
+    override fun <A : Any?> Set(interfaceName: String, propertyName: String, value: A) {
+        error("D-Bus menu properties are read-only.")
+    }
+
+    override fun GetAll(interfaceName: String): Map<String, Variant<*>> = menuProperties(interfaceName)
+
+    private fun menuProperties(interfaceName: String): Map<String, Variant<*>> {
+        if (interfaceName != DBUS_MENU_INTERFACE) return emptyMap()
+        return linkedMapOf(
+            "Version" to Variant(UInt32(3)),
+            "TextDirection" to Variant("ltr"),
+            "Status" to Variant("normal"),
+            "IconThemePath" to Variant(emptyList<String>(), "as"),
+        )
+    }
+
+    private fun menuLayout(
+        parentId: Int,
+        recursionDepth: Int,
+        propertyNames: List<String>,
+    ): DBusMenuLayout {
+        if (parentId != MENU_ROOT_ID) {
+            val properties = requireNotNull(menuItemProperties(parentId, propertyNames))
+            return DBusMenuLayout(parentId, properties, emptyList())
+        }
+        val children = if (recursionDepth == 0) {
+            emptyList()
+        } else {
+            MENU_ITEMS.map { (id, _) ->
+                Variant(DBusMenuLayout(id, menuItemProperties(id, propertyNames).orEmpty(), emptyList()))
+            }
+        }
+        return DBusMenuLayout(
+            MENU_ROOT_ID,
+            filterMenuProperties(mapOf("children-display" to Variant("submenu")), propertyNames),
+            children,
+        )
+    }
+
+    private fun menuItemProperties(id: Int, propertyNames: List<String>): Map<String, Variant<*>>? =
+        MENU_ITEMS.firstOrNull { it.first == id }?.let { (_, label) ->
+            filterMenuProperties(mapOf("label" to Variant(label)), propertyNames)
+        }
+
+    private fun filterMenuProperties(
+        properties: Map<String, Variant<*>>,
+        requested: List<String>,
+    ): Map<String, Variant<*>> = if (requested.isEmpty()) {
+        properties
+    } else {
+        properties.filterKeys(requested::contains)
+    }
+
+    private fun isKnownMenuId(id: Int): Boolean = id == MENU_ROOT_ID || MENU_ITEMS.any {
+        it.first == id
     }
 }
 
@@ -178,20 +364,25 @@ private class LinuxStatusNotifierTray private constructor(
     }
 
     companion object {
-        fun register(tooltip: String, onActivated: () -> Unit): DesktopTrayRegistration? =
+        fun register(
+            tooltip: String,
+            onAction: (DesktopTrayAction) -> Unit,
+        ): DesktopTrayRegistration? =
             runCatching {
                 val connection = DBusConnectionBuilder.forSessionBus().withShared(false).build()
                 val serviceName = "org.freedesktop.StatusNotifierItem-${ProcessHandle.current().pid()}-1"
                 val item = LinuxStatusNotifierItem(
                     initialTooltip = tooltip,
-                    onActivated = onActivated,
+                    onAction = onAction,
                     onTitleChanged = {
                         connection.sendMessage(StatusNotifierItem.NewTitle(STATUS_NOTIFIER_ITEM_PATH))
                     },
                 )
+                val menu = LinuxDBusMenu(onAction)
                 try {
                     connection.requestBusName(serviceName)
                     connection.exportObject(item)
+                    connection.exportObject(menu)
                     val registerWithWatcher = {
                         connection.getRemoteObject(
                             STATUS_NOTIFIER_WATCHER_SERVICE,
@@ -243,3 +434,14 @@ private const val STATUS_NOTIFIER_WATCHER_PATH = "/StatusNotifierWatcher"
 private const val STATUS_NOTIFIER_WATCHER_INTERFACE = "org.kde.StatusNotifierWatcher"
 private const val STATUS_NOTIFIER_ITEM_INTERFACE = "org.kde.StatusNotifierItem"
 private const val STATUS_NOTIFIER_ITEM_PATH = "/StatusNotifierItem"
+private const val STATUS_NOTIFIER_MENU_PATH = "/Menu"
+private const val DBUS_MENU_INTERFACE = "com.canonical.dbusmenu"
+private const val MENU_ROOT_ID = 0
+private const val MENU_SHOW_ACTIVITY_ID = 1
+private const val MENU_OPEN_APP_ID = 2
+private const val MENU_QUIT_ID = 3
+private val MENU_ITEMS = listOf(
+    MENU_SHOW_ACTIVITY_ID to "Show sync activity",
+    MENU_OPEN_APP_ID to "Open Nextcloud Native",
+    MENU_QUIT_ID to "Quit",
+)

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
@@ -5,6 +5,12 @@ import java.awt.TrayIcon
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.imageio.ImageIO
+import javax.swing.JMenuItem
+import javax.swing.JPopupMenu
+import javax.swing.JWindow
+import javax.swing.SwingUtilities
+import javax.swing.event.PopupMenuEvent
+import javax.swing.event.PopupMenuListener
 import org.freedesktop.dbus.annotations.DBusInterfaceName
 import org.freedesktop.dbus.annotations.DBusProperty
 import org.freedesktop.dbus.annotations.Position
@@ -123,6 +129,7 @@ internal interface StatusNotifierItem : DBusInterface {
 internal class LinuxStatusNotifierItem(
     initialTooltip: String,
     private val onAction: (DesktopTrayAction) -> Unit,
+    private val onContextMenu: (Int, Int) -> Unit = { _, _ -> },
     private val onTitleChanged: () -> Unit = {},
 ) : StatusNotifierItem, Properties {
     @Volatile
@@ -142,7 +149,7 @@ internal class LinuxStatusNotifierItem(
 
     override fun SecondaryActivate(x: Int, y: Int) = onAction(DesktopTrayAction.ShowActivity)
 
-    override fun ContextMenu(x: Int, y: Int) = onAction(DesktopTrayAction.ShowActivity)
+    override fun ContextMenu(x: Int, y: Int) = onContextMenu(x, y)
 
     override fun Scroll(delta: Int, orientation: String) = Unit
 
@@ -176,7 +183,7 @@ internal class LinuxStatusNotifierItem(
 @DBusProperty(name = "Version", type = UInt32::class)
 @DBusProperty(name = "TextDirection", type = String::class)
 @DBusProperty(name = "Status", type = String::class)
-@DBusProperty(name = "IconThemePath", type = List::class)
+@DBusProperty(name = "IconThemePath", type = Array<String>::class)
 internal interface DBusMenu : DBusInterface {
     @Suppress("FunctionName")
     fun GetLayout(
@@ -249,7 +256,7 @@ internal class LinuxDBusMenu(
     override fun GetGroupProperties(
         ids: List<Int>,
         propertyNames: List<String>,
-    ): List<DBusMenuItemProperties> = ids.mapNotNull { id ->
+    ): List<DBusMenuItemProperties> = (ids.ifEmpty { allMenuIds }).mapNotNull { id ->
         menuItemProperties(id, propertyNames)?.let { DBusMenuItemProperties(id, it) }
     }
 
@@ -260,11 +267,7 @@ internal class LinuxDBusMenu(
 
     override fun Event(id: Int, eventId: String, data: Variant<*>, timestamp: UInt32) {
         if (eventId != "clicked") return
-        when (id) {
-            MENU_SHOW_ACTIVITY_ID -> onAction(DesktopTrayAction.ShowActivity)
-            MENU_OPEN_APP_ID -> onAction(DesktopTrayAction.OpenApp)
-            MENU_QUIT_ID -> onAction(DesktopTrayAction.Quit)
-        }
+        menuAction(id)?.let(onAction)
     }
 
     override fun EventGroup(events: List<DBusMenuEvent>): List<Int> {
@@ -299,7 +302,7 @@ internal class LinuxDBusMenu(
             "Version" to Variant(UInt32(3)),
             "TextDirection" to Variant("ltr"),
             "Status" to Variant("normal"),
-            "IconThemePath" to Variant(emptyList<String>(), "as"),
+            "IconThemePath" to Variant(emptyArray<String>()),
         )
     }
 
@@ -355,6 +358,7 @@ private class LinuxStatusNotifierTray private constructor(
     private val connection: DBusConnection,
     private val serviceName: String,
     private val item: LinuxStatusNotifierItem,
+    private val contextMenu: LinuxTrayContextMenu,
     private val watcherOwnerSubscription: AutoCloseable,
 ) : DesktopTrayRegistration {
     override fun updateTooltip(tooltip: String) {
@@ -365,6 +369,7 @@ private class LinuxStatusNotifierTray private constructor(
 
     override fun close() {
         runCatching { watcherOwnerSubscription.close() }
+        runCatching { contextMenu.close() }
         runCatching { connection.releaseBusName(serviceName) }
         runCatching { connection.close() }
     }
@@ -377,9 +382,11 @@ private class LinuxStatusNotifierTray private constructor(
             runCatching {
                 val connection = DBusConnectionBuilder.forSessionBus().withShared(false).build()
                 val serviceName = "org.freedesktop.StatusNotifierItem-${ProcessHandle.current().pid()}-1"
+                val contextMenu = LinuxTrayContextMenu(onAction)
                 val item = LinuxStatusNotifierItem(
                     initialTooltip = tooltip,
                     onAction = onAction,
+                    onContextMenu = contextMenu::show,
                     onTitleChanged = {
                         connection.sendMessage(StatusNotifierItem.NewTitle(STATUS_NOTIFIER_ITEM_PATH))
                     },
@@ -407,9 +414,11 @@ private class LinuxStatusNotifierTray private constructor(
                         connection,
                         serviceName,
                         item,
+                        contextMenu,
                         watcherOwnerSubscription,
                     )
                 } catch (failure: Throwable) {
+                    runCatching { contextMenu.close() }
                     runCatching { connection.close() }
                     throw failure
                 }
@@ -419,6 +428,48 @@ private class LinuxStatusNotifierTray private constructor(
                         "${failure::class.simpleName}: ${failure.message.orEmpty()}",
                 )
             }.getOrNull()
+    }
+}
+
+private class LinuxTrayContextMenu(
+    private val onAction: (DesktopTrayAction) -> Unit,
+) : AutoCloseable {
+    private var owner: JWindow? = null
+
+    fun show(x: Int, y: Int) {
+        SwingUtilities.invokeLater {
+            closeNow()
+            val window = JWindow().apply {
+                isAlwaysOnTop = true
+                setLocation(x.coerceAtLeast(0), y.coerceAtLeast(0))
+                setSize(1, 1)
+                isVisible = true
+            }
+            owner = window
+            val popup = JPopupMenu().apply {
+                MENU_ITEMS.forEach { (id, label) ->
+                    add(JMenuItem(label).apply {
+                        addActionListener { menuAction(id)?.let(onAction) }
+                    })
+                }
+                addPopupMenuListener(object : PopupMenuListener {
+                    override fun popupMenuWillBecomeVisible(event: PopupMenuEvent) = Unit
+                    override fun popupMenuWillBecomeInvisible(event: PopupMenuEvent) = closeNow()
+                    override fun popupMenuCanceled(event: PopupMenuEvent) = closeNow()
+                })
+            }
+            popup.show(window.contentPane, 0, 0)
+        }
+    }
+
+    override fun close() {
+        SwingUtilities.invokeLater(::closeNow)
+    }
+
+    private fun closeNow() {
+        val window = owner
+        owner = null
+        window?.dispose()
     }
 }
 
@@ -451,3 +502,11 @@ private val MENU_ITEMS = listOf(
     MENU_OPEN_APP_ID to "Open Nextcloud Native",
     MENU_QUIT_ID to "Quit",
 )
+private val allMenuIds = listOf(MENU_ROOT_ID) + MENU_ITEMS.map(Pair<Int, String>::first)
+
+private fun menuAction(id: Int): DesktopTrayAction? = when (id) {
+    MENU_SHOW_ACTIVITY_ID -> DesktopTrayAction.ShowActivity
+    MENU_OPEN_APP_ID -> DesktopTrayAction.OpenApp
+    MENU_QUIT_ID -> DesktopTrayAction.Quit
+    else -> null
+}

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopTray.kt
@@ -321,14 +321,20 @@ internal class LinuxDBusMenu(
         }
         return DBusMenuLayout(
             MENU_ROOT_ID,
-            filterMenuProperties(mapOf("children-display" to Variant("submenu")), propertyNames),
+            requireNotNull(menuItemProperties(MENU_ROOT_ID, propertyNames)),
             children,
         )
     }
 
     private fun menuItemProperties(id: Int, propertyNames: List<String>): Map<String, Variant<*>>? =
-        MENU_ITEMS.firstOrNull { it.first == id }?.let { (_, label) ->
-            filterMenuProperties(mapOf("label" to Variant(label)), propertyNames)
+        when (id) {
+            MENU_ROOT_ID -> filterMenuProperties(
+                mapOf("children-display" to Variant("submenu")),
+                propertyNames,
+            )
+            else -> MENU_ITEMS.firstOrNull { it.first == id }?.let { (_, label) ->
+                filterMenuProperties(mapOf("label" to Variant(label)), propertyNames)
+            }
         }
 
     private fun filterMenuProperties(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -1375,7 +1375,7 @@ internal class LinuxNextcloudVirtualFileSystem(
         try {
             unmountOperation(this)
             detached = true
-            fuseConnectionId?.let(::abortLinuxFuseConnection)
+            abortLinuxFuseConnectionBestEffort(fuseConnectionId)
         } finally {
             readHandles.values.forEach { runCatching(it::close) }
             writeHandles.values.map(LinuxOpenWriteReference::shared).distinct().forEach { shared ->
@@ -1647,6 +1647,13 @@ private fun abortLinuxFuseConnection(connectionId: Int) {
         Path.of("/sys/fs/fuse/connections", connectionId.toString(), "abort"),
         "1\n",
     )
+}
+
+internal fun abortLinuxFuseConnectionBestEffort(
+    connectionId: Int?,
+    abortOperation: (Int) -> Unit = ::abortLinuxFuseConnection,
+) {
+    connectionId?.let { runCatching { abortOperation(it) } }
 }
 
 private const val MAX_UNSIGNED_UNIX_ID = 0xffff_ffffL

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -1,7 +1,10 @@
 package dev.obiente.nextcloudnative.app
 
+import java.nio.ByteBuffer
+import java.nio.channels.SeekableByteChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
@@ -1372,11 +1375,13 @@ internal class LinuxNextcloudVirtualFileSystem(
     fun unmount() {
         var detached = false
         val fuseConnectionId = mountedAt?.let(::linuxFuseConnectionIdForMount)
+        val fuseAbortHandle = fuseConnectionId?.let(::openLinuxFuseAbortHandle)
         try {
             unmountOperation(this)
             detached = true
-            abortLinuxFuseConnectionBestEffort(fuseConnectionId)
+            fuseAbortHandle?.abortBestEffort()
         } finally {
+            runCatching { fuseAbortHandle?.close() }
             readHandles.values.forEach { runCatching(it::close) }
             writeHandles.values.map(LinuxOpenWriteReference::shared).distinct().forEach { shared ->
                 runCatching(shared.delegate::close)
@@ -1641,19 +1646,25 @@ internal fun linuxFuseConnectionIdForMount(
     }
 }
 
-private fun abortLinuxFuseConnection(connectionId: Int) {
+private fun openLinuxFuseAbortHandle(connectionId: Int): LinuxFuseAbortHandle? {
     require(connectionId >= 0)
-    Files.writeString(
+    return openLinuxFuseAbortHandle(
         Path.of("/sys/fs/fuse/connections", connectionId.toString(), "abort"),
-        "1\n",
     )
 }
 
-internal fun abortLinuxFuseConnectionBestEffort(
-    connectionId: Int?,
-    abortOperation: (Int) -> Unit = ::abortLinuxFuseConnection,
-) {
-    connectionId?.let { runCatching { abortOperation(it) } }
+internal fun openLinuxFuseAbortHandle(path: Path): LinuxFuseAbortHandle? = runCatching {
+    LinuxFuseAbortHandle(Files.newByteChannel(path, StandardOpenOption.WRITE))
+}.getOrNull()
+
+internal class LinuxFuseAbortHandle(
+    private val channel: SeekableByteChannel,
+) : AutoCloseable {
+    fun abortBestEffort() {
+        runCatching { channel.write(ByteBuffer.wrap("1\n".encodeToByteArray())) }
+    }
+
+    override fun close() = channel.close()
 }
 
 private const val MAX_UNSIGNED_UNIX_ID = 0xffff_ffffL

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt
@@ -1,5 +1,6 @@
 package dev.obiente.nextcloudnative.app
 
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -1099,6 +1100,8 @@ internal class LinuxNextcloudVirtualFileSystem(
     private val mountOwnerUid: Long = linuxEffectiveProcessUid(),
     private val mountOwnerGid: Long = linuxEffectiveProcessGid(),
 ) : FuseStubFS() {
+    @Volatile
+    private var mountedAt: Path? = null
     private val nextHandle = AtomicLong(1L)
     private val readHandles = ConcurrentHashMap<Long, LinuxVirtualFileReadHandle>()
     private val readHandlePaths = ConcurrentHashMap<Long, String>()
@@ -1363,13 +1366,16 @@ internal class LinuxNextcloudVirtualFileSystem(
                 "-o", "big_writes",
             ),
         )
+        mountedAt = mountPoint.toAbsolutePath().normalize()
     }
 
     fun unmount() {
         var detached = false
+        val fuseConnectionId = mountedAt?.let(::linuxFuseConnectionIdForMount)
         try {
             unmountOperation(this)
             detached = true
+            fuseConnectionId?.let(::abortLinuxFuseConnection)
         } finally {
             readHandles.values.forEach { runCatching(it::close) }
             writeHandles.values.map(LinuxOpenWriteReference::shared).distinct().forEach { shared ->
@@ -1383,7 +1389,10 @@ internal class LinuxNextcloudVirtualFileSystem(
                 openDirectoryEntries = 0L
             }
             pendingCreatedFiles.clear()
-            if (detached) backend.close()
+            if (detached) {
+                mountedAt = null
+                backend.close()
+            }
         }
     }
 
@@ -1605,6 +1614,40 @@ internal class LinuxNextcloudVirtualFileSystem(
 private fun linuxEffectiveProcessUid(): Long = Integer.toUnsignedLong(POSIXFactory.getPOSIX().geteuid())
 
 private fun linuxEffectiveProcessGid(): Long = Integer.toUnsignedLong(POSIXFactory.getPOSIX().getegid())
+
+internal fun linuxFuseConnectionIdForMount(
+    mountPoint: Path,
+    mountInfo: String = runCatching { Files.readString(Path.of("/proc/self/mountinfo")) }.getOrDefault(""),
+): Int? {
+    val encodedMountPoint = mountPoint.toAbsolutePath().normalize().toString()
+        .replace("\\", "\\134")
+        .replace(" ", "\\040")
+        .replace("\t", "\\011")
+        .replace("\n", "\\012")
+    return mountInfo.lineSequence().firstNotNullOfOrNull { line ->
+        val fields = line.split(' ')
+        val separator = fields.indexOf("-")
+        if (
+            fields.size < 7 ||
+            separator < 6 ||
+            separator + 2 >= fields.size ||
+            fields[4] != encodedMountPoint ||
+            fields[separator + 1].let { type -> type != "fuse" && !type.startsWith("fuse.") } ||
+            fields[separator + 2] != "nextcloud-native"
+        ) {
+            return@firstNotNullOfOrNull null
+        }
+        fields[2].substringAfter(':', "").toIntOrNull()
+    }
+}
+
+private fun abortLinuxFuseConnection(connectionId: Int) {
+    require(connectionId >= 0)
+    Files.writeString(
+        Path.of("/sys/fs/fuse/connections", connectionId.toString(), "abort"),
+        "1\n",
+    )
+}
 
 private const val MAX_UNSIGNED_UNIX_ID = 0xffff_ffffL
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
@@ -170,7 +170,7 @@ fun main(arguments: Array<String>) {
     }
 
     fun toggleTrayPopup() {
-        SwingUtilities.invokeLater {
+        runOnAwtEventThread {
             val visible = trayPopupWindow.value?.isVisible != true
             trayPopupVisible.value = visible
             trayPopupWindow.value?.let { popup ->
@@ -385,6 +385,14 @@ internal fun nextDesktopFocusRequestSequence(current: Long): Long =
 internal fun shouldKeepDesktopProcessRunningOnWindowClose(
     keepRunningInBackground: Boolean,
 ): Boolean = keepRunningInBackground
+
+internal fun runOnAwtEventThread(action: () -> Unit) {
+    if (SwingUtilities.isEventDispatchThread()) {
+        action()
+    } else {
+        SwingUtilities.invokeLater(action)
+    }
+}
 
 private fun FileSyncCenterActionResult.trayMessage(): String = when (this) {
     is FileSyncCenterActionResult.Completed -> message

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
@@ -27,6 +27,7 @@ import dev.obiente.nextcloudnative.app.DesktopActivationKind
 import dev.obiente.nextcloudnative.app.DesktopSingleInstance
 import dev.obiente.nextcloudnative.app.DesktopSingleInstanceStart
 import dev.obiente.nextcloudnative.app.DesktopTrayRegistration
+import dev.obiente.nextcloudnative.app.DesktopTrayAction
 import dev.obiente.nextcloudnative.app.DesktopTrayActionFeedback
 import dev.obiente.nextcloudnative.app.DesktopFileSyncTrayPhase
 import dev.obiente.nextcloudnative.app.DesktopFileSyncTrayPopup
@@ -168,34 +169,18 @@ fun main(arguments: Array<String>) {
         onDispose(services::close)
     }
 
-    DisposableEffect(Unit) {
-        val registration = registerDesktopTray(
-            tooltip = traySnapshot.tooltip(),
-            onActivated = {
-                SwingUtilities.invokeLater {
-                    val visible = trayPopupWindow.value?.isVisible != true
-                    trayPopupVisible.value = visible
-                    trayPopupWindow.value?.let { popup ->
-                        popup.isVisible = visible
-                        if (visible) {
-                            popup.toFront()
-                            popup.requestFocus()
-                        }
-                    }
+    fun toggleTrayPopup() {
+        SwingUtilities.invokeLater {
+            val visible = trayPopupWindow.value?.isVisible != true
+            trayPopupVisible.value = visible
+            trayPopupWindow.value?.let { popup ->
+                popup.isVisible = visible
+                if (visible) {
+                    popup.toFront()
+                    popup.requestFocus()
                 }
-            },
-        )
-        desktopTrayRegistration.value = registration
-        trayAvailable.value = registration != null
-        trayRegistrationResolved.value = true
-        onDispose {
-            trayAvailable.value = false
-            desktopTrayRegistration.value = null
-            registration?.close()
+            }
         }
-    }
-    SideEffect {
-        desktopTrayRegistration.value?.updateTooltip(traySnapshot.tooltip())
     }
 
     fun showMainWindow() {
@@ -215,6 +200,32 @@ fun main(arguments: Array<String>) {
     fun quitDesktopApp() {
         stopLinuxUserServiceForExplicitQuit()
         exitApplication()
+    }
+
+    DisposableEffect(Unit) {
+        val registration = registerDesktopTray(
+            tooltip = traySnapshot.tooltip(),
+            onAction = { action ->
+                SwingUtilities.invokeLater {
+                    when (action) {
+                        DesktopTrayAction.ShowActivity -> toggleTrayPopup()
+                        DesktopTrayAction.OpenApp -> showMainWindow()
+                        DesktopTrayAction.Quit -> quitDesktopApp()
+                    }
+                }
+            },
+        )
+        desktopTrayRegistration.value = registration
+        trayAvailable.value = registration != null
+        trayRegistrationResolved.value = true
+        onDispose {
+            trayAvailable.value = false
+            desktopTrayRegistration.value = null
+            registration?.close()
+        }
+    }
+    SideEffect {
+        desktopTrayRegistration.value?.updateTooltip(traySnapshot.tooltip())
     }
 
     LaunchedEffect(singleInstance) {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLoginTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLoginTest.kt
@@ -235,6 +235,24 @@ class DesktopStartOnLoginTest {
     }
 
     @Test
+    fun supervisedExplicitQuitLetsTheCurrentProcessExitCleanly() {
+        val commands = mutableListOf<List<String>>()
+
+        assertTrue(
+            stopLinuxUserServiceForExplicitQuit(
+                osName = "Linux",
+                currentProcessIsLinuxUserService = { true },
+                processRunner = { command ->
+                    commands += command
+                    0
+                },
+            ),
+        )
+
+        assertTrue(commands.isEmpty())
+    }
+
+    @Test
     fun windowsRegistrationUsesTheCurrentUserRunKey() {
         val root = createTempDirectory("nextcloud-native-startup-windows").toFile()
         val launcher = File(root, "NextcloudNative.exe").apply { writeText("launcher") }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopTrayTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopTrayTest.kt
@@ -7,6 +7,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.freedesktop.dbus.types.UInt32
+import org.freedesktop.dbus.types.Variant
 import org.junit.Assume.assumeTrue
 
 class DesktopTrayTest {
@@ -29,25 +31,57 @@ class DesktopTrayTest {
         val activated = CountDownLatch(1)
         val registration = registerDesktopTray(
             "Nextcloud Native - all files are synced",
-            activated::countDown,
+            { action ->
+                if (action == DesktopTrayAction.ShowActivity) activated.countDown()
+            },
         )
 
         assertNotNull(registration)
         try {
             val serviceName = "org.freedesktop.StatusNotifierItem-${ProcessHandle.current().pid()}-1"
-            val activation = ProcessBuilder(
+            val menuPath = ProcessBuilder(
+                "busctl",
+                "--user",
+                "get-property",
+                serviceName,
+                "/StatusNotifierItem",
+                "org.kde.StatusNotifierItem",
+                "Menu",
+            ).redirectErrorStream(true).start().let { process ->
+                val output = process.inputStream.bufferedReader().use { it.readText() }
+                assertEquals(0, process.waitFor(), output)
+                output
+            }
+            assertTrue(menuPath.contains("/Menu"), menuPath)
+
+            val layout = ProcessBuilder(
                 "busctl",
                 "--user",
                 "call",
                 serviceName,
-                "/StatusNotifierItem",
-                "org.kde.StatusNotifierItem",
-                "Activate",
-                "ii",
+                "/Menu",
+                "com.canonical.dbusmenu",
+                "GetLayout",
+                "iias",
                 "0",
+                "--",
+                "-1",
                 "0",
-            ).redirectErrorStream(true).start()
-            activation.inputStream.bufferedReader().use { it.readText() }
+            ).redirectErrorStream(true).start().let { process ->
+                val output = process.inputStream.bufferedReader().use { it.readText() }
+                assertEquals(0, process.waitFor(), output)
+                output
+            }
+            assertTrue(layout.contains("Show sync activity"), layout)
+            assertTrue(layout.contains("Open Nextcloud Native"), layout)
+            assertTrue(layout.contains("Quit"), layout)
+
+            val activation = ProcessBuilder(
+                "busctl", "--user", "call", serviceName, "/Menu",
+                "com.canonical.dbusmenu", "Event", "isvu", "1", "clicked", "i", "0", "0",
+            ).redirectErrorStream(true).start().also { process ->
+                process.inputStream.bufferedReader().use { it.readText() }
+            }
             assertEquals(0, activation.waitFor())
             assertTrue(activated.await(2L, TimeUnit.SECONDS))
         } finally {
@@ -61,7 +95,7 @@ class DesktopTrayTest {
         var titleChanges = 0
         val item = LinuxStatusNotifierItem(
             initialTooltip = "All files are synced",
-            onActivated = { activated = true },
+            onAction = { action -> activated = action == DesktopTrayAction.ShowActivity },
             onTitleChanged = { titleChanges += 1 },
         )
 
@@ -97,6 +131,35 @@ class DesktopTrayTest {
         assertTrue(shouldReregisterStatusNotifier("org.kde.StatusNotifierWatcher", ":1.42"))
         assertFalse(shouldReregisterStatusNotifier("org.kde.StatusNotifierWatcher", ""))
         assertFalse(shouldReregisterStatusNotifier("org.example.OtherService", ":1.42"))
+    }
+
+    @Test
+    fun linuxTrayMenuPublishesActionsAndDispatchesClicks() {
+        val actions = mutableListOf<DesktopTrayAction>()
+        val menu = LinuxDBusMenu(actions::add)
+
+        val layout = menu.GetLayout(0, -1, emptyList()).layout
+
+        assertEquals("submenu", layout.properties.getValue("children-display").value)
+        assertEquals(
+            listOf("Show sync activity", "Open Nextcloud Native", "Quit"),
+            layout.children.map { child ->
+                child.value.properties.getValue("label").value
+            },
+        )
+
+        menu.Event(1, "clicked", Variant(0), UInt32(0))
+        menu.Event(2, "clicked", Variant(0), UInt32(0))
+        menu.Event(3, "clicked", Variant(0), UInt32(0))
+
+        assertEquals(
+            listOf(
+                DesktopTrayAction.ShowActivity,
+                DesktopTrayAction.OpenApp,
+                DesktopTrayAction.Quit,
+            ),
+            actions,
+        )
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopTrayTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopTrayTest.kt
@@ -3,10 +3,12 @@ package dev.obiente.nextcloudnative.app
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import org.freedesktop.dbus.annotations.DBusProperty
 import org.freedesktop.dbus.types.UInt32
 import org.freedesktop.dbus.types.Variant
 import org.junit.Assume.assumeTrue
@@ -93,9 +95,11 @@ class DesktopTrayTest {
     fun statusNotifierItemPublishesIdentityAndActivatesTheCustomPanel() {
         var activated = false
         var titleChanges = 0
+        var contextMenuCoordinates: Pair<Int, Int>? = null
         val item = LinuxStatusNotifierItem(
             initialTooltip = "All files are synced",
             onAction = { action -> activated = action == DesktopTrayAction.ShowActivity },
+            onContextMenu = { x, y -> contextMenuCoordinates = x to y },
             onTitleChanged = { titleChanges += 1 },
         )
 
@@ -117,8 +121,10 @@ class DesktopTrayTest {
         item.updateTooltip("Sync needs attention")
 
         item.Activate(0, 0)
+        item.ContextMenu(24, 48)
 
         assertEquals(true, activated)
+        assertEquals(24 to 48, contextMenuCoordinates)
         assertEquals(1, titleChanges)
         assertEquals(
             "Sync needs attention",
@@ -139,12 +145,23 @@ class DesktopTrayTest {
         val menu = LinuxDBusMenu(actions::add)
 
         val layout = menu.GetLayout(0, -1, emptyList()).layout
+        val iconThemeProperty = DBusMenu::class.java.getAnnotationsByType(DBusProperty::class.java)
+            .single { property -> property.name == "IconThemePath" }
 
+        assertEquals(Array<String>::class, iconThemeProperty.type)
+        assertContentEquals(
+            emptyArray(),
+            menu.Get<Array<String>>("com.canonical.dbusmenu", "IconThemePath"),
+        )
         assertEquals("submenu", layout.properties.getValue("children-display").value)
         assertEquals("submenu", menu.GetProperty(0, "children-display").value)
         val rootProperties = menu.GetGroupProperties(listOf(0), listOf("children-display")).single()
         assertEquals(0, rootProperties.id)
         assertEquals("submenu", rootProperties.properties.getValue("children-display").value)
+        assertEquals(
+            listOf(0, 1, 2, 3),
+            menu.GetGroupProperties(emptyList(), emptyList()).map(DBusMenuItemProperties::id),
+        )
         assertEquals(
             listOf("Show sync activity", "Open Nextcloud Native", "Quit"),
             layout.children.map { child ->

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopTrayTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopTrayTest.kt
@@ -141,6 +141,10 @@ class DesktopTrayTest {
         val layout = menu.GetLayout(0, -1, emptyList()).layout
 
         assertEquals("submenu", layout.properties.getValue("children-display").value)
+        assertEquals("submenu", menu.GetProperty(0, "children-display").value)
+        val rootProperties = menu.GetGroupProperties(listOf(0), listOf("children-display")).single()
+        assertEquals(0, rootProperties.id)
+        assertEquals("submenu", rootProperties.properties.getValue("children-display").value)
         assertEquals(
             listOf("Show sync activity", "Open Nextcloud Native", "Quit"),
             layout.children.map { child ->

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assume.assumeTrue
 import org.junit.Before
 import java.nio.ByteBuffer
 import java.nio.file.Files
+import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -30,6 +31,21 @@ import ru.serce.jnrfuse.struct.FileStat
 import ru.serce.jnrfuse.struct.FuseFileInfo
 
 class LinuxVirtualFileSystemTest {
+    @Test
+    fun `own fuse connection is resolved from its exact escaped mount point`() {
+        val mountInfo = """
+            624 73 0:94 / /mnt/Other rw - fuse.rclone remote: rw
+            712 73 0:115 / /mnt/Nextcloud\040Native rw - fuse nextcloud-native rw
+            713 73 0:116 / /mnt/Nextcloud\040Native rw - fuse.jnrfuse another-app rw
+        """.trimIndent()
+
+        assertEquals(
+            115,
+            linuxFuseConnectionIdForMount(Path.of("/mnt/Nextcloud Native"), mountInfo),
+        )
+        assertNull(linuxFuseConnectionIdForMount(Path.of("/mnt/Missing"), mountInfo))
+    }
+
     @Test
     fun largeDirectoryMetadataUsesAnAdaptiveFreshnessWindow() {
         assertEquals(5_000L, linuxVirtualMetadataFreshnessMillis(128, 5_000L))

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -47,15 +47,27 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
-    fun `post-unmount fuse abort is best effort`() {
-        var attemptedConnectionId: Int? = null
+    fun `fuse abort handle stays pinned when its path is reused`() {
+        val directory = Files.createTempDirectory("nc-native-fuse-abort-")
+        val abortPath = directory.resolve("abort")
+        val originalLink = directory.resolve("original-abort")
+        try {
+            Files.createFile(abortPath)
+            Files.createLink(originalLink, abortPath)
+            val handle = assertNotNull(openLinuxFuseAbortHandle(abortPath))
 
-        abortLinuxFuseConnectionBestEffort(115) { connectionId ->
-            attemptedConnectionId = connectionId
-            error("The detached connection has already disappeared")
+            Files.delete(abortPath)
+            Files.writeString(abortPath, "replacement")
+            handle.use(LinuxFuseAbortHandle::abortBestEffort)
+            handle.abortBestEffort()
+
+            assertEquals("1\n", Files.readString(originalLink))
+            assertEquals("replacement", Files.readString(abortPath))
+        } finally {
+            Files.deleteIfExists(abortPath)
+            Files.deleteIfExists(originalLink)
+            Files.deleteIfExists(directory)
         }
-
-        assertEquals(115, attemptedConnectionId)
     }
 
     @Test

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt
@@ -47,6 +47,18 @@ class LinuxVirtualFileSystemTest {
     }
 
     @Test
+    fun `post-unmount fuse abort is best effort`() {
+        var attemptedConnectionId: Int? = null
+
+        abortLinuxFuseConnectionBestEffort(115) { connectionId ->
+            attemptedConnectionId = connectionId
+            error("The detached connection has already disappeared")
+        }
+
+        assertEquals(115, attemptedConnectionId)
+    }
+
+    @Test
     fun largeDirectoryMetadataUsesAnAdaptiveFreshnessWindow() {
         assertEquals(5_000L, linuxVirtualMetadataFreshnessMillis(128, 5_000L))
         assertEquals(30_000L, linuxVirtualMetadataFreshnessMillis(2_000, 5_000L))

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DesktopWindowActivationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DesktopWindowActivationTest.kt
@@ -3,6 +3,7 @@ package dev.obiente.nextcloudnative.nativeui.preview
 import dev.obiente.nextcloudnative.app.NextcloudNativeNavigationRequest
 import dev.obiente.nextcloudnative.app.NextcloudNativeRoute
 import java.awt.Frame
+import javax.swing.SwingUtilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -48,5 +49,16 @@ class DesktopWindowActivationTest {
     fun `background preference does not depend on tray availability`() {
         assertEquals(true, shouldKeepDesktopProcessRunningOnWindowClose(true))
         assertEquals(false, shouldKeepDesktopProcessRunningOnWindowClose(false))
+    }
+
+    @Test
+    fun `tray work already on the event thread runs synchronously`() {
+        SwingUtilities.invokeAndWait {
+            var completed = false
+
+            runOnAwtEventThread { completed = true }
+
+            assertEquals(true, completed)
+        }
     }
 }

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -454,7 +454,7 @@
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DesktopBackgroundSettingsVisualQaMain.kt": "7d90dc22854409b9837b82ba739f7221d425554531a962296ff9e75b0a178c2d",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DynamicBoardInteractionPreviewMain.kt": "7402f5b4bf3bbf3cf20761eaa10eca9131fb6e63da2988d0aa6038942d706c53",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/FileSyncTrayVisualQaMain.kt": "a0533aec3f991b48d57f69ddf7e95124b969631b6a55110f550826ac46ffc1ad",
-        "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt": "f6f3dc55fdbae4c3e10e3a00e8ac13d5b1b19e908e5708c73497e94ec00b8f3d",
+        "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt": "af3d11fdf3c65f1a8d487562e1692f9346fccc6e0499700ed4a55205dee8a9bf",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/MarketingCaptureMain.kt": "759783eb557e8f500d623cdd635a67f94c45ebf9197e96ac2d67e4b4691e5fde",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/MarketingCaptureOwnership.kt": "67cf94e6f215167a2384f14086d135532961c7e91cecb69be8f15e4ee6324606",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/NativeTiffMarketingCapture.kt": "6970352c6e42d09b793c55ea296991d756d232f216d8d152aa00319b2ddb8d20",

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -454,7 +454,7 @@
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DesktopBackgroundSettingsVisualQaMain.kt": "7d90dc22854409b9837b82ba739f7221d425554531a962296ff9e75b0a178c2d",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DynamicBoardInteractionPreviewMain.kt": "7402f5b4bf3bbf3cf20761eaa10eca9131fb6e63da2988d0aa6038942d706c53",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/FileSyncTrayVisualQaMain.kt": "a0533aec3f991b48d57f69ddf7e95124b969631b6a55110f550826ac46ffc1ad",
-        "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt": "af3d11fdf3c65f1a8d487562e1692f9346fccc6e0499700ed4a55205dee8a9bf",
+        "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt": "1d46b38a5b7c7f904e1374c14d3babeddae67e3ed9ce5fc6e513edba37098510",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/MarketingCaptureMain.kt": "759783eb557e8f500d623cdd635a67f94c45ebf9197e96ac2d67e4b4691e5fde",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/MarketingCaptureOwnership.kt": "67cf94e6f215167a2384f14086d135532961c7e91cecb69be8f15e4ee6324606",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/NativeTiffMarketingCapture.kt": "6970352c6e42d09b793c55ea296991d756d232f216d8d152aa00319b2ddb8d20",


### PR DESCRIPTION
## Summary

- export a standard Linux D-Bus tray menu with sync activity, app, and quit actions
- let a systemd-supervised process exit cleanly instead of asking its own unit to stop it
- avoid the virtual-file provider lock inversion during shutdown and release pending requests from the exact Nextcloud Native FUSE connection

## Root cause

Linux tray hosts that render `com.canonical.dbusmenu` had no menu object to display. Explicit quit also asked systemd to stop the currently supervised process, allowing SIGTERM to interrupt Compose teardown. During clean teardown, provider and retained-metadata locks could be acquired in opposite orders, and a detached FUSE mount could retain an in-flight local scan request.

## Impact

Linux tray hosts can render useful Nextcloud Native controls. Quit now completes cleanly even while the Linux virtual filesystem and background sync are active, without leaving the service or its FUSE connection behind.

## Validation

- `./gradlew --no-daemon :ui:desktopTest`
- `./gradlew --no-daemon :ui:createDistributable`
- `bash tools/check-repository.sh`
- Runtime service test: exported menu properties and layout were read over D-Bus, sync activity was opened through the menu event, and Quit exited with status 0 in under one second while removing the app-owned FUSE connection.

Related to #286.
