### PR TITLE
fix(windows): recover equivalent branded root paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ windows = { version = "0.62.2", features = [
     "Storage_Search",
     "Storage_Streams",
     "Win32_Foundation",
+    "Win32_Globalization",
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_System_WinRT",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ windows = { version = "0.62.2", features = [
     "Storage_Search",
     "Storage_Streams",
     "Win32_Foundation",
-    "Win32_Globalization",
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_System_WinRT",

--- a/changes/unreleased/341-windows-equivalent-root-recovery.md
+++ b/changes/unreleased/341-windows-equivalent-root-recovery.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 341
-pull: none
+pull: 346
 platforms: windows
 user-facing: yes
 

--- a/changes/unreleased/341-windows-equivalent-root-recovery.md
+++ b/changes/unreleased/341-windows-equivalent-root-recovery.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 341
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows filesync can now recover a corrupt branded root when Windows returns the same registered path with different equivalent formatting.

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -60,6 +60,13 @@ fn normalized_windows_path_units(value: &[u16]) -> Vec<u16> {
     } else if units.starts_with(EXTENDED_PREFIX) {
         units.drain(..EXTENDED_PREFIX.len());
     }
+    if units.get(1) == Some(&COLON)
+        && units
+            .first()
+            .is_some_and(|unit| (b'A' as u16..=b'Z' as u16).contains(unit))
+    {
+        units[0] += u16::from(b'a' - b'A');
+    }
     while units.last() == Some(&BACKSLASH)
         && !(units.len() == 3 && units.get(1) == Some(&COLON))
         && units.len() > 1
@@ -82,17 +89,10 @@ fn ascii_windows_path_unit_eq(first: u16, second: u16) -> bool {
 }
 
 #[cfg(any(windows, test))]
-fn normalized_windows_paths_match<Compare>(
-    first: &[u16],
-    second: &[u16],
-    compare_case_insensitive: Compare,
-) -> bool
-where
-    Compare: FnOnce(&[u16], &[u16]) -> bool,
-{
+fn normalized_windows_paths_match(first: &[u16], second: &[u16]) -> bool {
     let first = normalized_windows_path_units(first);
     let second = normalized_windows_path_units(second);
-    !first.is_empty() && !second.is_empty() && compare_case_insensitive(&first, &second)
+    !first.is_empty() && first == second
 }
 
 #[cfg(any(windows, test))]
@@ -357,7 +357,6 @@ mod platform {
     };
     use windows::Storage::StorageFolder;
     use windows::Win32::Foundation::{CloseHandle, E_FAIL, HANDLE};
-    use windows::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
     use windows::Win32::Security::{
         GetLengthSid, GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
     };
@@ -383,11 +382,7 @@ mod platform {
 
         let registered: Vec<u16> = path.to_os_string().encode_wide().collect();
         let requested: Vec<u16> = requested.as_os_str().encode_wide().collect();
-        normalized_windows_paths_match(&registered, &requested, |first, second| {
-            // SAFETY: both slices remain alive for the call and the API reads exactly their
-            // declared lengths without requiring terminating nulls.
-            unsafe { CompareStringOrdinal(first, second, true) == CSTR_EQUAL }
-        })
+        normalized_windows_paths_match(&registered, &requested)
     }
 
     fn current_registration_state(
@@ -1028,55 +1023,36 @@ mod tests {
 
     #[test]
     fn normalizes_equivalent_windows_registration_path_forms() {
-        fn ascii_case_insensitive(first: &[u16], second: &[u16]) -> bool {
-            first.len() == second.len()
-                && first
-                    .iter()
-                    .zip(second)
-                    .all(|(left, right)| ascii_windows_path_unit_eq(*left, *right))
-        }
-
         let extended: Vec<u16> = r"\\?\C:\fixtures\Nextcloud Native\account-v2\"
             .encode_utf16()
             .collect();
-        let ordinary: Vec<u16> = r"c:/fixtures/nextcloud native/account-v2"
+        let ordinary: Vec<u16> = r"c:/fixtures/Nextcloud Native/account-v2"
             .encode_utf16()
             .collect();
-        assert!(normalized_windows_paths_match(
-            &extended,
-            &ordinary,
-            ascii_case_insensitive,
-        ));
+        assert!(normalized_windows_paths_match(&extended, &ordinary));
 
         let extended_unc: Vec<u16> = r"\\?\UNC\server\share\account-v2\".encode_utf16().collect();
-        let ordinary_unc: Vec<u16> = r"\\SERVER\SHARE\ACCOUNT-V2".encode_utf16().collect();
-        assert!(normalized_windows_paths_match(
-            &extended_unc,
-            &ordinary_unc,
-            ascii_case_insensitive,
-        ));
+        let ordinary_unc: Vec<u16> = r"\\server\share\account-v2".encode_utf16().collect();
+        assert!(normalized_windows_paths_match(&extended_unc, &ordinary_unc));
     }
 
     #[test]
     fn rejects_lexically_different_windows_registration_paths() {
-        fn ascii_case_insensitive(first: &[u16], second: &[u16]) -> bool {
-            first.len() == second.len()
-                && first
-                    .iter()
-                    .zip(second)
-                    .all(|(left, right)| ascii_windows_path_unit_eq(*left, *right))
-        }
-
         let registered: Vec<u16> = r"C:\fixtures\Nextcloud Native\old-account-v2"
             .encode_utf16()
             .collect();
         let requested: Vec<u16> = r"C:\fixtures\Nextcloud Native\account-v2"
             .encode_utf16()
             .collect();
+        assert!(!normalized_windows_paths_match(&registered, &requested));
+
+        let case_sensitive_registered: Vec<u16> =
+            r"C:\fixtures\Cloud\account-v2".encode_utf16().collect();
+        let case_sensitive_requested: Vec<u16> =
+            r"C:\fixtures\cloud\account-v2".encode_utf16().collect();
         assert!(!normalized_windows_paths_match(
-            &registered,
-            &requested,
-            ascii_case_insensitive,
+            &case_sensitive_registered,
+            &case_sensitive_requested,
         ));
     }
 

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -27,6 +27,75 @@ fn paths_refer_to_same_existing_entry(
 }
 
 #[cfg(any(windows, test))]
+fn normalized_windows_path_units(value: &[u16]) -> Vec<u16> {
+    const BACKSLASH: u16 = b'\\' as u16;
+    const SLASH: u16 = b'/' as u16;
+    const COLON: u16 = b':' as u16;
+    const EXTENDED_PREFIX: &[u16] = &[BACKSLASH, BACKSLASH, b'?' as u16, BACKSLASH];
+    const EXTENDED_UNC_PREFIX: &[u16] = &[
+        BACKSLASH,
+        BACKSLASH,
+        b'?' as u16,
+        BACKSLASH,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        BACKSLASH,
+    ];
+
+    let mut units: Vec<u16> = value
+        .iter()
+        .map(|unit| if *unit == SLASH { BACKSLASH } else { *unit })
+        .collect();
+    if units
+        .get(..EXTENDED_UNC_PREFIX.len())
+        .is_some_and(|prefix| {
+            prefix
+                .iter()
+                .zip(EXTENDED_UNC_PREFIX)
+                .all(|(actual, expected)| ascii_windows_path_unit_eq(*actual, *expected))
+        })
+    {
+        units.splice(..EXTENDED_UNC_PREFIX.len(), [BACKSLASH, BACKSLASH]);
+    } else if units.starts_with(EXTENDED_PREFIX) {
+        units.drain(..EXTENDED_PREFIX.len());
+    }
+    while units.last() == Some(&BACKSLASH)
+        && !(units.len() == 3 && units.get(1) == Some(&COLON))
+        && units.len() > 1
+    {
+        units.pop();
+    }
+    units
+}
+
+#[cfg(any(windows, test))]
+fn ascii_windows_path_unit_eq(first: u16, second: u16) -> bool {
+    fn lowercase(unit: u16) -> u16 {
+        if (b'A' as u16..=b'Z' as u16).contains(&unit) {
+            unit + u16::from(b'a' - b'A')
+        } else {
+            unit
+        }
+    }
+    lowercase(first) == lowercase(second)
+}
+
+#[cfg(any(windows, test))]
+fn normalized_windows_paths_match<Compare>(
+    first: &[u16],
+    second: &[u16],
+    compare_case_insensitive: Compare,
+) -> bool
+where
+    Compare: FnOnce(&[u16], &[u16]) -> bool,
+{
+    let first = normalized_windows_path_units(first);
+    let second = normalized_windows_path_units(second);
+    !first.is_empty() && !second.is_empty() && compare_case_insensitive(&first, &second)
+}
+
+#[cfg(any(windows, test))]
 #[derive(Debug, PartialEq, Eq)]
 enum RegisteredPathState {
     Missing,
@@ -271,9 +340,9 @@ mod platform {
         OwnedPathConflict, PROVIDER_ID, RECOVERABLE_ROOT_ARGUMENT, RegisteredPathState,
         RegistrationNotFound, UnsafeRegistrationConflict, account_id_from_sync_root_id,
         decode_identity_hex, existing_registration_action, is_windows_absence_hresult,
-        owned_registration_path_is_safe_to_unregister, paths_refer_to_same_existing_entry,
-        recoverable_root_matches, registered_path_state, sid_string, valid_account_id,
-        valid_display_name,
+        normalized_windows_paths_match, owned_registration_path_is_safe_to_unregister,
+        paths_refer_to_same_existing_entry, recoverable_root_matches, registered_path_state,
+        sid_string, valid_account_id, valid_display_name,
     };
     use std::collections::HashMap;
     use std::ffi::{OsStr, OsString};
@@ -288,6 +357,7 @@ mod platform {
     };
     use windows::Storage::StorageFolder;
     use windows::Win32::Foundation::{CloseHandle, E_FAIL, HANDLE};
+    use windows::Win32::Globalization::{CSTR_EQUAL, CompareStringOrdinal};
     use windows::Win32::Security::{
         GetLengthSid, GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
     };
@@ -302,10 +372,22 @@ mod platform {
     }
 
     fn registered_path_matches(path: &HSTRING, requested: &Path) -> Result<bool, std::io::Error> {
-        if path == &HSTRING::from(requested) {
+        if registered_path_lexically_matches(path, requested) {
             return Ok(true);
         }
         paths_refer_to_same_existing_entry(&PathBuf::from(path.to_os_string()), requested)
+    }
+
+    fn registered_path_lexically_matches(path: &HSTRING, requested: &Path) -> bool {
+        use std::os::windows::ffi::OsStrExt;
+
+        let registered: Vec<u16> = path.to_os_string().encode_wide().collect();
+        let requested: Vec<u16> = requested.as_os_str().encode_wide().collect();
+        normalized_windows_paths_match(&registered, &requested, |first, second| {
+            // SAFETY: both slices remain alive for the call and the API reads exactly their
+            // declared lengths without requiring terminating nulls.
+            unsafe { CompareStringOrdinal(first, second, true) == CSTR_EQUAL }
+        })
     }
 
     fn current_registration_state(
@@ -636,7 +718,7 @@ mod platform {
         match existing.Path().and_then(|folder| folder.Path()) {
             Ok(registered_path)
                 if owned_registration_path_is_safe_to_unregister(
-                    registered_path == HSTRING::from(root.as_path()),
+                    registered_path_lexically_matches(&registered_path, &root),
                     || registered_path_is_missing(&registered_path),
                     || registered_path_matches(&registered_path, &root),
                 )? => {}
@@ -942,6 +1024,60 @@ mod tests {
             )
             .expect("accept exact registered path")
         );
+    }
+
+    #[test]
+    fn normalizes_equivalent_windows_registration_path_forms() {
+        fn ascii_case_insensitive(first: &[u16], second: &[u16]) -> bool {
+            first.len() == second.len()
+                && first
+                    .iter()
+                    .zip(second)
+                    .all(|(left, right)| ascii_windows_path_unit_eq(*left, *right))
+        }
+
+        let extended: Vec<u16> = r"\\?\C:\fixtures\Nextcloud Native\account-v2\"
+            .encode_utf16()
+            .collect();
+        let ordinary: Vec<u16> = r"c:/fixtures/nextcloud native/account-v2"
+            .encode_utf16()
+            .collect();
+        assert!(normalized_windows_paths_match(
+            &extended,
+            &ordinary,
+            ascii_case_insensitive,
+        ));
+
+        let extended_unc: Vec<u16> = r"\\?\UNC\server\share\account-v2\".encode_utf16().collect();
+        let ordinary_unc: Vec<u16> = r"\\SERVER\SHARE\ACCOUNT-V2".encode_utf16().collect();
+        assert!(normalized_windows_paths_match(
+            &extended_unc,
+            &ordinary_unc,
+            ascii_case_insensitive,
+        ));
+    }
+
+    #[test]
+    fn rejects_lexically_different_windows_registration_paths() {
+        fn ascii_case_insensitive(first: &[u16], second: &[u16]) -> bool {
+            first.len() == second.len()
+                && first
+                    .iter()
+                    .zip(second)
+                    .all(|(left, right)| ascii_windows_path_unit_eq(*left, *right))
+        }
+
+        let registered: Vec<u16> = r"C:\fixtures\Nextcloud Native\old-account-v2"
+            .encode_utf16()
+            .collect();
+        let requested: Vec<u16> = r"C:\fixtures\Nextcloud Native\account-v2"
+            .encode_utf16()
+            .collect();
+        assert!(!normalized_windows_paths_match(
+            &registered,
+            &requested,
+            ascii_case_insensitive,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- recognize unconditionally equivalent Windows spellings of the same branded Cloud Files root without touching the disconnected filesystem
- preserve current-user, account ID, and provider GUID ownership checks while rejecting genuinely different or case-distinct directory roots
- cover drive-letter casing, slash styles, extended local and UNC prefixes, trailing separators, and negative path cases

Fixes #341

## Root cause

Corrupt-root recovery disconnects the Cloud Files provider before unregistering its branded registration. The previous fix short-circuited filesystem probes only when the WinRT path and application path were byte-for-byte equal. Windows can return the same path with an extended prefix, different slash style, a trailing separator, or different drive-letter casing, so the registrar fell back to a filesystem canonicalization probe that cannot succeed while the damaged provider is disconnected.

## Data safety

The lexical shortcut runs only after resolving the current user account-scoped registration ID and verifying the Obiente provider GUID. It unregisters Windows registration metadata only. It does not delete, overwrite, dehydrate, or replace local files. Directory-component casing remains exact because Windows per-directory case sensitivity can make differently cased names distinct roots. Every genuinely different root remains rejected, and the existing non-destructive recovery preserves the complete damaged root before rebuilding the provider.

## Validation

- focused shell registrar suite: 14 tests passed
- full Rust test suite passed
- Rust formatting passed
- Clippy passed with warnings denied
- Windows MSVC helper target compiled successfully
- changelog validation passed with 85 fragments
- repository hygiene and diff checks passed

## Runtime verification

After review and merge, the packaged Windows nightly still needs activation against the reported corrupt root. Success is the `corrupt-root-preserved` and `corrupt-root-recovered` diagnostic sequence instead of another unregistration rejection.