### PR TITLE
fix(windows): recover corrupt placeholder updates

### DIFF
--- a/changes/unreleased/333-windows-corrupt-placeholder-update.md
+++ b/changes/unreleased/333-windows-corrupt-placeholder-update.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 333
-pull: none
+pull: 334
 platforms: windows
 user-facing: yes
 

--- a/changes/unreleased/333-windows-corrupt-placeholder-update.md
+++ b/changes/unreleased/333-windows-corrupt-placeholder-update.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 333
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows filesync now preserves the existing root and rebuilds File Explorer integration when placeholder refresh reveals corrupt Cloud Files metadata.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -915,6 +915,15 @@ internal fun combinedAutomaticCacheExcess(
     return (total - maximumBytes).coerceAtLeast(0L)
 }
 
+internal fun detachVirtualFileProviderForReplacement(
+    provider: AutoCloseable?,
+    detach: () -> Unit,
+    onCleanupFailure: (Throwable) -> Unit,
+) {
+    detach()
+    runCatching { provider?.close() }.onFailure(onCleanupFailure)
+}
+
 class DesktopNextcloudServices(
     private val onThemePreferenceChanged: (ThemePreference) -> Unit = {},
     private val onKeepRunningInBackgroundChanged: (Boolean) -> Unit = {},
@@ -1864,9 +1873,22 @@ class DesktopNextcloudServices(
                         "Windows Cloud Files are already connected at ${desktopWindowsCloudFilesRoot(accountId).absolutePath}.",
                     )
                 }
