### PR TITLE
feat(updates): lock direct installs to Nightly

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClient.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClient.kt
@@ -627,8 +627,14 @@ internal class AndroidProjectContentClient(
         const val UPDATE_PROGRESS_STEP_BYTES = 256L * 1024L
     }
 
-    private fun storedUpdateChannel(): AndroidUpdateChannel =
-        parseAndroidUpdateChannel(preferences.getString(KEY_UPDATE_CHANNEL, null))
+    private fun storedUpdateChannel(): AndroidUpdateChannel {
+        val storedValue = preferences.getString(KEY_UPDATE_CHANNEL, null)
+        val channel = parseAndroidUpdateChannel(storedValue)
+        if (storedValue != channel.storageValue) {
+            preferences.edit().putString(KEY_UPDATE_CHANNEL, channel.storageValue).apply()
+        }
+        return channel
+    }
 }
 
 internal fun isRetryableAppUpdateHttpStatus(status: Int): Boolean =

--- a/changes/unreleased/228-nightly-default.md
+++ b/changes/unreleased/228-nightly-default.md
@@ -1,0 +1,7 @@
+category: platform
+issue: 228
+pull: none
+platforms: android, desktop
+user-facing: yes
+
+Direct installations now follow the Nightly update track by default. Existing Alpha selections migrate to Nightly, and channel selection stays locked until curated prereleases match the product's maturity.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannels.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannels.kt
@@ -20,6 +20,7 @@ fun canSelectAppUpdateChannel(
     support: AppUpdateSupport,
     requested: AndroidUpdateChannel,
 ): Boolean =
+    !appUpdateChannelSelectionLocked &&
     support.channel in setOf(
         AppDistributionChannel.DirectApk,
         AppDistributionChannel.DirectDesktopPackage,
@@ -47,19 +48,35 @@ fun appUpdateChannelPresentation(
         AppDistributionChannel.DirectApk,
         AppDistributionChannel.DirectDesktopPackage,
     )
-    val selectorEnabled = selectorVisible && support.canCheckDirectUpdates
+    val selectorEnabled = selectorVisible &&
+        support.canCheckDirectUpdates &&
+        !appUpdateChannelSelectionLocked
+    val effectiveSelectedChannel = if (appUpdateChannelSelectionLocked) {
+        enforcedAppUpdateChannel
+    } else {
+        selectedChannel
+    }
+    val presentedChannels = if (appUpdateChannelSelectionLocked) {
+        listOf(enforcedAppUpdateChannel)
+    } else {
+        AndroidUpdateChannel.entries
+    }
     return AppUpdateChannelPresentation(
         selectorVisible = selectorVisible,
         selectorEnabled = selectorEnabled,
-        selectedChannel = selectedChannel,
-        options = AndroidUpdateChannel.entries.map { channel ->
+        selectedChannel = effectiveSelectedChannel,
+        options = presentedChannels.map { channel ->
             AppUpdateChannelOptionPresentation(
                 channel = channel,
                 label = channel.label(),
                 description = channel.description(support.channel),
-                selected = channel == selectedChannel,
+                selected = channel == effectiveSelectedChannel,
                 enabled = selectorEnabled && channel.available,
-                availabilityLabel = if (channel.available) null else "Coming later",
+                availabilityLabel = when {
+                    appUpdateChannelSelectionLocked -> "Locked for now"
+                    channel.available -> null
+                    else -> "Coming later"
+                },
             )
         },
     )

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/NextcloudPlatform.kt
@@ -380,7 +380,7 @@ interface NextcloudPlatformServices {
         explanation = "In-app update checks are unavailable on this platform.",
     )
 
-    fun loadAppUpdateChannel(): AndroidUpdateChannel = AndroidUpdateChannel.Alpha
+    fun loadAppUpdateChannel(): AndroidUpdateChannel = enforcedAppUpdateChannel
 
     /**
      * Persists an available direct update channel.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt
@@ -202,6 +202,16 @@ enum class AndroidUpdateChannel(
     Stable("stable", "stable-v1", "channel-stable", false),
 }
 
+/**
+ * The direct release track is intentionally pinned to Nightly while the product is pre-alpha.
+ *
+ * Keep the other channel contracts intact so selection can be restored without another storage
+ * migration once curated prereleases accurately describe the product's maturity.
+ */
+val enforcedAppUpdateChannel: AndroidUpdateChannel = AndroidUpdateChannel.Nightly
+
+val appUpdateChannelSelectionLocked: Boolean = true
+
 fun AndroidUpdateChannel.manifestUrl(): String {
     require(available) { "$name updates are not available yet." }
     return "https://github.com/Obiente/nc-native/releases/download/$pointerTag/update-manifest.json"
@@ -214,7 +224,10 @@ fun AndroidUpdateChannel.desktopManifestUrl(): String {
 }
 
 fun parseAndroidUpdateChannel(value: String?): AndroidUpdateChannel =
-    AndroidUpdateChannel.entries
+    if (appUpdateChannelSelectionLocked) {
+        enforcedAppUpdateChannel
+    } else {
+        AndroidUpdateChannel.entries
         .singleOrNull { channel ->
             channel.available &&
                 (
@@ -223,7 +236,8 @@ fun parseAndroidUpdateChannel(value: String?): AndroidUpdateChannel =
                         channel.manifestChannel == value
                     )
         }
-        ?: AndroidUpdateChannel.Alpha
+        ?: enforcedAppUpdateChannel
+    }
 
 sealed interface AppUpdateCheckResult {
     data class Current(val support: AppUpdateSupport) : AppUpdateCheckResult

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannelsTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/AppUpdateChannelsTest.kt
@@ -19,22 +19,24 @@ class AppUpdateChannelsTest {
     )
 
     @Test
-    fun persistedChannelRestoresAvailableValuesAndSafelyDefaultsFutureValues() {
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel(null))
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel(""))
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("unknown"))
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("alpha"))
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("prerelease-v1"))
+    fun persistedChannelsMigrateToTheEnforcedNightlyTrack() {
+        assertTrue(appUpdateChannelSelectionLocked)
+        assertEquals(AndroidUpdateChannel.Nightly, enforcedAppUpdateChannel)
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel(null))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel(""))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("unknown"))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("alpha"))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("prerelease-v1"))
         assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("Nightly"))
         assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("nightly-v1"))
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("beta"))
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("stable-v1"))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("beta"))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("stable-v1"))
     }
 
     @Test
