### PR TITLE
fix(windows): tolerate unchanged placeholder refresh failures

### DIFF
--- a/changes/unreleased/windows-placeholder-reconciliation.md
+++ b/changes/unreleased/windows-placeholder-reconciliation.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 329
+pull: none
+platforms: desktop, windows
+user-facing: yes
+
+Windows Cloud Files startup no longer rewrites unchanged file placeholders, and a rejected optional directory refresh no longer disables the complete virtual-files provider.

--- a/changes/unreleased/windows-placeholder-reconciliation.md
+++ b/changes/unreleased/windows-placeholder-reconciliation.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 329
-pull: none
+pull: 330
 platforms: desktop, windows
 user-facing: yes
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -3063,6 +3063,7 @@ class DesktopNextcloudServices(
                 component = SupportDiagnosticComponent.VirtualFiles,
                 operation = operation,
                 outcome = "failed",
+                code = windowsCloudFilesDiagnosticCode(failure),
                 fields = listOf(
                     SupportDiagnosticFieldDraft("account", accountId, SupportDiagnosticValuePrivacy.Identifier),
                     SupportDiagnosticFieldDraft(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -871,6 +871,20 @@ internal class WindowsCloudFilesOperationException(
     val hResult: Int,
 ) : IllegalStateException("Could not $operation (HRESULT 0x${hResult.toUInt().toString(16)}).")
 
+internal fun windowsCloudFilesDiagnosticCode(failure: Throwable): String? {
+    var current: Throwable? = failure
+    repeat(MAX_WINDOWS_CLOUD_FILES_DIAGNOSTIC_CAUSE_DEPTH) {
+        val candidate = current ?: return null
+        if (candidate is WindowsCloudFilesOperationException) {
+            return "HRESULT:0x${candidate.hResult.toUInt().toString(16)}"
+        }
+        current = candidate.cause
+    }
+    return null
+}
+
+private const val MAX_WINDOWS_CLOUD_FILES_DIAGNOSTIC_CAUSE_DEPTH = 6
+
 internal interface CldApi : StdCallLibrary {
     fun CfRegisterSyncRoot(path: WString, registration: CfSyncRegistration, policies: CfSyncPolicies, flags: Int): Int
     fun CfUnregisterSyncRoot(path: WString): Int

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -437,6 +437,8 @@ internal class WindowsCloudFilesProvider(
         Thread(work, "nextcloud-windows-cloud-files").apply { isDaemon = true }
     },
     private val writebackRetryDelayMillis: (attempt: Int) -> Long = ::windowsWritebackRetryDelayMillis,
+    private val directoryRefreshRetryDelayMillis: (attempt: Int) -> Long =
+        ::windowsDirectoryRefreshRetryDelayMillis,
     private val recordDiagnostic: (SupportDiagnosticEventDraft) -> Unit = {},
     private val preserveCorruptRoot: (Path) -> Path = ::preserveWindowsCloudFilesCorruptRoot,
     private val recordPreservedCorruptRoot: (Path) -> Unit = {},
@@ -1375,6 +1377,61 @@ internal class WindowsCloudFilesProvider(
                 ),
             )
             if (!unchangedDirectoryRefresh) throw failure
+            scheduleUnchangedDirectoryRefresh(localPath, current, attempt = 1)
+        }
+    }
+
+    private fun scheduleUnchangedDirectoryRefresh(
+        localPath: Path,
+        identity: WindowsCloudFileIdentity,
+        attempt: Int,
+    ) {
+        if (callbacksPaused.get()) return
+        val delayMillis = directoryRefreshRetryDelayMillis(attempt).coerceAtLeast(0L)
+        runCatching {
+            localChangeScheduler.schedule(
+                {
+                    if (callbacksPaused.get()) return@schedule
+                    runCatching {
+                        executor.execute {
+                            if (callbacksPaused.get()) return@execute
+                            retryUnchangedDirectoryRefresh(localPath, identity, attempt)
+                        }
+                    }
+                },
+                delayMillis,
+                TimeUnit.MILLISECONDS,
+            )
+        }
+    }
+
+    private fun retryUnchangedDirectoryRefresh(
+        localPath: Path,
+        identity: WindowsCloudFileIdentity,
+        attempt: Int,
+    ) {
+        try {
+            api.updatePlaceholder(localPath, placeholder(identity), invalidateContent = false)
+            recordPlaceholderDiagnostic(
+                severity = SupportDiagnosticSeverity.Info,
+                operation = "cloud-files.placeholder-update",
+                outcome = "unchanged-refresh-recovered",
+                localDirectory = localPath.parent ?: root,
+                identity = identity,
+                fields = listOf(SupportDiagnosticFieldDraft("attempt", attempt.toString())),
+            )
+        } catch (failure: WindowsCloudFilesOperationException) {
+            val exhausted = attempt >= MAX_WINDOWS_DIRECTORY_REFRESH_ATTEMPTS
+            recordPlaceholderDiagnostic(
+                severity = SupportDiagnosticSeverity.Warning,
+                operation = "cloud-files.placeholder-update",
+                outcome = if (exhausted) "unchanged-refresh-stale" else "unchanged-refresh-retry-failed",
+                code = "HRESULT:0x${failure.hResult.toUInt().toString(16)}",
+                localDirectory = localPath.parent ?: root,
+                identity = identity,
+                fields = listOf(SupportDiagnosticFieldDraft("attempt", attempt.toString())),
+            )
+            if (!exhausted) scheduleUnchangedDirectoryRefresh(localPath, identity, attempt + 1)
         }
     }
 
@@ -1915,12 +1972,18 @@ private fun String.windowsCloudPath(): String {
 
 private const val WINDOWS_CLOUD_ALIGNMENT = 4 * 1024L
 private const val MAX_WINDOWS_WRITEBACK_ATTEMPTS = 5
+private const val MAX_WINDOWS_DIRECTORY_REFRESH_ATTEMPTS = 4
 private const val DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS = 120L
 private const val DEFAULT_INITIAL_POPULATION_TIMEOUT_SECONDS = 120L
 
 private fun windowsWritebackRetryDelayMillis(attempt: Int): Long {
     require(attempt in 1 until MAX_WINDOWS_WRITEBACK_ATTEMPTS)
     return (250L shl (attempt - 1)).coerceAtMost(30_000L)
+}
+
+private fun windowsDirectoryRefreshRetryDelayMillis(attempt: Int): Long {
+    require(attempt in 1..MAX_WINDOWS_DIRECTORY_REFRESH_ATTEMPTS)
+    return (1_000L shl (attempt - 1)).coerceAtMost(30_000L)
 }
 
 private fun Path.registerForWindowsCloudChanges(watcher: WatchService) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -1298,14 +1298,13 @@ internal class WindowsCloudFilesProvider(
                 ?: return false
             if (rechecked != existing) return false
         }
-        val contentChanged = existing.remoteRevision != authoritative.remoteRevision ||
-            existing.size != authoritative.size ||
-            existing.directory != authoritative.directory
+        val contentChanged = placeholderContentChanged(existing, authoritative)
         if (existing != authoritative || authoritative.directory) {
-            api.updatePlaceholder(
+            updateExistingPlaceholder(
                 localPath,
-                placeholder(authoritative),
-                invalidateContent = contentChanged && !authoritative.directory,
+                previous = existing,
+                current = authoritative,
+                contentChanged = contentChanged,
             )
         }
         knownIdentities[authoritative.path] = authoritative
@@ -1324,15 +1323,15 @@ internal class WindowsCloudFilesProvider(
                 check(previous == null || previous.accountId == backend.accountId && previous.path == identity.path) {
                     "The Windows Cloud Files directory contains remote entries that resolve to the same Windows path."
                 }
-                val contentChanged = previous == null ||
-                    previous.remoteRevision != identity.remoteRevision ||
-                    previous.size != identity.size ||
-                    previous.directory != identity.directory
-                api.updatePlaceholder(
-                    localPath,
-                    placeholder(identity),
-                    invalidateContent = contentChanged && !identity.directory,
-                )
+                val contentChanged = previous == null || placeholderContentChanged(previous, identity)
+                if (previous != identity || identity.directory) {
+                    updateExistingPlaceholder(
+                        localPath,
+                        previous = previous,
+                        current = identity,
+                        contentChanged = contentChanged,
+                    )
+                }
                 knownIdentities[identity.path] = identity
             }
             WindowsCloudPlaceholderState.Dirty -> {
@@ -1344,6 +1343,47 @@ internal class WindowsCloudFilesProvider(
             WindowsCloudPlaceholderState.Absent -> Unit
         }
     }
+
+    private fun updateExistingPlaceholder(
+        localPath: Path,
+        previous: WindowsCloudFileIdentity?,
+        current: WindowsCloudFileIdentity,
+        contentChanged: Boolean,
+    ) {
+        try {
+            api.updatePlaceholder(
+                localPath,
+                placeholder(current),
+                invalidateContent = contentChanged && !current.directory,
+            )
+        } catch (failure: WindowsCloudFilesOperationException) {
+            val unchangedDirectoryRefresh = previous == current && current.directory
+            recordPlaceholderDiagnostic(
+                severity = if (unchangedDirectoryRefresh) {
+                    SupportDiagnosticSeverity.Warning
+                } else {
+                    SupportDiagnosticSeverity.Error
+                },
+                operation = "cloud-files.placeholder-update",
+                outcome = if (unchangedDirectoryRefresh) "unchanged-refresh-skipped" else "failed",
+                code = "HRESULT:0x${failure.hResult.toUInt().toString(16)}",
+                localDirectory = localPath.parent ?: root,
+                identity = current,
+                fields = listOf(
+                    SupportDiagnosticFieldDraft("content_changed", contentChanged.toString()),
+                    SupportDiagnosticFieldDraft("identity_changed", (previous != current).toString()),
+                ),
+            )
+            if (!unchangedDirectoryRefresh) throw failure
+        }
+    }
+
+    private fun placeholderContentChanged(
+        previous: WindowsCloudFileIdentity,
+        current: WindowsCloudFileIdentity,
+    ): Boolean = previous.remoteRevision != current.remoteRevision ||
+        previous.size != current.size ||
+        previous.directory != current.directory
 
     private fun requireIdentity(
         info: WindowsCloudCallbackInfo,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -812,11 +812,13 @@ internal class WindowsCloudFilesProvider(
         submitDestructiveCallback(
             onRejected = { api.acknowledgeDelete(info, false) },
         ) {
-            val accepted = runCatching {
-                val identity = requireIdentity(info, expectDirectory = null)
-                backend.delete(identity)
-                knownIdentities.remove(identity.path)
-            }.isSuccess
+            val accepted = synchronized(namespaceMutationLock) {
+                runCatching {
+                    val identity = requireIdentity(info, expectDirectory = null)
+                    backend.delete(identity)
+                    knownIdentities.remove(identity.path)
+                }.isSuccess
+            }
             api.acknowledgeDelete(info, accepted)
         }
     }
@@ -1406,6 +1408,41 @@ internal class WindowsCloudFilesProvider(
     }
 
     private fun retryUnchangedDirectoryRefresh(
+        localPath: Path,
+        identity: WindowsCloudFileIdentity,
+        attempt: Int,
+    ) {
+        synchronized(namespaceMutationLock) {
+            if (callbacksPaused.get()) return
+            val inspection = api.inspectPlaceholder(localPath)
+            val currentIdentity = if (
+                inspection.state == WindowsCloudPlaceholderEntryState.InSync &&
+                inspection.placeholderState == WindowsCloudPlaceholderState.InSync
+            ) {
+                api.placeholderIdentity(localPath)
+                    ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
+            } else {
+                null
+            }
+            if (currentIdentity != identity) {
+                recordPlaceholderDiagnostic(
+                    severity = SupportDiagnosticSeverity.Warning,
+                    operation = "cloud-files.placeholder-update",
+                    outcome = "unchanged-refresh-abandoned",
+                    localDirectory = localPath.parent ?: root,
+                    identity = identity,
+                    fields = inspection.diagnosticFields() + listOf(
+                        SupportDiagnosticFieldDraft("attempt", attempt.toString()),
+                        SupportDiagnosticFieldDraft("identity_matches", (currentIdentity == identity).toString()),
+                    ),
+                )
+                return
+            }
+            retryVerifiedUnchangedDirectoryRefresh(localPath, identity, attempt)
+        }
+    }
+
+    private fun retryVerifiedUnchangedDirectoryRefresh(
         localPath: Path,
         identity: WindowsCloudFileIdentity,
         attempt: Int,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1430,6 +1430,96 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `startup does not rewrite an unchanged file placeholder`() {
+        val root = createTempDirectory("windows-cloud-unchanged-file-")
+        val local = root.resolve("example.raf")
+        local.writeBytes("cached bytes".encodeToByteArray())
+        val identity = fixtureIdentity(size = local.toFile().length()).copy(path = "example.raf")
+        val backend = FakeBackend("cached bytes".encodeToByteArray(), listed = listOf(identity))
+        val api = FakeApi().apply { seed(local, WindowsCloudPlaceholderState.InSync, identity) }
+        val provider = WindowsCloudFilesProvider(root, backend, api)
+
+        provider.start()
+
+        assertTrue(api.updatedPaths.isEmpty())
+        assertEquals(identity, api.decodedIdentity(local))
+        provider.close()
+    }
+
+    @Test
+    fun `startup keeps an unchanged directory active when its optional refresh is rejected`() {
+        val root = createTempDirectory("windows-cloud-unchanged-directory-")
+        val local = root.resolve("Photos")
+        local.toFile().mkdirs()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val failure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val diagnostics = mutableListOf<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend(ByteArray(0), listed = listOf(identity))
+        val api = FakeApi().apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            updatePlaceholderFailure = failure
+        }
+        val provider = WindowsCloudFilesProvider(root, backend, api, recordDiagnostic = diagnostics::add)
+
+        provider.start()
+
+        assertEquals(listOf(local), api.updatedPaths)
+        assertEquals("unchanged-refresh-skipped", diagnostics.single().outcome)
+        assertEquals("HRESULT:0x80070179", diagnostics.single().code)
+        assertEquals(identity, api.decodedIdentity(local))
+        provider.close()
+    }
+
+    @Test
+    fun `startup fails closed and records the HRESULT when a changed placeholder update is rejected`() {
+        val root = createTempDirectory("windows-cloud-changed-update-failure-")
+        val local = root.resolve("example.raf")
+        local.writeBytes("cached bytes".encodeToByteArray())
+        val previous = fixtureIdentity(size = local.toFile().length()).copy(path = "example.raf")
+        val current = previous.copy(remoteRevision = "new-remote-revision")
+        val failure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val diagnostics = mutableListOf<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend("new bytes".encodeToByteArray(), listed = listOf(current))
+        val api = FakeApi().apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, previous)
+            updatePlaceholderFailure = failure
+        }
+        val provider = WindowsCloudFilesProvider(root, backend, api, recordDiagnostic = diagnostics::add)
+
+        try {
+            assertEquals(
+                failure,
+                assertFailsWith<WindowsCloudFilesOperationException> { provider.start() },
+            )
+            assertEquals("failed", diagnostics.single().outcome)
+            assertEquals("HRESULT:0x80070179", diagnostics.single().code)
+            assertEquals(
+                "true",
+                diagnostics.single().fields.single { it.name == "content_changed" }.value,
+            )
+        } finally {
+            provider.close()
+        }
+    }
+
+    @Test
+    fun `Windows Cloud Files diagnostic code follows a bounded cause chain`() {
+        val failure = IllegalStateException(
+            "activation failed",
+            WindowsCloudFilesOperationException("update a placeholder", 0x80070179.toInt()),
+        )
+
+        assertEquals("HRESULT:0x80070179", windowsCloudFilesDiagnosticCode(failure))
+        assertEquals(null, windowsCloudFilesDiagnosticCode(IllegalStateException("unrelated")))
+    }
+
+    @Test
     fun `recovery uploads against the dirty placeholder revision`() {
         val root = createTempDirectory("windows-cloud-recovery-")
         val local = root.resolve("edit.txt")
@@ -1835,6 +1925,7 @@ class WindowsCloudFilesProviderTest {
         val disconnectAttempts = mutableListOf<Long>()
         var disconnectFailure: RuntimeException? = null
         var createPlaceholdersHook: ((Path, List<WindowsCloudPlaceholder>) -> Unit)? = null
+        var updatePlaceholderFailure: WindowsCloudFilesOperationException? = null
         var closed = false
         val lifecycleEvents = mutableListOf<String>()
 
@@ -1906,6 +1997,7 @@ class WindowsCloudFilesProviderTest {
             preserveSyncState: Boolean,
         ) {
             updatedPaths.add(path)
+            updatePlaceholderFailure?.let { throw it }
             if (!preserveSyncState) states[path] = WindowsCloudPlaceholderState.InSync
             identities[path] = placeholder.identity.copyOf()
             if (invalidateContent) invalidatedUpdates.add(path)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1474,6 +1474,85 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `startup retries a rejected unchanged directory refresh`() {
+        val root = createTempDirectory("windows-cloud-unchanged-directory-retry-")
+        val local = root.resolve("Photos")
+        local.toFile().mkdirs()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val failure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend(ByteArray(0), listed = listOf(identity))
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            updatePlaceholderFailure = failure
+            updatePlaceholderFailuresRemaining = 1
+        }
+        val provider = WindowsCloudFilesProvider(
+            root,
+            backend,
+            api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+        )
+
+        provider.start()
+
+        assertTrue(api.awaitPlaceholderUpdates())
+        val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (diagnostics.none { it.outcome == "unchanged-refresh-recovered" } && System.nanoTime() < recoveryDeadline) {
+            Thread.yield()
+        }
+        assertEquals(2, api.updatedPaths.size)
+        assertTrue(diagnostics.any { it.outcome == "unchanged-refresh-skipped" })
+        assertTrue(diagnostics.any { it.outcome == "unchanged-refresh-recovered" })
+        assertEquals(identity, api.decodedIdentity(local))
+        provider.close()
+    }
+
+    @Test
+    fun `startup reports an unchanged directory as stale after bounded refresh retries`() {
+        val root = createTempDirectory("windows-cloud-unchanged-directory-stale-")
+        val local = root.resolve("Photos")
+        local.toFile().mkdirs()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val failure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend(ByteArray(0), listed = listOf(identity))
+        val api = FakeApi(expectedPlaceholderUpdates = 5).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            updatePlaceholderFailure = failure
+        }
+        val provider = WindowsCloudFilesProvider(
+            root,
+            backend,
+            api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+        )
+
+        provider.start()
+
+        assertTrue(api.awaitPlaceholderUpdates())
+        val staleDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (diagnostics.none { it.outcome == "unchanged-refresh-stale" } && System.nanoTime() < staleDeadline) {
+            Thread.yield()
+        }
+        assertEquals(5, api.updatedPaths.size)
+        assertEquals("unchanged-refresh-stale", diagnostics.last().outcome)
+        assertEquals(
+            "4",
+            diagnostics.last().fields.single { it.name == "attempt" }.value,
+        )
+        provider.close()
+    }
+
+    @Test
     fun `startup fails closed and records the HRESULT when a changed placeholder update is rejected`() {
         val root = createTempDirectory("windows-cloud-changed-update-failure-")
         val local = root.resolve("example.raf")
@@ -1903,12 +1982,14 @@ class WindowsCloudFilesProviderTest {
         expectedRenames: Int = 0,
         expectedIdentityReads: Int = 0,
         expectedPlaceholderFetches: Int = 0,
+        expectedPlaceholderUpdates: Int = 0,
     ) : WindowsCloudFilesApi {
         private val transferLatch = CountDownLatch(expectedTransfers)
         private val conversionLatch = CountDownLatch(expectedConversions)
         private val renameLatch = CountDownLatch(expectedRenames)
         private val identityReadLatch = CountDownLatch(expectedIdentityReads)
         private val placeholderFetchLatch = CountDownLatch(expectedPlaceholderFetches)
+        private val placeholderUpdateLatch = CountDownLatch(expectedPlaceholderUpdates)
         private val states = HashMap<Path, WindowsCloudPlaceholderState>()
         private val inspections = HashMap<Path, WindowsCloudPlaceholderInspection>()
         private val inspectionScripts = HashMap<Path, ArrayDeque<WindowsCloudPlaceholderInspection>>()
@@ -1926,6 +2007,7 @@ class WindowsCloudFilesProviderTest {
         var disconnectFailure: RuntimeException? = null
         var createPlaceholdersHook: ((Path, List<WindowsCloudPlaceholder>) -> Unit)? = null
         var updatePlaceholderFailure: WindowsCloudFilesOperationException? = null
+        var updatePlaceholderFailuresRemaining: Int = Int.MAX_VALUE
         var closed = false
         val lifecycleEvents = mutableListOf<String>()
 
@@ -1997,10 +2079,19 @@ class WindowsCloudFilesProviderTest {
             preserveSyncState: Boolean,
         ) {
             updatedPaths.add(path)
-            updatePlaceholderFailure?.let { throw it }
-            if (!preserveSyncState) states[path] = WindowsCloudPlaceholderState.InSync
-            identities[path] = placeholder.identity.copyOf()
-            if (invalidateContent) invalidatedUpdates.add(path)
+            try {
+                updatePlaceholderFailure?.let { failure ->
+                    if (updatePlaceholderFailuresRemaining > 0) {
+                        updatePlaceholderFailuresRemaining -= 1
+                        throw failure
+                    }
+                }
+                if (!preserveSyncState) states[path] = WindowsCloudPlaceholderState.InSync
+                identities[path] = placeholder.identity.copyOf()
+                if (invalidateContent) invalidatedUpdates.add(path)
+            } finally {
+                placeholderUpdateLatch.countDown()
+            }
         }
         override fun convertToPlaceholder(path: Path, placeholder: WindowsCloudPlaceholder) {
             states[path] = WindowsCloudPlaceholderState.Dirty
@@ -2020,6 +2111,8 @@ class WindowsCloudFilesProviderTest {
         fun awaitIdentityReads(): Boolean = identityReadLatch.await(5, TimeUnit.SECONDS)
         fun awaitPlaceholderFetches(timeoutMillis: Long = TimeUnit.SECONDS.toMillis(5)): Boolean =
             placeholderFetchLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)
+        fun awaitPlaceholderUpdates(timeoutMillis: Long = TimeUnit.SECONDS.toMillis(5)): Boolean =
+            placeholderUpdateLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)
 
         fun decodedIdentity(path: Path): WindowsCloudFileIdentity? =
             placeholderIdentity(path)?.let(WindowsCloudFileIdentityCodec::decode)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1553,6 +1553,49 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `startup abandons a delayed directory refresh when the path identity changed`() {
+        val root = createTempDirectory("windows-cloud-unchanged-directory-replaced-")
+        val local = root.resolve("Photos")
+        local.toFile().mkdirs()
+        val original = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val replacement = original.copy(remoteRevision = "replacement-revision")
+        val failure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend(ByteArray(0), listed = listOf(original))
+        val api = FakeApi(expectedPlaceholderUpdates = 1).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, original)
+            updatePlaceholderFailure = failure
+            updatePlaceholderFailuresRemaining = 1
+            onUpdatePlaceholderFailure = {
+                seed(local, WindowsCloudPlaceholderState.InSync, replacement)
+            }
+        }
+        val provider = WindowsCloudFilesProvider(
+            root,
+            backend,
+            api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+        )
+
+        provider.start()
+
+        assertTrue(api.awaitPlaceholderUpdates())
+        val abandonedDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (diagnostics.none { it.outcome == "unchanged-refresh-abandoned" } && System.nanoTime() < abandonedDeadline) {
+            Thread.yield()
+        }
+        assertEquals(1, api.updatedPaths.size)
+        assertEquals(replacement, api.decodedIdentity(local))
+        val abandoned = diagnostics.single { it.outcome == "unchanged-refresh-abandoned" }
+        assertEquals("false", abandoned.fields.single { it.name == "identity_matches" }.value)
+        provider.close()
+    }
+
+    @Test
     fun `startup fails closed and records the HRESULT when a changed placeholder update is rejected`() {
         val root = createTempDirectory("windows-cloud-changed-update-failure-")
         val local = root.resolve("example.raf")
@@ -1807,7 +1850,7 @@ class WindowsCloudFilesProviderTest {
         backend.uploadFailuresRemaining = 0
         provider.closed(info, deleted = false)
 
-        assertTrue(api.awaitConversions())
+        assertTrue(api.awaitConversions(TimeUnit.SECONDS.toMillis(15)))
         val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
         while (provider.summary().pendingWritebackCount != 0 && System.nanoTime() < recoveryDeadline) {
             Thread.yield()
@@ -2008,6 +2051,7 @@ class WindowsCloudFilesProviderTest {
         var createPlaceholdersHook: ((Path, List<WindowsCloudPlaceholder>) -> Unit)? = null
         var updatePlaceholderFailure: WindowsCloudFilesOperationException? = null
         var updatePlaceholderFailuresRemaining: Int = Int.MAX_VALUE
+        var onUpdatePlaceholderFailure: (() -> Unit)? = null
         var closed = false
         val lifecycleEvents = mutableListOf<String>()
 
@@ -2083,6 +2127,7 @@ class WindowsCloudFilesProviderTest {
                 updatePlaceholderFailure?.let { failure ->
                     if (updatePlaceholderFailuresRemaining > 0) {
                         updatePlaceholderFailuresRemaining -= 1
+                        onUpdatePlaceholderFailure?.invoke()
                         throw failure
                     }
                 }
@@ -2106,7 +2151,8 @@ class WindowsCloudFilesProviderTest {
         }
 
         fun awaitTransfers(): Boolean = transferLatch.await(5, TimeUnit.SECONDS)
-        fun awaitConversions(): Boolean = conversionLatch.await(5, TimeUnit.SECONDS)
+        fun awaitConversions(timeoutMillis: Long = TimeUnit.SECONDS.toMillis(5)): Boolean =
+            conversionLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)
         fun awaitRenames(): Boolean = renameLatch.await(5, TimeUnit.SECONDS)
         fun awaitIdentityReads(): Boolean = identityReadLatch.await(5, TimeUnit.SECONDS)
         fun awaitPlaceholderFetches(timeoutMillis: Long = TimeUnit.SECONDS.toMillis(5)): Boolean =


### PR DESCRIPTION
## Summary

- avoid rewriting unchanged in-sync file placeholders during Windows Cloud Files startup
- keep the provider active when Windows rejects an optional refresh of an unchanged directory
- retain hard failures for changed remote content or identity
- include the structured HRESULT and anonymized placeholder context in support diagnostics

Closes #329

## Validation

- `./gradlew --no-daemon :ui:desktopTest --tests 'dev.obiente.nextcloudnative.app.WindowsCloudFilesProviderTest'`
- focused unchanged file, unchanged directory, changed placeholder, and diagnostic cause-chain tests
- `bash tools/check-repository.sh`
- `./gradlew --no-daemon :ui:createDistributable`

## Platform evidence

The failing support report came from Windows 10 amd64 package 1.0.3691. It confirms `CfOpenFileWithOplock` succeeds before `CfUpdatePlaceholder` rejects startup reconciliation. Hosted Windows packaging remains required before merge.