-                windowsCloudFilesProvider?.close()
-                windowsCloudFilesProvider = null
-                windowsCloudFilesIdentity = null
+                val replacedProvider = windowsCloudFilesProvider
+                detachVirtualFileProviderForReplacement(
+                    provider = replacedProvider,
+                    detach = {
+                        windowsCloudFilesProvider = null
+                        windowsCloudFilesIdentity = null
+                    },
+                    onCleanupFailure = { failure ->
+                        recordVirtualFileFailure(
+                            operation = "cloud-files.failed-provider-cleanup",
+                            accountId = accountId,
+                            root = desktopWindowsCloudFilesRoot(accountId).toPath(),
+                            failure = failure,
+                        )
+                    },
+                )
                 val root = desktopWindowsCloudFilesRoot(accountId).toPath()
                 val userHome = File(System.getProperty("user.home"))
                 val backend = DesktopNextcloudWindowsCloudFilesBackend(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -1944,11 +1944,13 @@ class DesktopNextcloudServices(
                 )
                 windowsCloudFilesProvider = provider
                 windowsCloudFilesIdentity = accountId
+                // Clear an earlier activation error before this provider can report a runtime
+                // failure. Never clear it after startup, where that would race the callback.
+                windowsCloudFilesFailure = null
                 try {
                     provider.start()
                     provider.recoverAfterStartup()
                     provider.runtimeRecoveryFailure()?.let { throw it }
-                    windowsCloudFilesFailure = null
                     preferences.put(
                         windowsCloudFilesRootPreferenceKey(accountId),
                         root.toAbsolutePath().toString(),

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -969,8 +969,11 @@ class DesktopNextcloudServices(
     private var linuxVirtualMetadataBackend: CachingLinuxVirtualFileBackend? = null
     private var linuxVirtualFileMountIdentity: String? = null
     private var linuxVirtualFileFailure: String? = null
+    @Volatile
     private var windowsCloudFilesProvider: WindowsCloudFilesProvider? = null
+    @Volatile
     private var windowsCloudFilesIdentity: String? = null
+    @Volatile
     private var windowsCloudFilesFailure: String? = null
     private val dynamicApiReadCache = DynamicApiResponseCache(
         desktopContractCacheDirectory("responses"),
@@ -1667,11 +1670,13 @@ class DesktopNextcloudServices(
         val windows = isWindowsDesktop()
         val cacheTiers = if (linux) desktopVirtualFileCacheTiers(preferences, accountId).configuration else null
         val overflowUnavailable = ranges != null && ranges.overflowCachedBytes > 0L && !ranges.overflowAvailable
+        val windowsFailure = windowsCloudFilesFailure
         val active = synchronized(virtualFileProviderLock) {
             (linux && linuxVirtualFileSystem != null && linuxVirtualFileMountIdentity == accountId) ||
-                (windows && windowsCloudFilesProvider != null && windowsCloudFilesIdentity == accountId)
+                (windows && windowsFailure == null && windowsCloudFilesProvider != null &&
+                    windowsCloudFilesIdentity == accountId)
         }
-        val windowsSummary = windowsVirtualFileSummary(accountId)
+        val windowsSummary = if (windowsFailure == null) windowsVirtualFileSummary(accountId) else null
         val writebacks = defaultDesktopLinuxWritebackStore(session).pendingWritebacks()
         VirtualFileStorageSnapshot(
             support = if (linux || windows) VirtualFileStorageSupport.Available else VirtualFileStorageSupport.CacheOnly,
@@ -1706,7 +1711,7 @@ class DesktopNextcloudServices(
                     add("Cache tier movement needs attention: $failure")
                 }
                 linuxVirtualFileFailure?.let { add("The last Linux mount attempt failed: $it") }
-                windowsCloudFilesFailure?.let { add("The last Windows Cloud Files activation failed: $it") }
+                windowsFailure?.let { add("The Windows Cloud Files integration needs recovery: $it") }
                 if (windows) {
                     add("Windows can dehydrate in-sync placeholders automatically when space is needed.")
                 }
@@ -1724,9 +1729,9 @@ class DesktopNextcloudServices(
                 (windowsSummary?.failedWritebackCount ?: 0) > 0 || windowsCloudFilesRecoveryNotice != null ->
                     VirtualFileProviderState.NeedsAttention
                 overflowUnavailable || ranges?.tierAttention != null -> VirtualFileProviderState.NeedsAttention
-                active -> VirtualFileProviderState.Active
-                rangeCacheResult.isFailure || linuxVirtualFileFailure != null || windowsCloudFilesFailure != null ->
+                rangeCacheResult.isFailure || linuxVirtualFileFailure != null || windowsFailure != null ->
                     VirtualFileProviderState.NeedsAttention
+                active -> VirtualFileProviderState.Active
                 linux || windows -> VirtualFileProviderState.Inactive
                 else -> VirtualFileProviderState.NotApplicable
             },
@@ -1912,7 +1917,8 @@ class DesktopNextcloudServices(
                     throw failure
                 }
                 val api = JnaWindowsCloudFilesApi(recordDiagnostic = recordCloudFilesDiagnostic)
-                val provider = WindowsCloudFilesProvider(
+                lateinit var provider: WindowsCloudFilesProvider
+                provider = WindowsCloudFilesProvider(
                     root = root,
                     backend = backend,
                     api = api,
@@ -1921,12 +1927,24 @@ class DesktopNextcloudServices(
                         persistWindowsCloudFilesPreservedRoot(preferences, accountId, preserved)
                         windowsCloudFilesRecoveryNotice = windowsCloudFilesRecoveryNoticeMessage(preserved)
                     },
+                    onRuntimeFailure = { failure ->
+                        if (windowsCloudFilesProvider === provider) {
+                            windowsCloudFilesFailure = failure.message ?: "Unknown Cloud Files recovery failure"
+                        }
+                        recordVirtualFileFailure(
+                            operation = "cloud-files.runtime-recovery",
+                            accountId = accountId,
+                            root = root,
+                            failure = failure,
+                        )
+                    },
                 )
+                windowsCloudFilesProvider = provider
+                windowsCloudFilesIdentity = accountId
                 try {
                     provider.start()
                     provider.recoverAfterStartup()
-                    windowsCloudFilesProvider = provider
-                    windowsCloudFilesIdentity = accountId
+                    provider.runtimeRecoveryFailure()?.let { throw it }
                     windowsCloudFilesFailure = null
                     preferences.put(
                         windowsCloudFilesRootPreferenceKey(accountId),
@@ -1936,6 +1954,10 @@ class DesktopNextcloudServices(
                     preferences.putBoolean(virtualFileProviderPreferenceKey(accountId), true)
                 } catch (failure: Throwable) {
                     runCatching(provider::close)
+                    if (windowsCloudFilesProvider === provider) {
+                        windowsCloudFilesProvider = null
+                        windowsCloudFilesIdentity = null
+                    }
                     windowsCloudFilesFailure = failure.message ?: "Unknown Cloud Files activation failure"
                     recordVirtualFileFailure(
                         operation = "cloud-files.activation",

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -915,14 +915,12 @@ internal fun combinedAutomaticCacheExcess(
     return (total - maximumBytes).coerceAtLeast(0L)
 }
 
-internal fun detachVirtualFileProviderForReplacement(
+internal fun closeVirtualFileProviderForReplacement(
     provider: AutoCloseable?,
     detach: () -> Unit,
-    onCleanupFailure: (Throwable) -> Unit,
-) {
-    detach()
-    runCatching { provider?.close() }.onFailure(onCleanupFailure)
-}
+): Throwable? = runCatching { provider?.close() }
+    .onSuccess { detach() }
+    .exceptionOrNull()
 
 class DesktopNextcloudServices(
     private val onThemePreferenceChanged: (ThemePreference) -> Unit = {},
@@ -1874,21 +1872,22 @@ class DesktopNextcloudServices(
                     )
                 }
                 val replacedProvider = windowsCloudFilesProvider
-                detachVirtualFileProviderForReplacement(
+                closeVirtualFileProviderForReplacement(
                     provider = replacedProvider,
                     detach = {
                         windowsCloudFilesProvider = null
                         windowsCloudFilesIdentity = null
                     },
-                    onCleanupFailure = { failure ->
-                        recordVirtualFileFailure(
-                            operation = "cloud-files.failed-provider-cleanup",
-                            accountId = accountId,
-                            root = desktopWindowsCloudFilesRoot(accountId).toPath(),
-                            failure = failure,
-                        )
-                    },
-                )
+                )?.let { failure ->
+                    windowsCloudFilesFailure = failure.message ?: "Unknown Cloud Files cleanup failure"
+                    recordVirtualFileFailure(
+                        operation = "cloud-files.failed-provider-cleanup",
+                        accountId = accountId,
+                        root = desktopWindowsCloudFilesRoot(accountId).toPath(),
+                        failure = failure,
+                    )
+                    throw failure
+                }
                 val root = desktopWindowsCloudFilesRoot(accountId).toPath()
                 val userHome = File(System.getProperty("user.home"))
                 val backend = DesktopNextcloudWindowsCloudFilesBackend(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -1856,7 +1856,10 @@ class DesktopNextcloudServices(
                 val recordCloudFilesDiagnostic: (SupportDiagnosticEventDraft) -> Unit = { event ->
                     supportDiagnostics.recordForAccountIdentity(accountId, event)
                 }
-                if (windowsCloudFilesProvider != null && windowsCloudFilesIdentity == accountId) {
+                if (
+                    windowsCloudFilesProvider != null && windowsCloudFilesIdentity == accountId &&
+                    windowsCloudFilesFailure == null && windowsCloudFilesProvider?.runtimeRecoveryFailure() == null
+                ) {
                     return@withContext VirtualFileStorageActionResult.Completed(
                         "Windows Cloud Files are already connected at ${desktopWindowsCloudFilesRoot(accountId).absolutePath}.",
                     )

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 internal const val MAX_WINDOWS_CLOUD_PLACEHOLDER_DIAGNOSTIC_RESULTS = 16
 private const val ERROR_FILE_NOT_FOUND = 2
 private const val ERROR_PATH_NOT_FOUND = 3
-private const val ERROR_CLOUD_FILE_METADATA_CORRUPT = 363
+internal const val WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT = 363
 private const val CF_PLACEHOLDER_STATE_PLACEHOLDER = 0x1
 private const val CF_PLACEHOLDER_STATE_IN_SYNC = 0x8
 private const val CF_PLACEHOLDER_STATE_INVALID = -1
@@ -61,7 +61,7 @@ internal fun windowsCloudPlaceholderInspection(
             ERROR_FILE_NOT_FOUND,
             ERROR_PATH_NOT_FOUND,
             -> WindowsCloudPlaceholderEntryState.Missing
-            ERROR_CLOUD_FILE_METADATA_CORRUPT -> WindowsCloudPlaceholderEntryState.Corrupt
+            WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT -> WindowsCloudPlaceholderEntryState.Corrupt
             else -> WindowsCloudPlaceholderEntryState.Unreadable
         }
         return WindowsCloudPlaceholderInspection(state = state, win32Error = error)
@@ -76,7 +76,7 @@ internal fun windowsCloudPlaceholderInspection(
         null
     }
     val state = when {
-        stateBits == CF_PLACEHOLDER_STATE_INVALID && stateError == ERROR_CLOUD_FILE_METADATA_CORRUPT ->
+        stateBits == CF_PLACEHOLDER_STATE_INVALID && stateError == WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT ->
             WindowsCloudPlaceholderEntryState.Corrupt
         stateBits == CF_PLACEHOLDER_STATE_INVALID -> WindowsCloudPlaceholderEntryState.Unreadable
         stateBits and CF_PLACEHOLDER_STATE_PLACEHOLDER == 0 -> WindowsCloudPlaceholderEntryState.Local
@@ -865,6 +865,9 @@ internal fun isWindowsCloudFilesConnectionAbsentResult(result: Int): Boolean =
 
 internal fun isWindowsCloudFilesPlaceholderAlreadyExistsResult(result: Int): Boolean =
     result == 0x800700B7.toInt() // HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)
+
+internal fun isWindowsCloudFilesPlaceholderMetadataCorruptResult(result: Int): Boolean =
+    result == 0x8007016B.toInt() // HRESULT_FROM_WIN32(ERROR_CLOUD_FILE_METADATA_CORRUPT)
 
 internal class WindowsCloudFilesOperationException(
     operation: String,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -1362,14 +1362,19 @@ internal class WindowsCloudFilesProvider(
             )
         } catch (failure: WindowsCloudFilesOperationException) {
             val unchangedDirectoryRefresh = previous == current && current.directory
+            val corruptMetadata = isWindowsCloudFilesPlaceholderMetadataCorruptResult(failure.hResult)
             recordPlaceholderDiagnostic(
-                severity = if (unchangedDirectoryRefresh) {
+                severity = if (unchangedDirectoryRefresh && !corruptMetadata) {
                     SupportDiagnosticSeverity.Warning
                 } else {
                     SupportDiagnosticSeverity.Error
                 },
                 operation = "cloud-files.placeholder-update",
-                outcome = if (unchangedDirectoryRefresh) "unchanged-refresh-skipped" else "failed",
+                outcome = when {
+                    corruptMetadata -> "corrupt-metadata-detected"
+                    unchangedDirectoryRefresh -> "unchanged-refresh-skipped"
+                    else -> "failed"
+                },
                 code = "HRESULT:0x${failure.hResult.toUInt().toString(16)}",
                 localDirectory = localPath.parent ?: root,
                 identity = current,
@@ -1378,6 +1383,17 @@ internal class WindowsCloudFilesProvider(
                     SupportDiagnosticFieldDraft("identity_changed", (previous != current).toString()),
                 ),
             )
+            if (corruptMetadata) {
+                throw corruptPlaceholder(
+                    identity = current,
+                    localDirectory = localPath.parent ?: root,
+                    inspection = WindowsCloudPlaceholderInspection(
+                        state = WindowsCloudPlaceholderEntryState.Corrupt,
+                        win32Error = WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT,
+                    ),
+                    cause = failure,
+                )
+            }
             if (!unchangedDirectoryRefresh) throw failure
             scheduleUnchangedDirectoryRefresh(localPath, current, attempt = 1)
         }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -696,9 +696,10 @@ internal class WindowsCloudFilesProvider(
                 DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS,
             )
             corruptRootRecoveryGeneration.incrementAndGet()
-            if (initialRecoveryFailure is WindowsCloudFilesCorruptEntryException) {
-                initialRecoveryFailure = null
-            }
+            // The completed initial scan describes the preserved root generation. Once the
+            // replacement root has been populated and scanned successfully, none of its
+            // failures can safely be applied to the new generation.
+            initialRecoveryFailure = null
         } catch (failure: Throwable) {
             if (failure is InterruptedException) Thread.currentThread().interrupt()
             if (failure.suppressed.none { it === recovery.corruption }) {
@@ -776,32 +777,34 @@ internal class WindowsCloudFilesProvider(
     /** Repairs the legacy namespace and flushes recoverable local writes before changing root generations. */
     fun recoverBeforeRootMigration(timeoutSeconds: Long = 120L) {
         require(timeoutSeconds > 0L)
-        runtimeRecoveryFailure.get()?.let { throw it }
         var deferredCorruption: WindowsCloudFilesCorruptEntryException? = null
-        try {
-            repairRemotePlaceholderTree()
-        } catch (corruption: WindowsCloudFilesCorruptEntryException) {
-            deferredCorruption = corruption
-        }
-        if (deferredCorruption == null) {
+        synchronized(corruptRootStableAccessLock) {
+            runtimeRecoveryFailure.get()?.let { throw it }
             try {
-                recoverLocalPlaceholders(failClosed = true)
-                recoverUnmanagedLocalEntries(failClosed = true)
+                repairRemotePlaceholderTree()
             } catch (corruption: WindowsCloudFilesCorruptEntryException) {
                 deferredCorruption = corruption
             }
+            if (deferredCorruption == null) {
+                try {
+                    recoverLocalPlaceholders(failClosed = true)
+                    recoverUnmanagedLocalEntries(failClosed = true)
+                } catch (corruption: WindowsCloudFilesCorruptEntryException) {
+                    deferredCorruption = corruption
+                }
+            }
+            check(initialRecoveryFinished.await(timeoutSeconds, TimeUnit.SECONDS)) {
+                "Timed out while checking the legacy Windows Cloud Files root for local edits."
+            }
+            runtimeRecoveryFailure.get()?.let { throw it }
+            when (val failure = initialRecoveryFailure) {
+                is WindowsCloudFilesCorruptEntryException -> deferredCorruption = deferredCorruption ?: failure
+                null -> Unit
+                else -> throw failure
+            }
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
+            awaitWritebackRecovery(deadline)
         }
-        check(initialRecoveryFinished.await(timeoutSeconds, TimeUnit.SECONDS)) {
-            "Timed out while checking the legacy Windows Cloud Files root for local edits."
-        }
-        runtimeRecoveryFailure.get()?.let { throw it }
-        when (val failure = initialRecoveryFailure) {
-            is WindowsCloudFilesCorruptEntryException -> deferredCorruption = deferredCorruption ?: failure
-            null -> Unit
-            else -> throw failure
-        }
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
-        awaitWritebackRecovery(deadline)
         deferredCorruption?.let { corruption ->
             val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
             recoverCorruptRoot(
@@ -809,7 +812,10 @@ internal class WindowsCloudFilesProvider(
                 corruption,
                 quiescenceTimeoutSeconds = timeoutSeconds,
             )
-            repairRemotePlaceholderTree()
+            initialRecoveryFailure = null
+            synchronized(corruptRootStableAccessLock) {
+                repairRemotePlaceholderTree()
+            }
         }
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -462,9 +462,11 @@ internal class WindowsCloudFilesProvider(
     private val writebackAttempts = ConcurrentHashMap<String, Int>()
     private val namespaceMutationLock = Any()
     private val callbacksPaused = AtomicBoolean(false)
+    private val corruptRootRecoveryLifecycleLock = Any()
     private val corruptRootRecoveryClaimed = AtomicBoolean(false)
     private val corruptRootRecoveryGeneration = AtomicLong(0L)
     private val runtimeRecoveryFailure = AtomicReference<Throwable?>(null)
+    private val runtimeStopping = AtomicBoolean(false)
     private val destructiveCallbackOperations = AtomicInteger()
     private val localChangeScheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { work ->
         Thread(work, "nextcloud-windows-local-changes").apply { isDaemon = true }
@@ -530,7 +532,8 @@ internal class WindowsCloudFilesProvider(
         require(quiescenceTimeoutSeconds > 0L)
         val observedGeneration = corruptRootRecoveryGeneration.get()
         val claimDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(quiescenceTimeoutSeconds)
-        while (!corruptRootRecoveryClaimed.compareAndSet(false, true)) {
+        while (!claimCorruptRootRecovery()) {
+            check(!runtimeStopping.get()) { "Windows Cloud Files is stopping." }
             runtimeRecoveryFailure.get()?.let { throw it }
             if (corruptRootRecoveryGeneration.get() != observedGeneration) return
             check(System.nanoTime() < claimDeadline) {
@@ -657,15 +660,10 @@ internal class WindowsCloudFilesProvider(
     ) {
         var claimed = false
         try {
-            check(runtimeStarted.await(DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                "Timed out waiting for Windows Cloud Files startup before corrupt-root recovery."
-            }
-            check(initialRecoveryFinished.await(DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                "Timed out waiting for the initial local-change scan before corrupt-root recovery."
-            }
+            if (runtimeStopping.get()) return
             if (runtimeRecoveryFailure.get() != null) return
             if (recovery.generation != corruptRootRecoveryGeneration.get()) return
-            if (!corruptRootRecoveryClaimed.compareAndSet(false, true)) {
+            if (!claimCorruptRootRecovery()) {
                 recordPlaceholderDiagnostic(
                     severity = SupportDiagnosticSeverity.Info,
                     operation = "cloud-files.corrupt-root-recovery",
@@ -708,6 +706,32 @@ internal class WindowsCloudFilesProvider(
     }
 
     fun runtimeRecoveryFailure(): Throwable? = runtimeRecoveryFailure.get()
+
+    private fun claimCorruptRootRecovery(): Boolean = synchronized(corruptRootRecoveryLifecycleLock) {
+        !runtimeStopping.get() && corruptRootRecoveryClaimed.compareAndSet(false, true)
+    }
+
+    private fun scheduleCorruptRootRecoveryAfterStartup(
+        recovery: WindowsCloudFilesDelayedCorruptRootRecovery,
+    ) {
+        if (callbacksPaused.get() || runtimeStopping.get() || runtimeRecoveryFailure.get() != null) return
+        runCatching {
+            localChangeScheduler.schedule(
+                {
+                    if (callbacksPaused.get() || runtimeStopping.get()) return@schedule
+                    if (runtimeStarted.count > 0L || initialRecoveryFinished.count > 0L) {
+                        scheduleCorruptRootRecoveryAfterStartup(recovery)
+                        return@schedule
+                    }
+                    runCatching {
+                        executor.execute { recoverCorruptRootAfterDelayedRefresh(recovery) }
+                    }
+                },
+                DELAYED_CORRUPT_ROOT_RECOVERY_POLL_MILLIS,
+                TimeUnit.MILLISECONDS,
+            )
+        }
+    }
 
     private fun connectWithRegistrationRecovery(syncRootIdentity: ByteArray): Long =
         try {
@@ -1104,7 +1128,14 @@ internal class WindowsCloudFilesProvider(
     }
 
     private fun stopRuntime() {
-        callbacksPaused.set(true)
+        synchronized(corruptRootRecoveryLifecycleLock) {
+            runtimeStopping.set(true)
+            callbacksPaused.set(true)
+        }
+        localChangeScheduler.shutdownNow()
+        awaitCorruptRootRecoveryCompletion(
+            System.nanoTime() + TimeUnit.SECONDS.toNanos(DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS),
+        )
         val key = connection.get()
         if (key != 0L) {
             api.disconnect(key)
@@ -1114,8 +1145,24 @@ internal class WindowsCloudFilesProvider(
         cancelledRequests.clear()
         stopLocalWatcher()
         queuedPathOperations.clear()
-        localChangeScheduler.shutdownNow()
         executor.shutdownNow()
+    }
+
+    private fun awaitCorruptRootRecoveryCompletion(deadline: Long) {
+        while (corruptRootRecoveryClaimed.get() && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(25L)
+            } catch (interrupted: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw IllegalStateException(
+                    "Interrupted while waiting for Windows Cloud Files recovery to stop.",
+                    interrupted,
+                )
+            }
+        }
+        check(!corruptRootRecoveryClaimed.get()) {
+            "Timed out while waiting for Windows Cloud Files recovery to stop."
+        }
     }
 
     private fun stopLocalWatcher() {
@@ -1562,7 +1609,7 @@ internal class WindowsCloudFilesProvider(
                 WindowsCloudFilesDelayedCorruptRootRecovery(corruption, recoveryGeneration)
             }
         }
-        recovery?.let(::recoverCorruptRootAfterDelayedRefresh)
+        recovery?.let(::scheduleCorruptRootRecoveryAfterStartup)
     }
 
     private fun retryVerifiedUnchangedDirectoryRefresh(
@@ -2161,6 +2208,7 @@ private fun String.windowsCloudPath(): String {
 private const val WINDOWS_CLOUD_ALIGNMENT = 4 * 1024L
 private const val MAX_WINDOWS_WRITEBACK_ATTEMPTS = 5
 private const val MAX_WINDOWS_DIRECTORY_REFRESH_ATTEMPTS = 4
+private const val DELAYED_CORRUPT_ROOT_RECOVERY_POLL_MILLIS = 25L
 private const val DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS = 120L
 private const val DEFAULT_INITIAL_POPULATION_TIMEOUT_SECONDS = 120L
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -22,6 +22,8 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
@@ -249,6 +251,11 @@ internal class WindowsCloudFilesUnreadableEntryException(
         inspection.win32Error?.let { " (Win32 error $it)." }.orEmpty(),
 )
 
+private data class WindowsCloudFilesDelayedCorruptRootRecovery(
+    val corruption: WindowsCloudFilesCorruptEntryException,
+    val generation: Long,
+)
+
 internal fun windowsCloudFilesRecoveryRoot(root: Path, recoveryId: String): Path {
     require(recoveryId.length in 8..32 && recoveryId.all { it.isLetterOrDigit() || it == '-' })
     val absoluteRoot = root.toAbsolutePath().normalize()
@@ -442,6 +449,7 @@ internal class WindowsCloudFilesProvider(
     private val recordDiagnostic: (SupportDiagnosticEventDraft) -> Unit = {},
     private val preserveCorruptRoot: (Path) -> Path = ::preserveWindowsCloudFilesCorruptRoot,
     private val recordPreservedCorruptRoot: (Path) -> Unit = {},
+    private val onRuntimeFailure: (Throwable) -> Unit = {},
 ) : AutoCloseable, WindowsCloudFilesCallbacks {
     private val connection = AtomicLongState()
     private val apiClosed = AtomicBoolean(false)
@@ -454,6 +462,9 @@ internal class WindowsCloudFilesProvider(
     private val writebackAttempts = ConcurrentHashMap<String, Int>()
     private val namespaceMutationLock = Any()
     private val callbacksPaused = AtomicBoolean(false)
+    private val corruptRootRecoveryClaimed = AtomicBoolean(false)
+    private val corruptRootRecoveryGeneration = AtomicLong(0L)
+    private val runtimeRecoveryFailure = AtomicReference<Throwable?>(null)
     private val destructiveCallbackOperations = AtomicInteger()
     private val localChangeScheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { work ->
         Thread(work, "nextcloud-windows-local-changes").apply { isDaemon = true }
@@ -462,6 +473,7 @@ internal class WindowsCloudFilesProvider(
     private val initialPopulationStarted = AtomicBoolean(false)
     private val initialPopulationFinished = CountDownLatch(1)
     @Volatile private var initialPopulationSucceeded = false
+    private val runtimeStarted = CountDownLatch(1)
     private val initialRecoveryFinished = CountDownLatch(1)
     @Volatile private var initialRecoveryFailure: WindowsCloudFilesStartupRecoveryException? = null
     @Volatile var preservedRecoveryRoot: Path? = null
@@ -497,9 +509,11 @@ internal class WindowsCloudFilesProvider(
                     initialRecoveryFinished.countDown()
                 }
             }
+            runtimeStarted.countDown()
         } catch (failure: Throwable) {
             callbacksPaused.set(true)
             initialPopulationFinished.countDown()
+            runtimeStarted.countDown()
             val key = connection.get()
             if (key != 0L && runCatching { api.disconnect(key) }.isSuccess) {
                 connection.compareAndSet(key, 0L)
@@ -512,6 +526,43 @@ internal class WindowsCloudFilesProvider(
         syncRootIdentity: ByteArray,
         corruption: WindowsCloudFilesCorruptEntryException,
         quiescenceTimeoutSeconds: Long = DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS,
+    ) {
+        require(quiescenceTimeoutSeconds > 0L)
+        val observedGeneration = corruptRootRecoveryGeneration.get()
+        val claimDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(quiescenceTimeoutSeconds)
+        while (!corruptRootRecoveryClaimed.compareAndSet(false, true)) {
+            runtimeRecoveryFailure.get()?.let { throw it }
+            if (corruptRootRecoveryGeneration.get() != observedGeneration) return
+            check(System.nanoTime() < claimDeadline) {
+                "Timed out waiting for the active Windows Cloud Files corrupt-root recovery."
+            }
+            try {
+                Thread.sleep(25L)
+            } catch (interrupted: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw IllegalStateException(
+                    "Interrupted while waiting for Windows Cloud Files corrupt-root recovery.",
+                    interrupted,
+                )
+            }
+        }
+        try {
+            runtimeRecoveryFailure.get()?.let { throw it }
+            if (corruptRootRecoveryGeneration.get() != observedGeneration) return
+            performCorruptRootRecovery(syncRootIdentity, corruption, quiescenceTimeoutSeconds)
+            corruptRootRecoveryGeneration.incrementAndGet()
+        } catch (failure: Throwable) {
+            runtimeRecoveryFailure.compareAndSet(null, failure)
+            throw failure
+        } finally {
+            corruptRootRecoveryClaimed.set(false)
+        }
+    }
+
+    private fun performCorruptRootRecovery(
+        syncRootIdentity: ByteArray,
+        corruption: WindowsCloudFilesCorruptEntryException,
+        quiescenceTimeoutSeconds: Long,
     ) {
         require(quiescenceTimeoutSeconds > 0L)
         val restartWatcher = watchService != null
@@ -601,6 +652,63 @@ internal class WindowsCloudFilesProvider(
         )
     }
 
+    private fun recoverCorruptRootAfterDelayedRefresh(
+        recovery: WindowsCloudFilesDelayedCorruptRootRecovery,
+    ) {
+        var claimed = false
+        try {
+            check(runtimeStarted.await(DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                "Timed out waiting for Windows Cloud Files startup before corrupt-root recovery."
+            }
+            check(initialRecoveryFinished.await(DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                "Timed out waiting for the initial local-change scan before corrupt-root recovery."
+            }
+            if (runtimeRecoveryFailure.get() != null) return
+            if (recovery.generation != corruptRootRecoveryGeneration.get()) return
+            if (!corruptRootRecoveryClaimed.compareAndSet(false, true)) {
+                recordPlaceholderDiagnostic(
+                    severity = SupportDiagnosticSeverity.Info,
+                    operation = "cloud-files.corrupt-root-recovery",
+                    outcome = "corrupt-root-recovery-coalesced",
+                    localDirectory = root,
+                    identity = null,
+                )
+                return
+            }
+            claimed = true
+            if (recovery.generation != corruptRootRecoveryGeneration.get()) return
+            val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
+            performCorruptRootRecovery(
+                WindowsCloudFileIdentityCodec.encode(rootIdentity),
+                recovery.corruption,
+                DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS,
+            )
+            corruptRootRecoveryGeneration.incrementAndGet()
+        } catch (failure: Throwable) {
+            if (failure is InterruptedException) Thread.currentThread().interrupt()
+            if (failure.suppressed.none { it === recovery.corruption }) {
+                failure.addSuppressed(recovery.corruption)
+            }
+            callbacksPaused.set(true)
+            runtimeRecoveryFailure.compareAndSet(null, failure)
+            recordPlaceholderDiagnostic(
+                severity = SupportDiagnosticSeverity.Error,
+                operation = "cloud-files.corrupt-root-recovery",
+                outcome = "corrupt-root-recovery-failed",
+                code = windowsCloudFilesDiagnosticCode(failure),
+                localDirectory = root,
+                identity = null,
+            )
+            runCatching { onRuntimeFailure(failure) }
+                .exceptionOrNull()
+                ?.let(failure::addSuppressed)
+        } finally {
+            if (claimed) corruptRootRecoveryClaimed.set(false)
+        }
+    }
+
+    fun runtimeRecoveryFailure(): Throwable? = runtimeRecoveryFailure.get()
+
     private fun connectWithRegistrationRecovery(syncRootIdentity: ByteArray): Long =
         try {
             api.connect(root, this)
@@ -625,6 +733,7 @@ internal class WindowsCloudFilesProvider(
     /** Repairs the legacy namespace and flushes recoverable local writes before changing root generations. */
     fun recoverBeforeRootMigration(timeoutSeconds: Long = 120L) {
         require(timeoutSeconds > 0L)
+        runtimeRecoveryFailure.get()?.let { throw it }
         var deferredCorruption: WindowsCloudFilesCorruptEntryException? = null
         try {
             repairRemotePlaceholderTree()
@@ -642,6 +751,7 @@ internal class WindowsCloudFilesProvider(
         check(initialRecoveryFinished.await(timeoutSeconds, TimeUnit.SECONDS)) {
             "Timed out while checking the legacy Windows Cloud Files root for local edits."
         }
+        runtimeRecoveryFailure.get()?.let { throw it }
         when (val failure = initialRecoveryFailure) {
             is WindowsCloudFilesCorruptEntryException -> deferredCorruption = deferredCorruption ?: failure
             null -> Unit
@@ -666,6 +776,7 @@ internal class WindowsCloudFilesProvider(
         check(initialRecoveryFinished.await(timeoutSeconds, TimeUnit.SECONDS)) {
             "Timed out while checking the Windows Cloud Files root for local metadata corruption."
         }
+        runtimeRecoveryFailure.get()?.let { throw it }
         when (val failure = initialRecoveryFailure) {
             is WindowsCloudFilesCorruptEntryException -> {
                 val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
@@ -1420,8 +1531,9 @@ internal class WindowsCloudFilesProvider(
         identity: WindowsCloudFileIdentity,
         attempt: Int,
     ) {
-        val corruption = synchronized(namespaceMutationLock) {
+        val recovery = synchronized(namespaceMutationLock) {
             if (callbacksPaused.get()) return
+            val recoveryGeneration = corruptRootRecoveryGeneration.get()
             val inspection = api.inspectPlaceholder(localPath)
             val currentIdentity = if (
                 inspection.state == WindowsCloudPlaceholderEntryState.InSync &&
@@ -1446,15 +1558,11 @@ internal class WindowsCloudFilesProvider(
                 )
                 return@synchronized null
             }
-            retryVerifiedUnchangedDirectoryRefresh(localPath, identity, attempt)
+            retryVerifiedUnchangedDirectoryRefresh(localPath, identity, attempt)?.let { corruption ->
+                WindowsCloudFilesDelayedCorruptRootRecovery(corruption, recoveryGeneration)
+            }
         }
-        if (corruption != null) {
-            val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
-            recoverCorruptRoot(
-                WindowsCloudFileIdentityCodec.encode(rootIdentity),
-                corruption,
-            )
-        }
+        recovery?.let(::recoverCorruptRootAfterDelayedRefresh)
     }
 
     private fun retryVerifiedUnchangedDirectoryRefresh(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -505,7 +505,7 @@ internal class WindowsCloudFilesProvider(
             }
             initialPopulationSucceeded = true
             initialPopulationFinished.countDown()
-            startLocalWatcher()
+            if (watchService == null) startLocalWatcher()
             executor.execute {
                 try {
                     recoverLocalChanges()
@@ -520,6 +520,7 @@ internal class WindowsCloudFilesProvider(
             callbacksPaused.set(true)
             initialPopulationFinished.countDown()
             runtimeStarted.countDown()
+            stopLocalWatcher()
             val key = connection.get()
             if (key != 0L && runCatching { api.disconnect(key) }.isSuccess) {
                 connection.compareAndSet(key, 0L)
@@ -584,8 +585,7 @@ internal class WindowsCloudFilesProvider(
         quiescenceTimeoutSeconds: Long,
     ) {
         require(quiescenceTimeoutSeconds > 0L)
-        val restartWatcher = watchService != null
-        if (restartWatcher) stopLocalWatcher()
+        if (watchService != null) stopLocalWatcher()
         synchronized(namespaceMutationLock) {
             callbacksPaused.set(true)
         }
@@ -649,7 +649,7 @@ internal class WindowsCloudFilesProvider(
             api.registerSyncRoot(root, backend.displayName, syncRootIdentity)
             connection.set(api.connect(root, this))
             populateDirectory("", root)
-            if (restartWatcher && !runtimeStopping.get()) startLocalWatcher()
+            if (!runtimeStopping.get()) startLocalWatcher()
             recoverUnmanagedLocalEntries(failClosed = true)
             resumeCallbacksAndReplayLocalChanges()
         } catch (retryFailure: Throwable) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -531,14 +531,14 @@ internal class WindowsCloudFilesProvider(
         syncRootIdentity: ByteArray,
         corruption: WindowsCloudFilesCorruptEntryException,
         quiescenceTimeoutSeconds: Long = DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS,
+        expectedGeneration: Long = corruptRootRecoveryGeneration.get(),
     ) {
         require(quiescenceTimeoutSeconds > 0L)
-        val observedGeneration = corruptRootRecoveryGeneration.get()
         val claimDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(quiescenceTimeoutSeconds)
         while (!claimCorruptRootRecovery()) {
             check(!runtimeStopping.get()) { "Windows Cloud Files is stopping." }
             runtimeRecoveryFailure.get()?.let { throw it }
-            if (corruptRootRecoveryGeneration.get() != observedGeneration) return
+            if (corruptRootRecoveryGeneration.get() != expectedGeneration) return
             check(System.nanoTime() < claimDeadline) {
                 "Timed out waiting for the active Windows Cloud Files corrupt-root recovery."
             }
@@ -554,7 +554,7 @@ internal class WindowsCloudFilesProvider(
         }
         try {
             runtimeRecoveryFailure.get()?.let { throw it }
-            if (corruptRootRecoveryGeneration.get() != observedGeneration) return
+            if (corruptRootRecoveryGeneration.get() != expectedGeneration) return
             performCorruptRootRecovery(syncRootIdentity, corruption, quiescenceTimeoutSeconds)
             corruptRootRecoveryGeneration.incrementAndGet()
         } catch (failure: Throwable) {
@@ -827,12 +827,15 @@ internal class WindowsCloudFilesProvider(
     fun recoverBeforeRootMigration(timeoutSeconds: Long = 120L) {
         require(timeoutSeconds > 0L)
         var deferredCorruption: WindowsCloudFilesCorruptEntryException? = null
+        var deferredCorruptionGeneration: Long? = null
         synchronized(corruptRootStableAccessLock) {
+            val inspectedGeneration = corruptRootRecoveryGeneration.get()
             runtimeRecoveryFailure.get()?.let { throw it }
             try {
                 repairRemotePlaceholderTree()
             } catch (corruption: WindowsCloudFilesCorruptEntryException) {
                 deferredCorruption = corruption
+                deferredCorruptionGeneration = inspectedGeneration
             }
             if (deferredCorruption == null) {
                 try {
@@ -840,6 +843,7 @@ internal class WindowsCloudFilesProvider(
                     recoverUnmanagedLocalEntries(failClosed = true)
                 } catch (corruption: WindowsCloudFilesCorruptEntryException) {
                     deferredCorruption = corruption
+                    deferredCorruptionGeneration = inspectedGeneration
                 }
             }
             check(initialRecoveryFinished.await(timeoutSeconds, TimeUnit.SECONDS)) {
@@ -847,7 +851,10 @@ internal class WindowsCloudFilesProvider(
             }
             runtimeRecoveryFailure.get()?.let { throw it }
             when (val failure = initialRecoveryFailure) {
-                is WindowsCloudFilesCorruptEntryException -> deferredCorruption = deferredCorruption ?: failure
+                is WindowsCloudFilesCorruptEntryException -> if (deferredCorruption == null) {
+                    deferredCorruption = failure
+                    deferredCorruptionGeneration = inspectedGeneration
+                }
                 null -> Unit
                 else -> throw failure
             }
@@ -855,11 +862,13 @@ internal class WindowsCloudFilesProvider(
             awaitWritebackRecovery(deadline)
         }
         deferredCorruption?.let { corruption ->
+            val expectedGeneration = requireNotNull(deferredCorruptionGeneration)
             val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
             recoverCorruptRoot(
                 WindowsCloudFileIdentityCodec.encode(rootIdentity),
                 corruption,
                 quiescenceTimeoutSeconds = timeoutSeconds,
+                expectedGeneration = expectedGeneration,
             )
             initialRecoveryFailure = null
             synchronized(corruptRootStableAccessLock) {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -962,8 +962,9 @@ internal class WindowsCloudFilesProvider(
                     ?: identity
                 val uploaded = backend.upload(identity.path, localPath.toFile(), current.remoteRevision)
                 knownIdentities[uploaded.path] = uploaded
-                api.updatePlaceholder(localPath, placeholder(uploaded))
-                api.markInSync(localPath)
+                if (updatePlaceholderAfterRemoteMutation(localPath, uploaded)) {
+                    api.markInSync(localPath)
+                }
             }
         }
     }
@@ -998,8 +999,15 @@ internal class WindowsCloudFilesProvider(
                     val moved = backend.move(identity, destination)
                     knownIdentities.remove(identity.path)
                     knownIdentities[moved.path] = moved
-                    api.updatePlaceholder(destinationPath, placeholder(moved), preserveSyncState = true)
-                    if (identity.directory) rebindMovedDescendants(identity, moved, destinationPath)
+                    if (
+                        updatePlaceholderAfterRemoteMutation(
+                            destinationPath,
+                            moved,
+                            preserveSyncState = true,
+                        ) && identity.directory
+                    ) {
+                        rebindMovedDescendants(identity, moved, destinationPath)
+                    }
                 }.isSuccess
             }
             api.acknowledgeRename(info, accepted)
@@ -1624,6 +1632,12 @@ internal class WindowsCloudFilesProvider(
             if (callbacksPaused.get()) return
             val recoveryGeneration = corruptRootRecoveryGeneration.get()
             val inspection = api.inspectPlaceholder(localPath)
+            if (inspection.state == WindowsCloudPlaceholderEntryState.Corrupt) {
+                return@synchronized WindowsCloudFilesDelayedCorruptRootRecovery(
+                    corruptPlaceholder(identity, localPath.parent ?: root, inspection),
+                    recoveryGeneration,
+                )
+            }
             val currentIdentity = if (
                 inspection.state == WindowsCloudPlaceholderEntryState.InSync &&
                 inspection.placeholderState == WindowsCloudPlaceholderState.InSync
@@ -1711,6 +1725,44 @@ internal class WindowsCloudFilesProvider(
         ),
         cause = failure,
     )
+
+    /**
+     * Commits a remote mutation to its existing placeholder. A corrupt CFAPI update cannot
+     * undo the already-completed server mutation, so finish the path operation and rebuild the
+     * root from the authoritative backend instead of replaying that mutation on retry.
+     */
+    private fun updatePlaceholderAfterRemoteMutation(
+        localPath: Path,
+        identity: WindowsCloudFileIdentity,
+        preserveSyncState: Boolean = false,
+    ): Boolean {
+        try {
+            api.updatePlaceholder(
+                localPath,
+                placeholder(identity),
+                preserveSyncState = preserveSyncState,
+            )
+            return true
+        } catch (failure: WindowsCloudFilesOperationException) {
+            if (!isWindowsCloudFilesPlaceholderMetadataCorruptResult(failure.hResult)) throw failure
+            recordPlaceholderDiagnostic(
+                severity = SupportDiagnosticSeverity.Error,
+                operation = "cloud-files.placeholder-update",
+                outcome = "corrupt-metadata-detected",
+                code = "HRESULT:0x${failure.hResult.toUInt().toString(16)}",
+                localDirectory = localPath.parent ?: root,
+                identity = identity,
+                fields = listOf(SupportDiagnosticFieldDraft("remote_mutation_completed", "true")),
+            )
+            scheduleCorruptRootRecoveryAfterStartup(
+                WindowsCloudFilesDelayedCorruptRootRecovery(
+                    corruptPlaceholderUpdate(localPath, identity, failure),
+                    corruptRootRecoveryGeneration.get(),
+                ),
+            )
+            return false
+        }
+    }
 
     private fun placeholderContentChanged(
         previous: WindowsCloudFileIdentity,
@@ -1985,8 +2037,9 @@ internal class WindowsCloudFilesProvider(
                         ) { "The dirty Windows placeholder identity is not safe to recover." }
                         val uploaded = backend.upload(current.path, local.toFile(), current.remoteRevision)
                         knownIdentities[uploaded.path] = uploaded
-                        api.updatePlaceholder(local, placeholder(uploaded))
-                        api.markInSync(local)
+                        if (updatePlaceholderAfterRemoteMutation(local, uploaded)) {
+                            api.markInSync(local)
+                        }
                     }
                 }
             }
@@ -2036,25 +2089,31 @@ internal class WindowsCloudFilesProvider(
     ) {
         if (!Files.isDirectory(localDirectory) || Files.isSymbolicLink(localDirectory)) return
         Files.walk(localDirectory).use { paths ->
-            paths.filter { path -> path != localDirectory && !Files.isSymbolicLink(path) }
-                .forEach { descendant ->
-                    val suffix = localDirectory.relativize(descendant).joinToString("/") { it.toString() }.windowsCloudPath()
-                    val expectedOriginalPath = "${originalDirectory.path}/$suffix"
-                    val previous = api.placeholderIdentity(descendant)
-                        ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
-                        ?.takeIf { identity ->
-                            identity.accountId == backend.accountId && identity.path == expectedOriginalPath
-                        }
-                        ?: return@forEach
-                    val rebound = previous.copy(path = "${movedDirectory.path}/$suffix")
-                    knownIdentities.remove(previous.path)
-                    knownIdentities[rebound.path] = rebound
-                    api.updatePlaceholder(
+            val descendants = paths.iterator()
+            while (descendants.hasNext()) {
+                val descendant = descendants.next()
+                if (descendant == localDirectory || Files.isSymbolicLink(descendant)) continue
+                val suffix = localDirectory.relativize(descendant).joinToString("/") { it.toString() }.windowsCloudPath()
+                val expectedOriginalPath = "${originalDirectory.path}/$suffix"
+                val previous = api.placeholderIdentity(descendant)
+                    ?.let { encoded -> runCatching { WindowsCloudFileIdentityCodec.decode(encoded) }.getOrNull() }
+                    ?.takeIf { identity ->
+                        identity.accountId == backend.accountId && identity.path == expectedOriginalPath
+                    }
+                    ?: continue
+                val rebound = previous.copy(path = "${movedDirectory.path}/$suffix")
+                knownIdentities.remove(previous.path)
+                knownIdentities[rebound.path] = rebound
+                if (
+                    !updatePlaceholderAfterRemoteMutation(
                         descendant,
-                        placeholder(rebound),
+                        rebound,
                         preserveSyncState = true,
                     )
+                ) {
+                    break
                 }
+            }
         }
     }
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -475,6 +475,7 @@ internal class WindowsCloudFilesProvider(
         Thread(work, "nextcloud-windows-local-changes").apply { isDaemon = true }
     }
     private val pendingLocalChanges = ConcurrentHashMap<Path, ScheduledFuture<*>>()
+    private val deferredLocalChanges = ConcurrentHashMap.newKeySet<Path>()
     private val initialPopulationStarted = AtomicBoolean(false)
     private val initialPopulationFinished = CountDownLatch(1)
     @Volatile private var initialPopulationSucceeded = false
@@ -650,7 +651,7 @@ internal class WindowsCloudFilesProvider(
             populateDirectory("", root)
             if (restartWatcher && !runtimeStopping.get()) startLocalWatcher()
             recoverUnmanagedLocalEntries(failClosed = true)
-            if (!runtimeStopping.get()) callbacksPaused.set(false)
+            resumeCallbacksAndReplayLocalChanges()
         } catch (retryFailure: Throwable) {
             retryFailure.addSuppressed(corruption)
             throw retryFailure
@@ -1142,9 +1143,17 @@ internal class WindowsCloudFilesProvider(
 
     /** Handles local files or complete directory trees that do not have Cloud Files identities yet. */
     fun localEntryChanged(path: Path) {
-        if (callbacksPaused.get()) return
         val normalized = path.toAbsolutePath().normalize()
         if (!normalized.startsWith(root.toAbsolutePath().normalize()) || normalized == root) return
+        val deferred = synchronized(namespaceMutationLock) {
+            if (callbacksPaused.get()) {
+                if (!runtimeStopping.get()) deferredLocalChanges.add(normalized)
+                true
+            } else {
+                false
+            }
+        }
+        if (deferred) return
         if (!Files.exists(normalized) || api.placeholderState(normalized) != WindowsCloudPlaceholderState.Absent) return
         val relative = root.toAbsolutePath().normalize().relativize(normalized)
             .joinToString("/") { it.toString() }.windowsCloudPath()
@@ -1317,6 +1326,16 @@ internal class WindowsCloudFilesProvider(
         watchService = null
         pendingLocalChanges.values.forEach { it.cancel(false) }
         pendingLocalChanges.clear()
+        deferredLocalChanges.clear()
+    }
+
+    private fun resumeCallbacksAndReplayLocalChanges() {
+        val replay = synchronized(namespaceMutationLock) {
+            if (runtimeStopping.get()) return
+            callbacksPaused.set(false)
+            deferredLocalChanges.toList().also(deferredLocalChanges::removeAll)
+        }
+        replay.forEach(::scheduleLocalChange)
     }
 
     private fun closeApi() {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -1384,15 +1384,7 @@ internal class WindowsCloudFilesProvider(
                 ),
             )
             if (corruptMetadata) {
-                throw corruptPlaceholder(
-                    identity = current,
-                    localDirectory = localPath.parent ?: root,
-                    inspection = WindowsCloudPlaceholderInspection(
-                        state = WindowsCloudPlaceholderEntryState.Corrupt,
-                        win32Error = WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT,
-                    ),
-                    cause = failure,
-                )
+                throw corruptPlaceholderUpdate(localPath, current, failure)
             }
             if (!unchangedDirectoryRefresh) throw failure
             scheduleUnchangedDirectoryRefresh(localPath, current, attempt = 1)
@@ -1428,7 +1420,7 @@ internal class WindowsCloudFilesProvider(
         identity: WindowsCloudFileIdentity,
         attempt: Int,
     ) {
-        synchronized(namespaceMutationLock) {
+        val corruption = synchronized(namespaceMutationLock) {
             if (callbacksPaused.get()) return
             val inspection = api.inspectPlaceholder(localPath)
             val currentIdentity = if (
@@ -1452,9 +1444,16 @@ internal class WindowsCloudFilesProvider(
                         SupportDiagnosticFieldDraft("identity_matches", (currentIdentity == identity).toString()),
                     ),
                 )
-                return
+                return@synchronized null
             }
             retryVerifiedUnchangedDirectoryRefresh(localPath, identity, attempt)
+        }
+        if (corruption != null) {
+            val rootIdentity = WindowsCloudFileIdentity(backend.accountId, "", "root", 0L, true)
+            recoverCorruptRoot(
+                WindowsCloudFileIdentityCodec.encode(rootIdentity),
+                corruption,
+            )
         }
     }
 
@@ -1462,7 +1461,7 @@ internal class WindowsCloudFilesProvider(
         localPath: Path,
         identity: WindowsCloudFileIdentity,
         attempt: Int,
-    ) {
+    ): WindowsCloudFilesCorruptEntryException? {
         try {
             api.updatePlaceholder(localPath, placeholder(identity), invalidateContent = false)
             recordPlaceholderDiagnostic(
@@ -1473,20 +1472,48 @@ internal class WindowsCloudFilesProvider(
                 identity = identity,
                 fields = listOf(SupportDiagnosticFieldDraft("attempt", attempt.toString())),
             )
+            return null
         } catch (failure: WindowsCloudFilesOperationException) {
+            val corruptMetadata = isWindowsCloudFilesPlaceholderMetadataCorruptResult(failure.hResult)
             val exhausted = attempt >= MAX_WINDOWS_DIRECTORY_REFRESH_ATTEMPTS
             recordPlaceholderDiagnostic(
-                severity = SupportDiagnosticSeverity.Warning,
+                severity = if (corruptMetadata) {
+                    SupportDiagnosticSeverity.Error
+                } else {
+                    SupportDiagnosticSeverity.Warning
+                },
                 operation = "cloud-files.placeholder-update",
-                outcome = if (exhausted) "unchanged-refresh-stale" else "unchanged-refresh-retry-failed",
+                outcome = when {
+                    corruptMetadata -> "corrupt-metadata-detected"
+                    exhausted -> "unchanged-refresh-stale"
+                    else -> "unchanged-refresh-retry-failed"
+                },
                 code = "HRESULT:0x${failure.hResult.toUInt().toString(16)}",
                 localDirectory = localPath.parent ?: root,
                 identity = identity,
                 fields = listOf(SupportDiagnosticFieldDraft("attempt", attempt.toString())),
             )
+            if (corruptMetadata) {
+                return corruptPlaceholderUpdate(localPath, identity, failure)
+            }
             if (!exhausted) scheduleUnchangedDirectoryRefresh(localPath, identity, attempt + 1)
+            return null
         }
     }
+
+    private fun corruptPlaceholderUpdate(
+        localPath: Path,
+        identity: WindowsCloudFileIdentity,
+        failure: WindowsCloudFilesOperationException,
+    ): WindowsCloudFilesCorruptEntryException = corruptPlaceholder(
+        identity = identity,
+        localDirectory = localPath.parent ?: root,
+        inspection = WindowsCloudPlaceholderInspection(
+            state = WindowsCloudPlaceholderEntryState.Corrupt,
+            win32Error = WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT,
+        ),
+        cause = failure,
+    )
 
     private fun placeholderContentChanged(
         previous: WindowsCloudFileIdentity,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -466,6 +466,8 @@ internal class WindowsCloudFilesProvider(
     private val corruptRootStableAccessLock = Any()
     private val corruptRootRecoveryClaimed = AtomicBoolean(false)
     private val corruptRootRecoveryGeneration = AtomicLong(0L)
+    private val pendingActivationDirectoryRefreshChecks = AtomicInteger()
+    private val pendingDelayedCorruptRootRecoveries = ConcurrentHashMap.newKeySet<WindowsCloudFilesDelayedCorruptRootRecovery>()
     private val runtimeRecoveryFailure = AtomicReference<Throwable?>(null)
     private val runtimeStopping = AtomicBoolean(false)
     private val destructiveCallbackOperations = AtomicInteger()
@@ -734,23 +736,70 @@ internal class WindowsCloudFilesProvider(
     private fun scheduleCorruptRootRecoveryAfterStartup(
         recovery: WindowsCloudFilesDelayedCorruptRootRecovery,
     ) {
-        if (callbacksPaused.get() || runtimeStopping.get() || runtimeRecoveryFailure.get() != null) return
-        runCatching {
+        if (!pendingDelayedCorruptRootRecoveries.add(recovery)) return
+        scheduleRegisteredCorruptRootRecoveryAfterStartup(recovery)
+    }
+
+    private fun scheduleRegisteredCorruptRootRecoveryAfterStartup(
+        recovery: WindowsCloudFilesDelayedCorruptRootRecovery,
+    ) {
+        if (callbacksPaused.get() || runtimeStopping.get() || runtimeRecoveryFailure.get() != null) {
+            pendingDelayedCorruptRootRecoveries.remove(recovery)
+            return
+        }
+        try {
             localChangeScheduler.schedule(
                 {
-                    if (callbacksPaused.get() || runtimeStopping.get()) return@schedule
-                    if (runtimeStarted.count > 0L || initialRecoveryFinished.count > 0L) {
-                        scheduleCorruptRootRecoveryAfterStartup(recovery)
+                    if (callbacksPaused.get() || runtimeStopping.get() || runtimeRecoveryFailure.get() != null) {
+                        pendingDelayedCorruptRootRecoveries.remove(recovery)
                         return@schedule
                     }
-                    runCatching {
-                        executor.execute { recoverCorruptRootAfterDelayedRefresh(recovery) }
+                    if (runtimeStarted.count > 0L || initialRecoveryFinished.count > 0L) {
+                        scheduleRegisteredCorruptRootRecoveryAfterStartup(recovery)
+                        return@schedule
+                    }
+                    try {
+                        executor.execute {
+                            try {
+                                recoverCorruptRootAfterDelayedRefresh(recovery)
+                            } finally {
+                                pendingDelayedCorruptRootRecoveries.remove(recovery)
+                            }
+                        }
+                    } catch (failure: Throwable) {
+                        failScheduledCorruptRootRecovery(recovery, failure)
                     }
                 },
                 DELAYED_CORRUPT_ROOT_RECOVERY_POLL_MILLIS,
                 TimeUnit.MILLISECONDS,
             )
+        } catch (failure: Throwable) {
+            failScheduledCorruptRootRecovery(recovery, failure)
         }
+    }
+
+    private fun failScheduledCorruptRootRecovery(
+        recovery: WindowsCloudFilesDelayedCorruptRootRecovery,
+        failure: Throwable,
+    ) {
+        pendingDelayedCorruptRootRecoveries.remove(recovery)
+        if (runtimeStopping.get()) return
+        if (failure.suppressed.none { it === recovery.corruption }) {
+            failure.addSuppressed(recovery.corruption)
+        }
+        callbacksPaused.set(true)
+        runtimeRecoveryFailure.compareAndSet(null, failure)
+        recordPlaceholderDiagnostic(
+            severity = SupportDiagnosticSeverity.Error,
+            operation = "cloud-files.corrupt-root-recovery",
+            outcome = "corrupt-root-recovery-scheduling-failed",
+            code = windowsCloudFilesDiagnosticCode(failure),
+            localDirectory = root,
+            identity = null,
+        )
+        runCatching { onRuntimeFailure(failure) }
+            .exceptionOrNull()
+            ?.let(failure::addSuppressed)
     }
 
     private fun connectWithRegistrationRecovery(syncRootIdentity: ByteArray): Long =
@@ -822,9 +871,12 @@ internal class WindowsCloudFilesProvider(
     /** Completes the initial local scan and repairs corruption before this provider is published as active. */
     fun recoverAfterStartup(timeoutSeconds: Long = 120L) {
         require(timeoutSeconds > 0L)
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
         check(initialRecoveryFinished.await(timeoutSeconds, TimeUnit.SECONDS)) {
             "Timed out while checking the Windows Cloud Files root for local metadata corruption."
         }
+        awaitActivationDirectoryRefreshChecks(deadline)
+        awaitPendingDelayedCorruptRootRecoveries(deadline)
         runtimeRecoveryFailure.get()?.let { throw it }
         when (val failure = initialRecoveryFailure) {
             is WindowsCloudFilesCorruptEntryException -> {
@@ -838,6 +890,40 @@ internal class WindowsCloudFilesProvider(
             }
             null -> Unit
             else -> throw failure
+        }
+    }
+
+    private fun awaitActivationDirectoryRefreshChecks(deadline: Long) {
+        while (pendingActivationDirectoryRefreshChecks.get() > 0 && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(25L)
+            } catch (interrupted: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw IllegalStateException(
+                    "Interrupted while verifying Windows Cloud Files metadata before activation.",
+                    interrupted,
+                )
+            }
+        }
+        check(pendingActivationDirectoryRefreshChecks.get() == 0) {
+            "Timed out while verifying delayed Windows Cloud Files metadata before activation."
+        }
+    }
+
+    private fun awaitPendingDelayedCorruptRootRecoveries(deadline: Long) {
+        while (pendingDelayedCorruptRootRecoveries.isNotEmpty() && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(25L)
+            } catch (interrupted: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw IllegalStateException(
+                    "Interrupted while waiting for Windows Cloud Files recovery before activation.",
+                    interrupted,
+                )
+            }
+        }
+        check(pendingDelayedCorruptRootRecoveries.isEmpty()) {
+            "Timed out while recovering corrupt Windows Cloud Files metadata before activation."
         }
     }
 
@@ -1605,21 +1691,50 @@ internal class WindowsCloudFilesProvider(
         attempt: Int,
     ) {
         if (callbacksPaused.get()) return
+        val gatesActivation = attempt == 1 && runtimeStarted.count > 0L
+        if (gatesActivation) pendingActivationDirectoryRefreshChecks.incrementAndGet()
+        fun completeActivationGate() {
+            if (gatesActivation) check(pendingActivationDirectoryRefreshChecks.decrementAndGet() >= 0)
+        }
+        fun failScheduling(failure: Throwable) {
+            completeActivationGate()
+            recordPlaceholderDiagnostic(
+                severity = SupportDiagnosticSeverity.Warning,
+                operation = "cloud-files.placeholder-update",
+                outcome = "unchanged-refresh-scheduling-failed",
+                code = windowsCloudFilesDiagnosticCode(failure),
+                localDirectory = localPath.parent ?: root,
+                identity = identity,
+                fields = listOf(SupportDiagnosticFieldDraft("attempt", attempt.toString())),
+            )
+        }
         val delayMillis = directoryRefreshRetryDelayMillis(attempt).coerceAtLeast(0L)
-        runCatching {
+        try {
             localChangeScheduler.schedule(
                 {
-                    if (callbacksPaused.get()) return@schedule
-                    runCatching {
+                    if (callbacksPaused.get()) {
+                        completeActivationGate()
+                        return@schedule
+                    }
+                    try {
                         executor.execute {
-                            if (callbacksPaused.get()) return@execute
-                            retryUnchangedDirectoryRefresh(localPath, identity, attempt)
+                            try {
+                                if (!callbacksPaused.get()) {
+                                    retryUnchangedDirectoryRefresh(localPath, identity, attempt)
+                                }
+                            } finally {
+                                completeActivationGate()
+                            }
                         }
+                    } catch (failure: Throwable) {
+                        failScheduling(failure)
                     }
                 },
                 delayMillis,
                 TimeUnit.MILLISECONDS,
             )
+        } catch (failure: Throwable) {
+            failScheduling(failure)
         }
     }
 
@@ -1628,15 +1743,18 @@ internal class WindowsCloudFilesProvider(
         identity: WindowsCloudFileIdentity,
         attempt: Int,
     ) {
-        val recovery = synchronized(namespaceMutationLock) {
+        synchronized(namespaceMutationLock) {
             if (callbacksPaused.get()) return
             val recoveryGeneration = corruptRootRecoveryGeneration.get()
             val inspection = api.inspectPlaceholder(localPath)
             if (inspection.state == WindowsCloudPlaceholderEntryState.Corrupt) {
-                return@synchronized WindowsCloudFilesDelayedCorruptRootRecovery(
-                    corruptPlaceholder(identity, localPath.parent ?: root, inspection),
-                    recoveryGeneration,
+                scheduleCorruptRootRecoveryAfterStartup(
+                    WindowsCloudFilesDelayedCorruptRootRecovery(
+                        corruptPlaceholder(identity, localPath.parent ?: root, inspection),
+                        recoveryGeneration,
+                    ),
                 )
+                return
             }
             val currentIdentity = if (
                 inspection.state == WindowsCloudPlaceholderEntryState.InSync &&
@@ -1659,13 +1777,14 @@ internal class WindowsCloudFilesProvider(
                         SupportDiagnosticFieldDraft("identity_matches", (currentIdentity == identity).toString()),
                     ),
                 )
-                return@synchronized null
+                return
             }
             retryVerifiedUnchangedDirectoryRefresh(localPath, identity, attempt)?.let { corruption ->
-                WindowsCloudFilesDelayedCorruptRootRecovery(corruption, recoveryGeneration)
+                scheduleCorruptRootRecoveryAfterStartup(
+                    WindowsCloudFilesDelayedCorruptRootRecovery(corruption, recoveryGeneration),
+                )
             }
         }
-        recovery?.let(::scheduleCorruptRootRecoveryAfterStartup)
     }
 
     private fun retryVerifiedUnchangedDirectoryRefresh(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -463,6 +463,7 @@ internal class WindowsCloudFilesProvider(
     private val namespaceMutationLock = Any()
     private val callbacksPaused = AtomicBoolean(false)
     private val corruptRootRecoveryLifecycleLock = Any()
+    private val corruptRootStableAccessLock = Any()
     private val corruptRootRecoveryClaimed = AtomicBoolean(false)
     private val corruptRootRecoveryGeneration = AtomicLong(0L)
     private val runtimeRecoveryFailure = AtomicReference<Throwable?>(null)
@@ -566,6 +567,18 @@ internal class WindowsCloudFilesProvider(
         syncRootIdentity: ByteArray,
         corruption: WindowsCloudFilesCorruptEntryException,
         quiescenceTimeoutSeconds: Long,
+    ) = synchronized(corruptRootStableAccessLock) {
+        performCorruptRootRecoveryWithExclusiveRootAccess(
+            syncRootIdentity,
+            corruption,
+            quiescenceTimeoutSeconds,
+        )
+    }
+
+    private fun performCorruptRootRecoveryWithExclusiveRootAccess(
+        syncRootIdentity: ByteArray,
+        corruption: WindowsCloudFilesCorruptEntryException,
+        quiescenceTimeoutSeconds: Long,
     ) {
         require(quiescenceTimeoutSeconds > 0L)
         val restartWatcher = watchService != null
@@ -632,9 +645,10 @@ internal class WindowsCloudFilesProvider(
             prepareRootDirectory()
             api.registerSyncRoot(root, backend.displayName, syncRootIdentity)
             connection.set(api.connect(root, this))
-            callbacksPaused.set(false)
             populateDirectory("", root)
-            if (restartWatcher) startLocalWatcher()
+            if (restartWatcher && !runtimeStopping.get()) startLocalWatcher()
+            recoverUnmanagedLocalEntries(failClosed = true)
+            if (!runtimeStopping.get()) callbacksPaused.set(false)
         } catch (retryFailure: Throwable) {
             retryFailure.addSuppressed(corruption)
             throw retryFailure
@@ -682,6 +696,9 @@ internal class WindowsCloudFilesProvider(
                 DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS,
             )
             corruptRootRecoveryGeneration.incrementAndGet()
+            if (initialRecoveryFailure is WindowsCloudFilesCorruptEntryException) {
+                initialRecoveryFailure = null
+            }
         } catch (failure: Throwable) {
             if (failure is InterruptedException) Thread.currentThread().interrupt()
             if (failure.suppressed.none { it === recovery.corruption }) {
@@ -706,6 +723,8 @@ internal class WindowsCloudFilesProvider(
     }
 
     fun runtimeRecoveryFailure(): Throwable? = runtimeRecoveryFailure.get()
+
+    internal fun isCorruptRootRecoveryInProgress(): Boolean = corruptRootRecoveryClaimed.get()
 
     private fun claimCorruptRootRecovery(): Boolean = synchronized(corruptRootRecoveryLifecycleLock) {
         !runtimeStopping.get() && corruptRootRecoveryClaimed.compareAndSet(false, true)
@@ -1025,7 +1044,12 @@ internal class WindowsCloudFilesProvider(
         }
     }
 
-    fun freeUpSpace(requestedBytes: Long): Long {
+    fun freeUpSpace(requestedBytes: Long): Long = synchronized(corruptRootStableAccessLock) {
+        if (corruptRootRecoveryClaimed.get() || runtimeStopping.get()) return@synchronized 0L
+        freeUpSpaceWithStableRoot(requestedBytes)
+    }
+
+    private fun freeUpSpaceWithStableRoot(requestedBytes: Long): Long {
         require(requestedBytes >= 0L)
         var freed = 0L
         knownIdentities.values.asSequence()
@@ -1044,7 +1068,15 @@ internal class WindowsCloudFilesProvider(
         return freed
     }
 
-    fun enforcePolicy(policy: VirtualFileCachePolicy, nowEpochMillis: Long = System.currentTimeMillis()): Long {
+    fun enforcePolicy(
+        policy: VirtualFileCachePolicy,
+        nowEpochMillis: Long = System.currentTimeMillis(),
+    ): Long = synchronized(corruptRootStableAccessLock) {
+        if (corruptRootRecoveryClaimed.get() || runtimeStopping.get()) return@synchronized 0L
+        enforcePolicyWithStableRoot(policy, nowEpochMillis)
+    }
+
+    private fun enforcePolicyWithStableRoot(policy: VirtualFileCachePolicy, nowEpochMillis: Long): Long {
         if (!policy.automaticCleanup) return 0L
         val entries = knownIdentities.values.mapNotNull { identity ->
             if (identity.directory) return@mapNotNull null
@@ -1085,7 +1117,11 @@ internal class WindowsCloudFilesProvider(
         return freed
     }
 
-    fun summary(): WindowsCloudFilesSummary {
+    fun summary(): WindowsCloudFilesSummary = synchronized(corruptRootStableAccessLock) {
+        summaryWithStableRoot()
+    }
+
+    private fun summaryWithStableRoot(): WindowsCloudFilesSummary {
         var cached = 0L
         var reclaimable = 0L
         var pinned = 0L
@@ -1132,10 +1168,10 @@ internal class WindowsCloudFilesProvider(
             runtimeStopping.set(true)
             callbacksPaused.set(true)
         }
-        localChangeScheduler.shutdownNow()
         awaitCorruptRootRecoveryCompletion(
             System.nanoTime() + TimeUnit.SECONDS.toNanos(DEFAULT_CORRUPT_ROOT_QUIESCENCE_TIMEOUT_SECONDS),
         )
+        localChangeScheduler.shutdownNow()
         val key = connection.get()
         if (key != 0L) {
             api.disconnect(key)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualFileProviderPreferencesTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualFileProviderPreferencesTest.kt
@@ -3,6 +3,7 @@ package dev.obiente.nextcloudnative.app
 import java.util.prefs.Preferences
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -22,18 +23,29 @@ class DesktopVirtualFileProviderPreferencesTest {
     }
 
     @Test
-    fun `failed provider cleanup cannot prevent replacement detachment`() {
+    fun `failed provider cleanup retains the provider and blocks replacement`() {
         val cleanupFailure = IllegalStateException("simulated disconnect failure")
         var detached = false
-        var recordedFailure: Throwable? = null
 
-        detachVirtualFileProviderForReplacement(
+        val returnedFailure = closeVirtualFileProviderForReplacement(
             provider = AutoCloseable { throw cleanupFailure },
             detach = { detached = true },
-            onCleanupFailure = { recordedFailure = it },
+        )
+
+        assertFalse(detached)
+        assertSame(cleanupFailure, returnedFailure)
+    }
+
+    @Test
+    fun `successful provider cleanup permits replacement detachment`() {
+        var detached = false
+
+        val returnedFailure = closeVirtualFileProviderForReplacement(
+            provider = AutoCloseable {},
+            detach = { detached = true },
         )
 
         assertTrue(detached)
-        assertSame(cleanupFailure, recordedFailure)
+        assertEquals(null, returnedFailure)
     }
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualFileProviderPreferencesTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualFileProviderPreferencesTest.kt
@@ -4,6 +4,7 @@ import java.util.prefs.Preferences
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DesktopVirtualFileProviderPreferencesTest {
@@ -18,5 +19,21 @@ class DesktopVirtualFileProviderPreferencesTest {
         assertEquals("vfp-active.$firstAccountId", firstKey)
         assertTrue(firstKey.length <= Preferences.MAX_KEY_LENGTH)
         assertNotEquals(firstKey, secondKey)
+    }
+
+    @Test
+    fun `failed provider cleanup cannot prevent replacement detachment`() {
+        val cleanupFailure = IllegalStateException("simulated disconnect failure")
+        var detached = false
+        var recordedFailure: Throwable? = null
+
+        detachVirtualFileProviderForReplacement(
+            provider = AutoCloseable { throw cleanupFailure },
+            detach = { detached = true },
+            onCleanupFailure = { recordedFailure = it },
+        )
+
+        assertTrue(detached)
+        assertSame(cleanupFailure, recordedFailure)
     }
 }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -644,6 +644,56 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `initial corruption recovery watches files created after the rebuilt scan`() {
+        val root = createTempDirectory("windows-cloud-initial-recovery-watcher-")
+        val identity = WindowsCloudFileIdentity("account-01", "Apps", "revision", 0L, true)
+        val corruptPath = root.resolve("Apps")
+        val localBytes = "created after rebuilt startup scan".encodeToByteArray()
+        val localFile = root.resolve("late-note.txt")
+        val backend = FakeBackend(ByteArray(0), listOf(identity), expectedUploads = 1)
+        val preserved = root.resolveSibling("preserved-initial-recovery-watcher")
+        val api = FakeApi().apply {
+            createPlaceholdersHook = { _, _ ->
+                seedInspection(
+                    corruptPath,
+                    WindowsCloudPlaceholderInspection(
+                        state = WindowsCloudPlaceholderEntryState.Corrupt,
+                        win32Error = 363,
+                    ),
+                )
+                throw WindowsCloudFilesOperationException(
+                    "create Windows Cloud Files placeholders",
+                    0x800700B7.toInt(),
+                )
+            }
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = backend,
+            api = api,
+            recordDiagnostic = { event ->
+                if (event.outcome == "corrupt-root-recovered") localFile.writeBytes(localBytes)
+            },
+            preserveCorruptRoot = { current ->
+                api.clearInspection(corruptPath)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+
+            assertTrue(backend.awaitUploads())
+            assertEquals("late-note.txt", backend.lastUploadedPath)
+            assertEquals(listOf(localBytes.toList()), backend.uploadedBytes.map(ByteArray::toList))
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun corruptRootWaitsForQueuedWritebackBeforeMovingLocalData() {
         val root = createTempDirectory("windows-cloud-corrupt-root-writeback")
         val localBytes = "local edit queued before corruption recovery".encodeToByteArray()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -2167,6 +2167,7 @@ class WindowsCloudFilesProviderTest {
         val releaseMigration = CountDownLatch(1)
         val migrationFinished = CountDownLatch(1)
         val preservationStarted = CountDownLatch(1)
+        val preserveCount = AtomicInteger()
         val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
         val preserved = root.resolveSibling("preserved-migration-delayed-corruption")
         val backend = FakeBackend(ByteArray(0), listed = listOf(identity))
@@ -2181,6 +2182,7 @@ class WindowsCloudFilesProviderTest {
             directoryRefreshRetryDelayMillis = { 500L },
             recordDiagnostic = diagnostics::add,
             preserveCorruptRoot = { current ->
+                preserveCount.incrementAndGet()
                 preservationStarted.countDown()
                 api.seedState(local, WindowsCloudPlaceholderState.Absent)
                 Files.move(current, preserved)
@@ -2229,6 +2231,7 @@ class WindowsCloudFilesProviderTest {
                 Thread.yield()
             }
             assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
+            assertEquals(1, preserveCount.get())
             assertEquals(preserved, provider.preservedRecoveryRoot)
         } finally {
             releaseMigration.countDown()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -9,6 +9,7 @@ import java.security.MessageDigest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.createDirectory
 import kotlin.io.path.createTempDirectory
@@ -1627,6 +1628,123 @@ class WindowsCloudFilesProviderTest {
             provider.removeSyncRoot()
             root.toFile().deleteRecursively()
             preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `concurrent corrupt directory retries preserve the root only once`() {
+        val root = createTempDirectory("windows-cloud-concurrent-corrupt-root-")
+        root.resolve("local-note.txt").writeBytes("keep me".encodeToByteArray())
+        val photos = root.resolve("Photos").createDirectory()
+        val videos = root.resolve("Videos").createDirectory()
+        val identities = listOf(
+            fixtureIdentity(size = 0L).copy(path = "Photos", directory = true),
+            fixtureIdentity(size = 0L).copy(path = "Videos", directory = true),
+        )
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val preserveCount = AtomicInteger()
+        val rejectedUpdates = AtomicInteger()
+        val preserved = root.resolveSibling("preserved-concurrent-corrupt-root")
+        val api = FakeApi(expectedPlaceholderUpdates = 4).apply {
+            seed(photos, WindowsCloudPlaceholderState.InSync, identities[0])
+            seed(videos, WindowsCloudPlaceholderState.InSync, identities[1])
+            updatePlaceholderFailure = ordinaryFailure
+            onUpdatePlaceholderFailure = {
+                if (rejectedUpdates.incrementAndGet() == 2) updatePlaceholderFailure = corruptFailure
+            }
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = identities),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 25L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                preserveCount.incrementAndGet()
+                api.updatePlaceholderFailure = null
+                api.seedState(photos, WindowsCloudPlaceholderState.Absent)
+                api.seedState(videos, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertEquals(1, preserveCount.get())
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+            assertTrue(Files.exists(preserved.resolve("local-note.txt")))
+            assertEquals(1, diagnostics.count { it.outcome == "corrupt-root-preserved" })
+            assertEquals(1, diagnostics.count { it.outcome == "corrupt-root-recovered" })
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `failed delayed corrupt root recovery is retained and reported`() {
+        val root = createTempDirectory("windows-cloud-delayed-recovery-failure-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val preservationFailure = IllegalStateException("recovery drive unavailable")
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val reportedFailure = AtomicReference<Throwable?>()
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            updatePlaceholderFailure = ordinaryFailure
+            onUpdatePlaceholderFailure = { updatePlaceholderFailure = corruptFailure }
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { throw preservationFailure },
+            onRuntimeFailure = reportedFailure::set,
+        )
+
+        try {
+            provider.start()
+
+            val failureDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (reportedFailure.get() == null && System.nanoTime() < failureDeadline) {
+                Thread.yield()
+            }
+            val retained = provider.runtimeRecoveryFailure()
+            assertTrue(retained is IllegalStateException)
+            assertTrue(retained.message.orEmpty().contains("Could not preserve"))
+            assertEquals(retained, reportedFailure.get())
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovery-failed" })
+            assertFailsWith<IllegalStateException> { provider.recoverAfterStartup(timeoutSeconds = 5L) }
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
         }
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -2299,6 +2299,65 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `local change delivered while recovery is paused replays after rebuilt scan`() {
+        val root = createTempDirectory("windows-cloud-rebuild-deferred-local-file-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val localBytes = "created after recovery scan passed this directory".encodeToByteArray()
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend(ByteArray(0), listed = listOf(identity), expectedUploads = 1)
+        val preserved = root.resolveSibling("preserved-rebuild-deferred-local-file")
+        val deferred = root.resolve("deferred.txt")
+        lateinit var provider: WindowsCloudFilesProvider
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
+        }
+        provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = backend,
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = { event ->
+                diagnostics += event
+                if (event.outcome == "corrupt-root-recovered") deferred.writeBytes(localBytes)
+            },
+            preserveCorruptRoot = { current ->
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                provider.localEntryChanged(deferred)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+            assertTrue(backend.awaitUploads())
+            assertEquals("deferred.txt", backend.lastUploadedPath)
+            assertEquals(listOf(localBytes.toList()), backend.uploadedBytes.map(ByteArray::toList))
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `cache cleanup waits until corrupt root preservation finishes`() {
         val root = createTempDirectory("windows-cloud-cache-during-recovery-")
         val local = root.resolve("Photos").createDirectory()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1687,6 +1687,65 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `activation waits for queued delayed corruption recovery to finish`() {
+        val root = createTempDirectory("windows-cloud-activation-waits-recovery-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val preservationStarted = CountDownLatch(1)
+        val releasePreservation = CountDownLatch(1)
+        val activationFinished = CountDownLatch(1)
+        val activationFailure = AtomicReference<Throwable?>()
+        val preserved = root.resolveSibling("preserved-activation-waits-recovery")
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            preserveCorruptRoot = { current ->
+                preservationStarted.countDown()
+                check(releasePreservation.await(5, TimeUnit.SECONDS))
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+        val activation = Thread {
+            runCatching { provider.recoverAfterStartup(timeoutSeconds = 5L) }
+                .onFailure(activationFailure::set)
+            activationFinished.countDown()
+        }
+
+        try {
+            provider.start()
+            activation.start()
+            assertTrue(preservationStarted.await(5, TimeUnit.SECONDS))
+            assertFalse(activationFinished.await(100, TimeUnit.MILLISECONDS))
+
+            releasePreservation.countDown()
+            assertTrue(activationFinished.await(5, TimeUnit.SECONDS))
+            activationFailure.get()?.let { throw it }
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+        } finally {
+            releasePreservation.countDown()
+            activation.join(TimeUnit.SECONDS.toMillis(5))
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `corrupt placeholder update after writeback rebuilds without replaying the upload`() {
         val root = createTempDirectory("windows-cloud-writeback-update-corrupt-")
         val localBytes = "locally edited once".encodeToByteArray()
@@ -2080,17 +2139,10 @@ class WindowsCloudFilesProviderTest {
 
         try {
             provider.start()
-            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-            while (
-                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
-                System.nanoTime() < recoveryDeadline
-            ) {
-                Thread.yield()
-            }
-
             provider.recoverAfterStartup(timeoutSeconds = 5L)
             assertEquals(1, preserveCount.get())
             assertEquals(preserved, provider.preservedRecoveryRoot)
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
         } finally {
             provider.close()
             root.toFile().deleteRecursively()
@@ -2135,21 +2187,29 @@ class WindowsCloudFilesProviderTest {
             },
         )
         val migrationFailure = AtomicReference<Throwable?>()
-        val migration = Thread {
-            runCatching { provider.recoverBeforeRootMigration(timeoutSeconds = 5L) }
+        lateinit var migration: Thread
+        migration = Thread {
+            runCatching { provider.recoverBeforeRootMigration(timeoutSeconds = 15L) }
                 .onFailure(migrationFailure::set)
             migrationFinished.countDown()
-        }
+        }.apply { name = "legacy-root-migration-test" }
 
         try {
             provider.start()
-            provider.recoverAfterStartup(timeoutSeconds = 5L)
+            val initialRecoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (backend.listedPaths.size < 2 && System.nanoTime() < initialRecoveryDeadline) {
+                Thread.yield()
+            }
+            assertTrue(backend.listedPaths.size >= 2)
             backend.beforeList = {
-                migrationEntered.countDown()
-                check(releaseMigration.await(5, TimeUnit.SECONDS))
+                if (Thread.currentThread() === migration) {
+                    migrationEntered.countDown()
+                    check(releaseMigration.await(15, TimeUnit.SECONDS))
+                }
             }
             migration.start()
             assertTrue(migrationEntered.await(5, TimeUnit.SECONDS))
+            assertTrue(api.awaitPlaceholderUpdates())
 
             val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
             while (!provider.isCorruptRootRecoveryInProgress() && System.nanoTime() < recoveryDeadline) {
@@ -2757,10 +2817,7 @@ class WindowsCloudFilesProviderTest {
             remoteIdentities[path]
         }
         override fun list(path: String): List<WindowsCloudFileIdentity> = synchronized(this) {
-            beforeList?.also { hook ->
-                beforeList = null
-                hook(path)
-            }
+            beforeList?.invoke(path)
             listedPaths += path
             if (scriptedLists.isNotEmpty()) return@synchronized scriptedLists.removeFirst()
             listed.mapNotNull { identity -> remoteIdentities[identity.path] }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1568,6 +1568,69 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `delayed directory refresh preserves the root when a retry reveals corrupt metadata`() {
+        val root = createTempDirectory("windows-cloud-retry-corrupt-root-")
+        val localBytes = "local data preserved after delayed corruption".encodeToByteArray()
+        root.resolve("local-note.txt").writeBytes(localBytes)
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val preserved = root.resolveSibling("preserved-retry-corrupt-root")
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            updatePlaceholderFailure = ordinaryFailure
+            onUpdatePlaceholderFailure = { updatePlaceholderFailure = corruptFailure }
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                api.updatePlaceholderFailure = null
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+
+            assertTrue(api.awaitPlaceholderUpdates())
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+            assertContentEquals(localBytes, preserved.resolve("local-note.txt").toFile().readBytes())
+            assertTrue(Files.isDirectory(root))
+            assertEquals(2, api.updatedPaths.size)
+            assertEquals(listOf("Photos"), api.createdPlaceholderBatches.single().map(WindowsCloudPlaceholder::name))
+            assertEquals(listOf(1L), api.disconnectAttempts)
+            assertTrue(diagnostics.any { it.outcome == "unchanged-refresh-skipped" })
+            assertTrue(diagnostics.any { it.outcome == "corrupt-metadata-detected" })
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
+            assertFalse(diagnostics.any { it.outcome == "unchanged-refresh-stale" })
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `startup reports an unchanged directory as stale after bounded refresh retries`() {
         val root = createTempDirectory("windows-cloud-unchanged-directory-stale-")
         val local = root.resolve("Photos")

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1832,6 +1832,256 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `shutdown keeps writeback retries alive until corrupt root recovery quiesces`() {
+        val root = createTempDirectory("windows-cloud-shutdown-writeback-retry-")
+        val localBytes = "retry before preserving".encodeToByteArray()
+        val localFile = root.resolve("draft.txt")
+        localFile.writeBytes(localBytes)
+        val directoryPath = root.resolve("Photos").createDirectory()
+        val draft = fixtureIdentity(size = localBytes.size.toLong()).copy(path = "draft.txt")
+        val directory = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend(
+            source = ByteArray(0),
+            listed = listOf(draft, directory),
+            expectedUploads = 1,
+            uploadFailuresRemaining = 1,
+        )
+        val preserved = root.resolveSibling("preserved-shutdown-writeback-retry")
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(localFile, WindowsCloudPlaceholderState.Dirty, draft)
+            seed(directoryPath, WindowsCloudPlaceholderState.InSync, directory)
+            scriptUpdatePlaceholderFailures(directoryPath, ordinaryFailure, corruptFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = backend,
+            api = api,
+            writebackRetryDelayMillis = { 100L },
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                api.seedState(localFile, WindowsCloudPlaceholderState.Absent)
+                api.seedState(directoryPath, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+        val closeFinished = CountDownLatch(1)
+        val closer = Thread {
+            provider.close()
+            closeFinished.countDown()
+        }
+
+        try {
+            provider.start()
+            val corruptionDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-metadata-detected" } &&
+                System.nanoTime() < corruptionDeadline
+            ) {
+                Thread.yield()
+            }
+            while (
+                (!provider.isCorruptRootRecoveryInProgress() || backend.uploadFailuresRemaining > 0) &&
+                System.nanoTime() < corruptionDeadline
+            ) {
+                Thread.yield()
+            }
+            assertTrue(provider.isCorruptRootRecoveryInProgress())
+            assertEquals(0, backend.uploadFailuresRemaining)
+
+            closer.start()
+            assertTrue(closeFinished.await(5, TimeUnit.SECONDS))
+            assertTrue(backend.awaitUploads())
+            assertContentEquals(localBytes, preserved.resolve("draft.txt").toFile().readBytes())
+            assertEquals(listOf(localBytes.toList()), backend.uploadedBytes.map(ByteArray::toList))
+        } finally {
+            closer.join(TimeUnit.SECONDS.toMillis(5))
+            if (!api.closed) provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `successful delayed recovery invalidates stale startup corruption`() {
+        val root = createTempDirectory("windows-cloud-stale-startup-corruption-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val inSync = WindowsCloudPlaceholderInspection(WindowsCloudPlaceholderEntryState.InSync)
+        val corrupt = WindowsCloudPlaceholderInspection(
+            WindowsCloudPlaceholderEntryState.Corrupt,
+            win32Error = WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT,
+        )
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val preserveCount = AtomicInteger()
+        val preserved = root.resolveSibling("preserved-stale-startup-corruption")
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            queueInspections(local, inSync, corrupt, inSync)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 100L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                preserveCount.incrementAndGet()
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+
+            provider.recoverAfterStartup(timeoutSeconds = 5L)
+            assertEquals(1, preserveCount.get())
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `delayed recovery scans files created during rebuilt root population`() {
+        val root = createTempDirectory("windows-cloud-rebuild-local-file-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val localBytes = "created while rebuilding".encodeToByteArray()
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val backend = FakeBackend(ByteArray(0), listed = listOf(identity), expectedUploads = 1)
+        val preserved = root.resolveSibling("preserved-rebuild-local-file")
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = backend,
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                api.createPlaceholdersHook = { baseDirectory, _ ->
+                    baseDirectory.resolve("captured.txt").writeBytes(localBytes)
+                }
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+            assertTrue(backend.awaitUploads())
+            assertEquals("captured.txt", backend.lastUploadedPath)
+            assertEquals(listOf(localBytes.toList()), backend.uploadedBytes.map(ByteArray::toList))
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `cache cleanup waits until corrupt root preservation finishes`() {
+        val root = createTempDirectory("windows-cloud-cache-during-recovery-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val preservationStarted = CountDownLatch(1)
+        val finishPreservation = CountDownLatch(1)
+        val cleanupFinished = CountDownLatch(1)
+        val preserved = root.resolveSibling("preserved-cache-during-recovery")
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            preserveCorruptRoot = { current ->
+                preservationStarted.countDown()
+                check(finishPreservation.await(5, TimeUnit.SECONDS))
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+        val cleanup = Thread {
+            provider.freeUpSpace(1L)
+            cleanupFinished.countDown()
+        }
+
+        try {
+            provider.start()
+            assertTrue(preservationStarted.await(5, TimeUnit.SECONDS))
+            cleanup.start()
+            assertFalse(cleanupFinished.await(100, TimeUnit.MILLISECONDS))
+            finishPreservation.countDown()
+            assertTrue(cleanupFinished.await(5, TimeUnit.SECONDS))
+            assertTrue(Files.isDirectory(preserved.resolve("Photos")))
+        } finally {
+            finishPreservation.countDown()
+            cleanup.join(TimeUnit.SECONDS.toMillis(5))
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `failed delayed corrupt root recovery is retained and reported`() {
         val root = createTempDirectory("windows-cloud-delayed-recovery-failure-")
         val local = root.resolve("Photos").createDirectory()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -9,6 +9,7 @@ import java.security.MessageDigest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.createDirectory
@@ -1699,6 +1700,138 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `corrupt retries wait for startup without starving the initial recovery worker`() {
+        val root = createTempDirectory("windows-cloud-startup-retry-recovery-")
+        val identities = (1..5).map { index ->
+            fixtureIdentity(size = 0L).copy(path = "Folder-$index", directory = true)
+        }
+        val localPaths = identities.map { identity -> root.resolve(identity.path).createDirectory() }
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val fifthInitialUpdateEntered = CountDownLatch(1)
+        val finishInitialPopulation = CountDownLatch(1)
+        val delayedInitialUpdate = AtomicBoolean(false)
+        val startFailure = AtomicReference<Throwable?>()
+        val preserved = root.resolveSibling("preserved-startup-retry-recovery")
+        val api = FakeApi().apply {
+            localPaths.zip(identities).forEach { (path, identity) ->
+                seed(path, WindowsCloudPlaceholderState.InSync, identity)
+                scriptUpdatePlaceholderFailures(path, ordinaryFailure, corruptFailure)
+            }
+            beforeUpdatePlaceholder = { path ->
+                if (path == localPaths.last() && delayedInitialUpdate.compareAndSet(false, true)) {
+                    fifthInitialUpdateEntered.countDown()
+                    check(finishInitialPopulation.await(5, TimeUnit.SECONDS))
+                }
+            }
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = identities),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                localPaths.forEach { api.seedState(it, WindowsCloudPlaceholderState.Absent) }
+                Files.move(current, preserved)
+            },
+        )
+        val starter = Thread {
+            runCatching(provider::start).exceptionOrNull()?.let(startFailure::set)
+        }
+
+        try {
+            starter.start()
+            assertTrue(fifthInitialUpdateEntered.await(5, TimeUnit.SECONDS))
+            Thread.sleep(100L)
+            finishInitialPopulation.countDown()
+            starter.join(TimeUnit.SECONDS.toMillis(5))
+            assertFalse(starter.isAlive)
+            assertEquals(null, startFailure.get())
+
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+            assertEquals(1, diagnostics.count { it.outcome == "corrupt-root-recovered" })
+        } finally {
+            finishInitialPopulation.countDown()
+            starter.join(TimeUnit.SECONDS.toMillis(5))
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `shutdown waits for delayed corrupt root recovery before disconnecting the rebuilt provider`() {
+        val root = createTempDirectory("windows-cloud-shutdown-during-recovery-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val recoveryEntered = CountDownLatch(1)
+        val finishRecovery = CountDownLatch(1)
+        val closeFinished = CountDownLatch(1)
+        val preserved = root.resolveSibling("preserved-shutdown-recovery")
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            preserveCorruptRoot = { current ->
+                recoveryEntered.countDown()
+                check(finishRecovery.await(5, TimeUnit.SECONDS))
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+
+        val closer = Thread {
+            provider.close()
+            closeFinished.countDown()
+        }
+        try {
+            provider.start()
+            assertTrue(recoveryEntered.await(5, TimeUnit.SECONDS))
+
+            closer.start()
+            assertFalse(closeFinished.await(100, TimeUnit.MILLISECONDS))
+            finishRecovery.countDown()
+            assertTrue(closeFinished.await(5, TimeUnit.SECONDS))
+            assertEquals(listOf(1L, 1L), api.disconnectAttempts)
+            assertTrue(api.closed)
+        } finally {
+            finishRecovery.countDown()
+            closer.join(TimeUnit.SECONDS.toMillis(5))
+            if (!api.closed) provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `failed delayed corrupt root recovery is retained and reported`() {
         val root = createTempDirectory("windows-cloud-delayed-recovery-failure-")
         val local = root.resolve("Photos").createDirectory()
@@ -2276,7 +2409,7 @@ class WindowsCloudFilesProviderTest {
         val transfers = mutableListOf<Pair<Long, ByteArray>>()
         val createdPlaceholderBatches = mutableListOf<List<WindowsCloudPlaceholder>>()
         val invalidatedUpdates = mutableListOf<Path>()
-        val updatedPaths = mutableListOf<Path>()
+        val updatedPaths = CopyOnWriteArrayList<Path>()
         var completedPlaceholders = emptyList<WindowsCloudPlaceholder>()
         var lastRenameAccepted = false
         var unregisteredRoot: Path? = null
@@ -2288,6 +2421,8 @@ class WindowsCloudFilesProviderTest {
         var updatePlaceholderFailure: WindowsCloudFilesOperationException? = null
         var updatePlaceholderFailuresRemaining: Int = Int.MAX_VALUE
         var onUpdatePlaceholderFailure: (() -> Unit)? = null
+        var beforeUpdatePlaceholder: ((Path) -> Unit)? = null
+        private val updatePlaceholderFailureScripts = HashMap<Path, ArrayDeque<WindowsCloudFilesOperationException>>()
         var closed = false
         val lifecycleEvents = mutableListOf<String>()
 
@@ -2358,8 +2493,13 @@ class WindowsCloudFilesProviderTest {
             invalidateContent: Boolean,
             preserveSyncState: Boolean,
         ) {
+            beforeUpdatePlaceholder?.invoke(path)
             updatedPaths.add(path)
             try {
+                val scriptedFailure = synchronized(updatePlaceholderFailureScripts) {
+                    updatePlaceholderFailureScripts[path]?.removeFirstOrNull()
+                }
+                if (scriptedFailure != null) throw scriptedFailure
                 updatePlaceholderFailure?.let { failure ->
                     if (updatePlaceholderFailuresRemaining > 0) {
                         updatePlaceholderFailuresRemaining -= 1
@@ -2395,6 +2535,15 @@ class WindowsCloudFilesProviderTest {
             placeholderFetchLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)
         fun awaitPlaceholderUpdates(timeoutMillis: Long = TimeUnit.SECONDS.toMillis(5)): Boolean =
             placeholderUpdateLatch.await(timeoutMillis, TimeUnit.MILLISECONDS)
+
+        fun scriptUpdatePlaceholderFailures(
+            path: Path,
+            vararg failures: WindowsCloudFilesOperationException,
+        ) {
+            synchronized(updatePlaceholderFailureScripts) {
+                updatePlaceholderFailureScripts[path] = ArrayDeque(failures.asList())
+            }
+        }
 
         fun decodedIdentity(path: Path): WindowsCloudFileIdentity? =
             placeholderIdentity(path)?.let(WindowsCloudFileIdentityCodec::decode)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1912,14 +1912,14 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
-    fun `successful delayed recovery invalidates stale startup corruption`() {
-        val root = createTempDirectory("windows-cloud-stale-startup-corruption-")
+    fun `successful delayed recovery invalidates stale unreadable startup failure`() {
+        val root = createTempDirectory("windows-cloud-stale-startup-unreadable-")
         val local = root.resolve("Photos").createDirectory()
         val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
         val inSync = WindowsCloudPlaceholderInspection(WindowsCloudPlaceholderEntryState.InSync)
-        val corrupt = WindowsCloudPlaceholderInspection(
-            WindowsCloudPlaceholderEntryState.Corrupt,
-            win32Error = WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT,
+        val unreadable = WindowsCloudPlaceholderInspection(
+            WindowsCloudPlaceholderEntryState.Unreadable,
+            win32Error = 5,
         )
         val ordinaryFailure = WindowsCloudFilesOperationException(
             "update a Windows Cloud Files placeholder",
@@ -1931,10 +1931,10 @@ class WindowsCloudFilesProviderTest {
         )
         val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
         val preserveCount = AtomicInteger()
-        val preserved = root.resolveSibling("preserved-stale-startup-corruption")
+        val preserved = root.resolveSibling("preserved-stale-startup-unreadable")
         val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
             seed(local, WindowsCloudPlaceholderState.InSync, identity)
-            queueInspections(local, inSync, corrupt, inSync)
+            queueInspections(local, inSync, unreadable, inSync)
             scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
         }
         val provider = WindowsCloudFilesProvider(
@@ -1964,6 +1964,87 @@ class WindowsCloudFilesProviderTest {
             assertEquals(1, preserveCount.get())
             assertEquals(preserved, provider.preservedRecoveryRoot)
         } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `legacy migration keeps stable root access ahead of delayed corruption recovery`() {
+        val root = createTempDirectory("windows-cloud-migration-delayed-corruption-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val migrationEntered = CountDownLatch(1)
+        val releaseMigration = CountDownLatch(1)
+        val migrationFinished = CountDownLatch(1)
+        val preservationStarted = CountDownLatch(1)
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val preserved = root.resolveSibling("preserved-migration-delayed-corruption")
+        val backend = FakeBackend(ByteArray(0), listed = listOf(identity))
+        val api = FakeApi(expectedPlaceholderUpdates = 2).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure, corruptFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = backend,
+            api = api,
+            directoryRefreshRetryDelayMillis = { 500L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                preservationStarted.countDown()
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+        val migrationFailure = AtomicReference<Throwable?>()
+        val migration = Thread {
+            runCatching { provider.recoverBeforeRootMigration(timeoutSeconds = 5L) }
+                .onFailure(migrationFailure::set)
+            migrationFinished.countDown()
+        }
+
+        try {
+            provider.start()
+            provider.recoverAfterStartup(timeoutSeconds = 5L)
+            backend.beforeList = {
+                migrationEntered.countDown()
+                check(releaseMigration.await(5, TimeUnit.SECONDS))
+            }
+            migration.start()
+            assertTrue(migrationEntered.await(5, TimeUnit.SECONDS))
+
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (!provider.isCorruptRootRecoveryInProgress() && System.nanoTime() < recoveryDeadline) {
+                Thread.yield()
+            }
+            assertTrue(provider.isCorruptRootRecoveryInProgress())
+            assertFalse(preservationStarted.await(100, TimeUnit.MILLISECONDS))
+
+            releaseMigration.countDown()
+            assertTrue(migrationFinished.await(5, TimeUnit.SECONDS))
+            migrationFailure.get()?.let { throw it }
+            assertTrue(preservationStarted.await(5, TimeUnit.SECONDS))
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+        } finally {
+            releaseMigration.countDown()
+            migration.join(TimeUnit.SECONDS.toMillis(5))
             provider.close()
             root.toFile().deleteRecursively()
             preserved.toFile().deleteRecursively()
@@ -2538,6 +2619,7 @@ class WindowsCloudFilesProviderTest {
         val operations = mutableListOf<String>()
         val listedPaths = CopyOnWriteArrayList<String>()
         val resolvedPaths = CopyOnWriteArrayList<String>()
+        @Volatile var beforeList: ((String) -> Unit)? = null
         private val remoteIdentities = listed.associateBy { identity -> identity.path }.toMutableMap()
         private val remoteContents = mutableMapOf<String, ByteArray>()
         private val scriptedLists = ArrayDeque<List<WindowsCloudFileIdentity>>()
@@ -2547,6 +2629,10 @@ class WindowsCloudFilesProviderTest {
             remoteIdentities[path]
         }
         override fun list(path: String): List<WindowsCloudFileIdentity> = synchronized(this) {
+            beforeList?.also { hook ->
+                beforeList = null
+                hook(path)
+            }
             listedPaths += path
             if (scriptedLists.isNotEmpty()) return@synchronized scriptedLists.removeFirst()
             listed.mapNotNull { identity -> remoteIdentities[identity.path] }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1474,6 +1474,61 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `startup preserves and rebuilds a root when placeholder update reports corrupt metadata`() {
+        val root = createTempDirectory("windows-cloud-update-corrupt-root-")
+        val localBytes = "local-only recovery data".encodeToByteArray()
+        root.resolve("local-note.txt").writeBytes(localBytes)
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val failure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val diagnostics = mutableListOf<SupportDiagnosticEventDraft>()
+        val preserved = root.resolveSibling("preserved-update-corrupt-root")
+        val api = FakeApi().apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            updatePlaceholderFailure = failure
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                api.updatePlaceholderFailure = null
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+            assertContentEquals(localBytes, preserved.resolve("local-note.txt").toFile().readBytes())
+            assertTrue(Files.isDirectory(root))
+            assertEquals(listOf(local), api.updatedPaths)
+            assertEquals(listOf("Photos"), api.createdPlaceholderBatches.single().map(WindowsCloudPlaceholder::name))
+            assertEquals(listOf(1L), api.disconnectAttempts)
+            assertEquals(
+                listOf(
+                    "corrupt-metadata-detected",
+                    "corrupt-entry-detected",
+                    "corrupt-root-preserved",
+                    "corrupt-root-recovered",
+                ),
+                diagnostics.map(SupportDiagnosticEventDraft::outcome),
+            )
+            assertEquals("HRESULT:0x8007016b", diagnostics.first().code)
+        } finally {
+            provider.removeSyncRoot()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `startup retries a rejected unchanged directory refresh`() {
         val root = createTempDirectory("windows-cloud-unchanged-directory-retry-")
         val local = root.resolve("Photos")

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -1633,6 +1633,134 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
+    fun `delayed directory refresh preserves the root when retry inspection reveals corruption`() {
+        val root = createTempDirectory("windows-cloud-retry-inspection-corrupt-root-")
+        val local = root.resolve("Photos").createDirectory()
+        val identity = fixtureIdentity(size = 0L).copy(path = "Photos", directory = true)
+        val ordinaryFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x80070179.toInt(),
+        )
+        val inSync = WindowsCloudPlaceholderInspection(WindowsCloudPlaceholderEntryState.InSync)
+        val corrupt = WindowsCloudPlaceholderInspection(
+            WindowsCloudPlaceholderEntryState.Corrupt,
+            win32Error = WINDOWS_ERROR_CLOUD_FILE_METADATA_CORRUPT,
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val preserved = root.resolveSibling("preserved-retry-inspection-corrupt-root")
+        val api = FakeApi(expectedPlaceholderUpdates = 1).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+            queueInspections(local, inSync, corrupt)
+            scriptUpdatePlaceholderFailures(local, ordinaryFailure)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = FakeBackend(ByteArray(0), listed = listOf(identity)),
+            api = api,
+            directoryRefreshRetryDelayMillis = { 0L },
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+            assertTrue(api.awaitPlaceholderUpdates())
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertTrue(diagnostics.any { it.outcome == "corrupt-entry-detected" })
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+            assertEquals(1, api.updatedPaths.size)
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `corrupt placeholder update after writeback rebuilds without replaying the upload`() {
+        val root = createTempDirectory("windows-cloud-writeback-update-corrupt-")
+        val localBytes = "locally edited once".encodeToByteArray()
+        val local = root.resolve("edit.txt")
+        local.writeBytes(localBytes)
+        val identity = WindowsCloudFileIdentity(
+            "account-01",
+            "edit.txt",
+            "\"etag-01\"",
+            localBytes.size.toLong(),
+            false,
+        )
+        val corruptFailure = WindowsCloudFilesOperationException(
+            "update a Windows Cloud Files placeholder",
+            0x8007016B.toInt(),
+        )
+        val diagnostics = CopyOnWriteArrayList<SupportDiagnosticEventDraft>()
+        val preserved = root.resolveSibling("preserved-writeback-update-corrupt")
+        val backend = FakeBackend(
+            source = "remote".encodeToByteArray(),
+            listed = listOf(identity),
+            expectedUploads = 1,
+        )
+        val api = FakeApi(expectedPlaceholderUpdates = 1).apply {
+            seed(local, WindowsCloudPlaceholderState.InSync, identity)
+        }
+        val provider = WindowsCloudFilesProvider(
+            root = root,
+            backend = backend,
+            api = api,
+            recordDiagnostic = diagnostics::add,
+            preserveCorruptRoot = { current ->
+                api.updatePlaceholderFailure = null
+                api.seedState(local, WindowsCloudPlaceholderState.Absent)
+                Files.move(current, preserved)
+            },
+        )
+
+        try {
+            provider.start()
+            provider.recoverAfterStartup(timeoutSeconds = 5L)
+            api.seed(local, WindowsCloudPlaceholderState.Dirty, identity)
+            api.updatePlaceholderFailure = corruptFailure
+            provider.closed(
+                callbackInfo(root, identity).copy(normalizedPath = local.toString()),
+                deleted = false,
+            )
+
+            assertTrue(backend.awaitUploads())
+            assertTrue(api.awaitPlaceholderUpdates())
+            val recoveryDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+            while (
+                diagnostics.none { it.outcome == "corrupt-root-recovered" } &&
+                System.nanoTime() < recoveryDeadline
+            ) {
+                Thread.yield()
+            }
+            assertTrue(diagnostics.any { event ->
+                event.outcome == "corrupt-metadata-detected" &&
+                    event.fields.any { it.name == "remote_mutation_completed" && it.value == "true" }
+            })
+            assertTrue(diagnostics.any { it.outcome == "corrupt-root-recovered" })
+            assertEquals(listOf<String?>("\"etag-01\""), backend.uploadExpectedRevisions)
+            assertEquals(1, backend.uploadedBytes.size)
+            assertContentEquals(localBytes, preserved.resolve("edit.txt").toFile().readBytes())
+            assertEquals(preserved, provider.preservedRecoveryRoot)
+        } finally {
+            provider.close()
+            root.toFile().deleteRecursively()
+            preserved.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
     fun `concurrent corrupt directory retries preserve the root only once`() {
         val root = createTempDirectory("windows-cloud-concurrent-corrupt-root-")
         root.resolve("local-note.txt").writeBytes("keep me".encodeToByteArray())


### PR DESCRIPTION
## Summary

- classify `0x8007016b` returned by `CfUpdatePlaceholder` as confirmed corrupt Cloud Files metadata
- preserve the complete damaged root before rebuilding the canonical File Explorer provider
- recover corruption discovered during inspection, ordinary refresh, delayed retry, startup scan, and post-mutation identity commits
- avoid replaying a WebDAV upload after its remote mutation already succeeded
- bind deferred migration failures to the root generation they describe
- wait for queued startup corruption recovery before publishing the provider as active
- serialize recovery with legacy migration, cache cleanup, shutdown, and concurrent recovery attempts
- keep a failed provider attached and abort replacement if native cleanup cannot complete, preventing duplicate owners
- start the rebuilt root watcher before callbacks resume and replay local changes queued during recovery
- add structured diagnostics and focused lifecycle regressions

Closes #333

## Root cause

Windows can report a directory placeholder as in sync during native inspection, then return `ERROR_CLOUD_FILE_METADATA_CORRUPT` only when `CfUpdatePlaceholder` refreshes it. The existing recovery recognized corruption discovered during inspection, but the update path treated every unchanged-directory failure as optional. That left the provider inactive in older builds or left the corrupt directory stale after the general tolerance fix.

## Data safety

Recovery disconnects and unregisters the damaged provider before moving the complete root to a unique preserved sibling. It does not delete, overwrite, dehydrate, or convert the old root. If preservation or rebuilding fails, activation remains fail-closed, the failure stays visible for support diagnostics, and the original data remains preserved. A server mutation that already succeeded is not replayed after local metadata corruption; the rebuilt root is populated from the authoritative server generation. Provider replacement is blocked when native cleanup fails so two callback owners cannot race the same root.

## Validation

- focused `WindowsCloudFilesProviderTest` suite: 75 tests passed
- virtual-file provider replacement helper suite: 3 tests passed
- complete desktop test suite passed
- desktop distributable build passed
- repository hygiene and all 78 changelog fragments passed
- diff and whitespace validation passed

## Platform validation

[Build and test run 31649479236](https://github.com/Obiente/nc-native/actions/runs/31649479236) passed on exact head `412b4acb`:

- Linux desktop tests, build, and artifact upload passed
- Windows desktop tests and MSI packaging passed
- Windows MSI metadata verification passed
- WinGet manifest generation passed
- Windows MSI artifact upload passed

The resulting nightly still needs an activation test against the reported damaged root before issue #333 is considered complete.
