### PR TITLE
fix(windows): use oplocks for placeholder updates

### DIFF
--- a/changes/unreleased/326-windows-placeholder-update-oplocks.md
+++ b/changes/unreleased/326-windows-placeholder-update-oplocks.md
@@ -1,0 +1,7 @@
+category: fix
+issue: none
+pull: 326
+platforms: desktop, windows
+user-facing: yes
+
+Windows virtual files now use Cloud Files oplocks while updating existing placeholders so File Explorer access cannot interrupt activation with a handle-sharing race.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -24,6 +24,8 @@ private const val ERROR_CLOUD_FILE_METADATA_CORRUPT = 363
 private const val CF_PLACEHOLDER_STATE_PLACEHOLDER = 0x1
 private const val CF_PLACEHOLDER_STATE_IN_SYNC = 0x8
 private const val CF_PLACEHOLDER_STATE_INVALID = -1
+private const val CF_OPEN_FILE_FLAG_EXCLUSIVE = 0x1
+private const val CF_OPEN_FILE_FLAG_WRITE_ACCESS = 0x2
 
 internal fun windowsCloudPlaceholderDiagnosticSampleSize(availableCount: Int): Int {
     require(availableCount >= 0)
@@ -41,6 +43,10 @@ internal fun windowsCloudFailedPlaceholderIndex(
         ?: processedCount.takeIf { it in 0 until placeholderCount }
         ?: (processedCount - 1).takeIf { it in 0 until placeholderCount }
 }
+
+internal fun windowsCloudOpenFileFlags(write: Boolean, exclusive: Boolean): Int =
+    (if (write) CF_OPEN_FILE_FLAG_WRITE_ACCESS else 0) or
+        (if (exclusive) CF_OPEN_FILE_FLAG_EXCLUSIVE else 0)
 
 internal fun windowsCloudPlaceholderInspection(
     findSucceeded: Boolean,
@@ -475,7 +481,7 @@ internal class JnaWindowsCloudFilesApi(
         preserveSyncState: Boolean,
     ) {
         require(!invalidateContent || !preserveSyncState)
-        withFileHandle(path, write = true, exclusive = invalidateContent) { handle ->
+        withCloudFileHandle(path, write = true, exclusive = invalidateContent) { handle ->
             val metadata = placeholder.windowsMetadata(fallbackEpochMillis = null)
             val identity = placeholder.identity.nativeMemory()
             val flags = if (preserveSyncState) {
@@ -652,6 +658,29 @@ internal class JnaWindowsCloudFilesApi(
             block(handle)
         } finally {
             Kernel32.INSTANCE.CloseHandle(handle)
+        }
+    }
+
+    /**
+     * Cloud Files updates use a protected handle so Explorer can break the oplock cleanly instead
+     * of racing a background CreateFile call with a transient sharing violation.
+     */
+    private inline fun <T> withCloudFileHandle(
+        path: Path,
+        write: Boolean,
+        exclusive: Boolean = false,
+        block: (WinNT.HANDLE) -> T,
+    ): T {
+        val handle = WinNT.HANDLEByReference()
+        val flags = windowsCloudOpenFileFlags(write, exclusive)
+        checkHResult(
+            cldApi.CfOpenFileWithOplock(WString(path.toAbsolutePath().toString()), flags, handle),
+            "open a Windows Cloud Files placeholder for update",
+        )
+        return try {
+            block(handle.value)
+        } finally {
+            cldApi.CfCloseHandle(handle.value)
         }
     }
 
@@ -850,6 +879,8 @@ internal interface CldApi : StdCallLibrary {
     fun CfCreatePlaceholders(path: WString, placeholders: Pointer?, count: Int, flags: Int, processed: IntByReference): Int
     fun CfExecute(operationInfo: Pointer, operationParameters: Pointer): Int
     fun CfGetPlaceholderStateFromFindData(findData: Pointer): Int
+    fun CfOpenFileWithOplock(path: WString, flags: Int, protectedHandle: WinNT.HANDLEByReference): Int
+    fun CfCloseHandle(protectedHandle: WinNT.HANDLE)
     fun CfGetPlaceholderInfo(
         handle: WinNT.HANDLE,
         infoClass: Int,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -22,6 +22,13 @@ import kotlin.test.assertTrue
 
 class WindowsCloudFilesProviderTest {
     @Test
+    fun cloudFileUpdateHandlesRequestOnlyRequiredAccess() {
+        assertEquals(0, windowsCloudOpenFileFlags(write = false, exclusive = false))
+        assertEquals(2, windowsCloudOpenFileFlags(write = true, exclusive = false))
+        assertEquals(3, windowsCloudOpenFileFlags(write = true, exclusive = true))
+    }
+
+    @Test
     fun nativeInspectionDistinguishesMissingCorruptAndUnreadableEntries() {
         assertEquals(
             WindowsCloudPlaceholderEntryState.Missing,


### PR DESCRIPTION
## Summary

- open placeholders for Cloud Files updates with `CfOpenFileWithOplock`
- request write access for metadata and identity updates
- request an exclusive protected handle only when an update also dehydrates file content

## Root cause

After placeholder population was serialized, activation could still fail while reconciling an existing placeholder. The update path used an ordinary `CreateFile` background handle. That can race foreground File Explorer access and fail before `CfUpdatePlaceholder` runs. Cloud Files provides protected oplock handles specifically so conflicting foreground access can break and drain a background handle cleanly.

## Impact

Existing Windows placeholders can be reconciled during virtual-files activation without the provider competing with File Explorer through ordinary file-handle sharing.

## Validation

- `./gradlew --no-daemon :ui:desktopTest :ui:createDistributable`
- `bash tools/check-repository.sh`
- `git diff --check`

Hosted Windows packaging and Cloud Files runtime verification remain required.

Follow-up to #324.
