### PR TITLE
fix(windows): recover corrupt root unregistration

### DIFF
--- a/changes/unreleased/341-windows-corrupt-root-unregister.md
+++ b/changes/unreleased/341-windows-corrupt-root-unregister.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 341
-pull: none
+pull: 342
 platforms: windows
 user-facing: yes
 

--- a/changes/unreleased/341-windows-corrupt-root-unregister.md
+++ b/changes/unreleased/341-windows-corrupt-root-unregister.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 341
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows filesync can now safely unregister an exact branded root during corrupt-metadata recovery without probing the unavailable Cloud Files directory first.

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -52,6 +52,25 @@ fn registered_path_state(
 }
 
 #[cfg(any(windows, test))]
+fn owned_registration_path_is_safe_to_unregister<Missing, SameEntry>(
+    exact_registered_path: bool,
+    registered_path_is_missing: Missing,
+    registered_path_is_same_entry: SameEntry,
+) -> std::io::Result<bool>
+where
+    Missing: FnOnce() -> std::io::Result<bool>,
+    SameEntry: FnOnce() -> std::io::Result<bool>,
+{
+    if exact_registered_path {
+        return Ok(true);
+    }
+    if registered_path_is_missing()? {
+        return Ok(true);
+    }
+    registered_path_is_same_entry()
+}
+
+#[cfg(any(windows, test))]
 #[derive(Debug, PartialEq, Eq)]
 enum ExistingRegistrationAction {
     KeepCurrent,
@@ -252,8 +271,9 @@ mod platform {
         OwnedPathConflict, PROVIDER_ID, RECOVERABLE_ROOT_ARGUMENT, RegisteredPathState,
         RegistrationNotFound, UnsafeRegistrationConflict, account_id_from_sync_root_id,
         decode_identity_hex, existing_registration_action, is_windows_absence_hresult,
-        paths_refer_to_same_existing_entry, recoverable_root_matches, registered_path_state,
-        sid_string, valid_account_id, valid_display_name,
+        owned_registration_path_is_safe_to_unregister, paths_refer_to_same_existing_entry,
+        recoverable_root_matches, registered_path_state, sid_string, valid_account_id,
+        valid_display_name,
     };
     use std::collections::HashMap;
     use std::ffi::{OsStr, OsString};
@@ -614,8 +634,12 @@ mod platform {
             return Err(Box::new(UnsafeRegistrationConflict));
         }
         match existing.Path().and_then(|folder| folder.Path()) {
-            Ok(registered_path) if registered_path_is_missing(&registered_path)? => {}
-            Ok(registered_path) if registered_path_matches(&registered_path, &root)? => {}
+            Ok(registered_path)
+                if owned_registration_path_is_safe_to_unregister(
+                    registered_path == HSTRING::from(root.as_path()),
+                    || registered_path_is_missing(&registered_path),
+                    || registered_path_matches(&registered_path, &root),
+                )? => {}
             Ok(_) => return Err(Box::new(UnsafeRegistrationConflict)),
             Err(failure) if is_windows_absence_hresult(failure.code().0) => {}
             Err(failure) => return Err(failure.into()),
@@ -906,6 +930,40 @@ mod tests {
         ));
 
         std::fs::remove_dir_all(&base).expect("remove registration path fixture");
+    }
+
+    #[test]
+    fn exact_registration_path_bypasses_unavailable_filesystem_probes() {
+        assert!(
+            owned_registration_path_is_safe_to_unregister(
+                true,
+                || Err(std::io::Error::other("cloud provider is unavailable")),
+                || panic!("an exact registered path must not be canonicalized"),
+            )
+            .expect("accept exact registered path")
+        );
+    }
+
+    #[test]
+    fn non_exact_registration_paths_retain_fail_closed_checks() {
+        let unavailable = owned_registration_path_is_safe_to_unregister(
+            false,
+            || Err(std::io::Error::other("cloud provider is unavailable")),
+            || Ok(true),
+        );
+        assert!(unavailable.is_err());
+        assert!(
+            owned_registration_path_is_safe_to_unregister(
+                false,
+                || Ok(true),
+                || { panic!("a missing registered path needs no canonical comparison") }
+            )
+            .expect("accept missing registration path")
+        );
+        assert!(
+            !owned_registration_path_is_safe_to_unregister(false, || Ok(false), || Ok(false))
+                .expect("reject a different existing registration path")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- accept an exact branded sync-root path before probing the unavailable Cloud Files directory
- retain provider ownership, current-user registration, and non-exact path safety checks
- cover exact-match short-circuiting and non-exact fail-closed behavior with focused Rust tests
- add a user-facing Windows changelog fragment

Closes #341

## Root cause

Corrupt-metadata recovery disconnects the provider before unregistering its branded sync root. The shell registrar checked whether the registered directory still existed before checking its exact metadata path. Once disconnected, that existence probe can fail because the damaged Cloud Files root is unavailable, causing safe unregistration to be rejected before recovery can preserve the root.

## Data safety

The exact-path shortcut runs only after the helper resolves the current user's account-scoped registration ID and verifies Obiente's provider GUID. It changes only Windows registration metadata. A non-exact path still has to be missing or resolve to the same existing filesystem entry; probe failures and different existing paths remain rejected.

## Validation

- shell registrar unit suite: 12 tests passed
- Rust formatting passed
- Clippy passed with warnings denied
- Windows MSVC target compile passed
- repository hygiene and all 80 changelog fragments passed
- diff and whitespace validation passed

## Platform validation

[Build and test run 31653337711](https://github.com/Obiente/nc-native/actions/runs/31653337711) passed on exact head `a18b9bac`:

- repository hygiene, changelog enforcement, and semantic compiler tests passed
- Windows desktop tests and MSI packaging passed
- Windows MSI metadata verification passed
- WinGet manifest generation passed
- Windows MSI artifact upload passed

## Runtime validation

The next Windows nightly should be activated against the reported corrupt root. Successful recovery should record preservation and rebuild outcomes after the confirmed `0x8007016b` detection instead of stopping during branded-root unregistration.