-    fun onlyAvailableDirectChannelsCanBeSelected() {
-        assertTrue(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Alpha))
-        assertTrue(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Nightly))
+    fun directChannelSelectionRemainsLocked() {
+        assertFalse(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Alpha))
+        assertFalse(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Nightly))
         assertFalse(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Beta))
         assertFalse(canSelectAppUpdateChannel(directSupport, AndroidUpdateChannel.Stable))
         assertFalse(
@@ -46,7 +48,7 @@ class AppUpdateChannelsTest {
                 AndroidUpdateChannel.Nightly,
             ),
         )
-        assertTrue(
+        assertFalse(
             canSelectAppUpdateChannel(
                 directSupport.copy(channel = AppDistributionChannel.DirectDesktopPackage),
                 AndroidUpdateChannel.Nightly,
@@ -55,25 +57,22 @@ class AppUpdateChannelsTest {
     }
 
     @Test
-    fun presentationExposesRiskAndFutureChannelsWithoutEnablingThem() {
+    fun presentationShowsOnlyTheLockedNightlyTrack() {
         val presentation = appUpdateChannelPresentation(
             directSupport,
-            selectedChannel = AndroidUpdateChannel.Nightly,
+            selectedChannel = AndroidUpdateChannel.Alpha,
         )
 
         assertTrue(presentation.selectorVisible)
-        assertTrue(presentation.selectorEnabled)
-        assertEquals(AndroidUpdateChannel.entries.toList(), presentation.options.map { it.channel })
-        val nightly = presentation.options.single { it.channel == AndroidUpdateChannel.Nightly }
+        assertFalse(presentation.selectorEnabled)
+        assertEquals(AndroidUpdateChannel.Nightly, presentation.selectedChannel)
+        val nightly = presentation.options.single()
+        assertEquals(AndroidUpdateChannel.Nightly, nightly.channel)
         assertTrue(nightly.selected)
-        assertTrue(nightly.enabled)
+        assertFalse(nightly.enabled)
+        assertEquals("Locked for now", nightly.availabilityLabel)
         assertTrue(nightly.description.contains("signed APK"))
         assertTrue(nightly.description.contains("less stable"))
-        listOf(AndroidUpdateChannel.Beta, AndroidUpdateChannel.Stable).forEach { channel ->
-            val option = presentation.options.single { it.channel == channel }
-            assertFalse(option.enabled)
-            assertEquals("Coming later", option.availabilityLabel)
-        }
 
         val storePresentation = appUpdateChannelPresentation(
             directSupport.copy(

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdatesTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdatesTest.kt
@@ -261,14 +261,14 @@ class ProjectNewsAndUpdatesTest {
     @Test
     fun updateChannelPreferencesAcceptStableIdentifiersAndSafelyDefault() {
         assertEquals(
-            AndroidUpdateChannel.Alpha,
+            AndroidUpdateChannel.Nightly,
             parseAndroidUpdateChannel(AndroidUpdateChannel.Alpha.manifestChannel),
         )
         assertEquals(
             AndroidUpdateChannel.Nightly,
             parseAndroidUpdateChannel(AndroidUpdateChannel.Nightly.name),
         )
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel(null))
-        assertEquals(AndroidUpdateChannel.Alpha, parseAndroidUpdateChannel("stable-v1"))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel(null))
+        assertEquals(AndroidUpdateChannel.Nightly, parseAndroidUpdateChannel("stable-v1"))
     }
 }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdates.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdates.kt
@@ -408,8 +408,14 @@ internal class DesktopAppUpdater(
         return true
     }
 
-    private fun storedUpdateChannel(): AndroidUpdateChannel =
-        parseAndroidUpdateChannel(preferences.get(KEY_UPDATE_CHANNEL, null))
+    private fun storedUpdateChannel(): AndroidUpdateChannel {
+        val storedValue = preferences.get(KEY_UPDATE_CHANNEL, null)
+        val channel = parseAndroidUpdateChannel(storedValue)
+        if (storedValue != channel.storageValue) {
+            preferences.put(KEY_UPDATE_CHANNEL, channel.storageValue)
+        }
+        return channel
+    }
 
     private companion object {
         const val KEY_UPDATE_CHANNEL = "app-update-channel"

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdatesTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdatesTest.kt
@@ -462,6 +462,7 @@ class DesktopAppUpdatesTest {
         val node = Preferences.userRoot().node("desktop-update-channel-test-${UUID.randomUUID()}")
         val directory = Files.createTempDirectory("desktop-update-channel-test").toFile()
         try {
+            node.put("app-update-channel", AndroidUpdateChannel.Alpha.storageValue)
             val updater = DesktopAppUpdater(
                 preferences = node,
                 buildIdentity = DesktopUpdateBuildIdentity(
@@ -492,7 +493,10 @@ class DesktopAppUpdatesTest {
                 releaseNotesUrl = "https://github.com/Obiente/nc-native/releases/tag/v0.1.0-alpha.2",
             )
 
-            assertTrue(updater.saveUpdateChannel(AndroidUpdateChannel.Nightly))
+            assertEquals(AndroidUpdateChannel.Nightly, updater.updateChannel())
+            assertEquals(AndroidUpdateChannel.Nightly.storageValue, node.get("app-update-channel", null))
+            assertFalse(updater.saveUpdateChannel(AndroidUpdateChannel.Alpha))
+            assertFalse(updater.saveUpdateChannel(AndroidUpdateChannel.Nightly))
             val result = runBlocking { updater.beginUpdate(alphaRelease) }
             val rejected = assertIs<AppUpdateInstallResult.Rejected>(result)
             assertTrue(rejected.message.contains("channel changed", ignoreCase = true))


### PR DESCRIPTION
## Summary

- make Nightly the enforced default update track for direct APK and desktop package installations
- migrate saved Alpha and invalid channel values to Nightly and persist the migration
- temporarily lock the channel selector to Nightly while retaining the Alpha release contract for one final transition release

## Rollout

Existing direct-install users can discover and install the planned final Alpha through the current prerelease pointer. After that build starts, it rewrites the selected channel to Nightly. Subsequent builds follow the Nightly pointer, while store-managed installations remain owned by their store.

The Alpha manifest and release contract stay intact so the transition release can still be published without repurposing its channel.

## Validation

- `./gradlew :ui:desktopTest --tests 'dev.obiente.nextcloudnative.app.AppUpdateChannelsTest' --tests 'dev.obiente.nextcloudnative.app.ProjectNewsAndUpdatesTest' --tests 'dev.obiente.nextcloudnative.app.DesktopAppUpdatesTest'`
- `./gradlew :androidApp:testDebugUnitTest --tests 'dev.obiente.nextcloudnative.AndroidProjectContentClientTest'`
- `bash tools/check-repository.sh`