### PR TITLE
feat(release): add stable platform downloads

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -481,6 +481,7 @@ jobs:
               --source-sha "${NIGHTLY_SHA}" \
               --source-run-url "${SOURCE_RUN_URL}" \
               --available "${available_platforms}" \
+              --assets dist \
               --output "${RUNNER_TEMP}/release-notes.md"
           }
           write_release_notes "${STAGED_AVAILABLE_PLATFORMS}"
@@ -561,7 +562,15 @@ jobs:
           echo "successful=${canonical_successful}" >>"${GITHUB_OUTPUT}"
           echo "available=${canonical_available}" >>"${GITHUB_OUTPUT}"
 
-          write_release_notes "${canonical_available}"
+          rm -f "${canonical}/SHA256SUMS"
+          node tools/nightly-release-notes.mjs \
+            --repository "${GITHUB_REPOSITORY}" \
+            --tag "${NIGHTLY_TAG}" \
+            --source-sha "${NIGHTLY_SHA}" \
+            --source-run-url "${SOURCE_RUN_URL}" \
+            --available "${canonical_available}" \
+            --assets "${canonical}" \
+            --output "${RUNNER_TEMP}/release-notes.md"
           gh release edit "${NIGHTLY_TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
             --verify-tag \
@@ -673,7 +682,7 @@ jobs:
       - source
       - publish
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     concurrency:
       group: app-nightly-channel
       cancel-in-progress: false
@@ -697,6 +706,14 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --pattern '*update-manifest.json' \
             --dir channel
+          gh release download "${NIGHTLY_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern '*.apk' \
+            --pattern '*.deb' \
+            --pattern '*.rpm' \
+            --pattern '*.msi' \
+            --pattern '*.dmg' \
+            --dir channel
           android_manifest="-"
           desktop_manifest="-"
           [[ -f channel/update-manifest.json ]] && android_manifest=channel/update-manifest.json
@@ -709,3 +726,8 @@ jobs:
             "${android_manifest}" \
             "${desktop_manifest}" \
             1
+          tools/promote-download-channel.sh \
+            "${GITHUB_REPOSITORY}" \
+            channel-nightly \
+            "${NIGHTLY_TAG}" \
+            channel

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -555,6 +555,17 @@ jobs:
             NR == 2 && /^$/ { next }
             { print }
           ' "docs/release-notes/${version}.md" >"${RUNNER_TEMP}/release-notes.md"
+          node tools/release-download-table.mjs \
+            --repository "${GITHUB_REPOSITORY}" \
+            --tag "${GITHUB_REF_NAME}" \
+            --assets dist \
+            --output "${RUNNER_TEMP}/release-downloads.md"
+          {
+            cat "${RUNNER_TEMP}/release-downloads.md"
+            cat "${RUNNER_TEMP}/release-notes.md"
+          } >"${RUNNER_TEMP}/release-notes-with-downloads.md"
+          mv "${RUNNER_TEMP}/release-notes-with-downloads.md" \
+            "${RUNNER_TEMP}/release-notes.md"
           if [[ "${SUCCESSFUL_PLATFORMS}" -lt 4 ]]; then
             {
               printf '\n## Build availability\n\n'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -713,6 +713,19 @@ jobs:
             if [[ -f "${canonical}/SHA256SUMS" ]]; then
               rm "${canonical}/SHA256SUMS"
             fi
+            node tools/release-download-table.mjs \
+              --repository "${GITHUB_REPOSITORY}" \
+              --tag "${GITHUB_REF_NAME}" \
+              --assets "${canonical}" \
+              --output "${RUNNER_TEMP}/canonical-release-downloads.md" \
+              --replace-in "${RUNNER_TEMP}/release-notes.md"
+            gh release edit "${GITHUB_REF_NAME}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --verify-tag \
+              --prerelease \
+              --latest=false \
+              --notes-file "${RUNNER_TEMP}/release-notes.md" \
+              --title "Nextcloud Native ${version}"
             mapfile -d '' canonical_apks < <(
               find "${canonical}" -maxdepth 1 -type f \
                 -name 'nextcloud-native-*-android.apk' -print0

--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ endorsed by Nextcloud GmbH.
 
 ## Quick downloads
 
-Nightly is currently the default and only selectable update track. These stable
-links will keep working when package version filenames change; the `latest`
-links follow Nightly for now and can move to Stable later.
+Nightly is currently the default and only selectable update track.
 
 | Platform | Latest build | Explicit Nightly |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ feel like one operating-system service:
 Nextcloud Native is unofficial and is not affiliated with, sponsored by, or
 endorsed by Nextcloud GmbH.
 
+## Quick downloads
+
+Nightly is currently the default and only selectable update track. These stable
+links will keep working when package version filenames change; the `latest`
+links follow Nightly for now and can move to Stable later.
+
+| Platform | Latest build | Explicit Nightly |
+| --- | --- | --- |
+| Android 8.0+ | [Download APK](https://nc-native.obiente.dev/d/android-latest) | [Nightly APK](https://nc-native.obiente.dev/d/android-nightly) |
+| Linux (Debian/Ubuntu) | [Download DEB](https://nc-native.obiente.dev/d/linux-deb-latest) | [Nightly DEB](https://nc-native.obiente.dev/d/linux-deb-nightly) |
+| Linux (Fedora/RHEL) | [Download RPM](https://nc-native.obiente.dev/d/linux-rpm-latest) | [Nightly RPM](https://nc-native.obiente.dev/d/linux-rpm-nightly) |
+| Windows x86-64 | [Download MSI](https://nc-native.obiente.dev/d/windows-latest) | [Nightly MSI](https://nc-native.obiente.dev/d/windows-nightly) |
+| macOS Intel preview | [Download DMG](https://nc-native.obiente.dev/d/macos-latest) | [Nightly DMG](https://nc-native.obiente.dev/d/macos-nightly) |
+
+The macOS package is a packaging preview and cannot sign in yet. Windows builds
+are not Authenticode-signed. See the current release notes for platform-specific
+limitations, checksums, and Windows provenance verification.
+
 ## Why this project exists
 
 The Nextcloud ecosystem has excellent server apps, but their mobile and desktop

--- a/changes/unreleased/stable-platform-download-links.md
+++ b/changes/unreleased/stable-platform-download-links.md
@@ -1,0 +1,7 @@
+category: feature
+issue: none
+pull: 349
+platforms: android, linux, macos, website, windows
+user-facing: yes
+
+Release notes, the README, and the website now provide clear per-platform downloads, stable Latest and Nightly URLs, and a live GitHub star link with a resilient fallback.

--- a/tools/check-repository.sh
+++ b/tools/check-repository.sh
@@ -56,11 +56,13 @@ bash tools/test-build-jvm-criteria.sh
 node tools/changelog-fragments.mjs validate
 node --test tools/changelog-fragments.test.mjs
 node --test tools/nightly-release-notes.test.mjs
+node --test tools/release-download-table.test.mjs
 bash tools/test-desktop-package-version.sh
 bash tools/test-android-update-manifest-assets.sh
 bash tools/test-nightly-release-workflow.sh
 bash tools/test-marketing-capture-workflow.sh
 bash tools/test-update-channel-promotion.sh
+bash tools/test-download-channel-promotion.sh
 bash tools/test-linux-package-metadata.sh
 bash tools/test-desktop-update-manifest.sh
 

--- a/tools/nightly-release-notes.mjs
+++ b/tools/nightly-release-notes.mjs
@@ -120,6 +120,15 @@ export function composeNightlyReleaseNotes({
     );
   }
 
+  if (availablePlatforms.has("macos")) {
+    lines.push(
+      "",
+      "## macOS limitations",
+      "",
+      "The Intel DMG is an early packaging preview. Native Keychain credential storage is not implemented, so this package cannot be used to sign in to a Nextcloud account. It also has no direct update path; install a newer DMG manually when one is published.",
+    );
+  }
+
   lines.push(
     "",
     "## Updating",

--- a/tools/nightly-release-notes.mjs
+++ b/tools/nightly-release-notes.mjs
@@ -9,6 +9,7 @@ import {
   loadFragments,
   renderFragments,
 } from "./changelog-fragments.mjs";
+import { composeReleaseDownloadTable } from "./release-download-table.mjs";
 
 const modulePath = fileURLToPath(import.meta.url);
 
@@ -55,6 +56,7 @@ function parseAvailablePlatforms(value) {
 }
 
 export function composeNightlyReleaseNotes({
+  assetNames = [],
   availablePlatforms,
   fragments,
   repository,
@@ -92,6 +94,7 @@ export function composeNightlyReleaseNotes({
   const lines = [
     `# Nextcloud Native ${tag}`,
     "",
+    composeReleaseDownloadTable({ assetNames, repository, tag }),
     "This is an automated prerelease built from the exact `main` revision that passed the repository's build and test workflow. Nightlies are intended for testing and may include unfinished behavior. Keep a backup of important data.",
     "",
     "## Current development highlights",
@@ -104,19 +107,6 @@ export function composeNightlyReleaseNotes({
     lines.push(highlights, "");
   } else {
     lines.push("No user-facing changelog entries are currently recorded.", "");
-  }
-
-  lines.push(
-    "## Downloads",
-    "",
-    "Choose the package for your platform from the release assets below.",
-    "",
-    "| Platform | Package | Status |",
-    "| --- | --- | --- |",
-  );
-  for (const row of platformRows) {
-    const status = availablePlatforms.has(row.id) ? "Available" : "Unavailable";
-    lines.push(`| ${row.label} | ${row.packages} | ${status} |`);
   }
 
   if (availablePlatforms.has("windows")) {
@@ -160,8 +150,13 @@ async function runCli() {
   const availablePlatforms = parseAvailablePlatforms(
     argumentValue(args, "--available", ""),
   );
+  const assetsDirectory = argumentValue(args, "--assets");
+  const assetNames = assetsDirectory
+    ? await (await import("node:fs/promises")).readdir(path.resolve(repositoryRoot, assetsDirectory))
+    : [];
   const fragments = await loadFragments(repositoryRoot);
   const notes = composeNightlyReleaseNotes({
+    assetNames,
     availablePlatforms,
     fragments,
     repository,

--- a/tools/nightly-release-notes.test.mjs
+++ b/tools/nightly-release-notes.test.mjs
@@ -86,3 +86,16 @@ test("nightly notes disclose the unsigned Windows installation path", () => {
     /gh attestation verify <downloaded-msi> --repo Obiente\/nc-native/,
   );
 });
+
+test("nightly notes disclose macOS sign-in and update limitations", () => {
+  const notes = composeNightlyReleaseNotes({
+    ...baseOptions,
+    assetNames: ["NextcloudNative-1.0.1.dmg"],
+    availablePlatforms: new Set(["macos"]),
+  });
+
+  assert.match(notes, /\| macOS preview \| \[DMG \(Intel\)\]/);
+  assert.match(notes, /## macOS limitations/);
+  assert.match(notes, /cannot be used to sign in to a Nextcloud account/);
+  assert.match(notes, /has no direct update path/);
+});

--- a/tools/nightly-release-notes.test.mjs
+++ b/tools/nightly-release-notes.test.mjs
@@ -55,7 +55,7 @@ test("nightly notes are useful, traceable, and omit internal fragments", () => {
   );
   assert.doesNotMatch(notes, /Release automation now emits richer nightly descriptions/);
   assert.match(notes, /\| Android \| \[APK\]\(.*android\.apk\) \|/);
-  assert.match(notes, /\| Linux \| \[DEB\]\(.*\.deb\) · \[RPM\]\(.*\.rpm\) \|/);
+  assert.match(notes, /\| Linux \| \[DEB\]\(.*\.deb\) \/ \[RPM\]\(.*\.rpm\) \|/);
   assert.match(notes, /\| Windows \| Unavailable \|/);
   assert.match(notes, new RegExp(`/commit/${sourceSha.replaceAll("/", "\\/")}`));
   assert.match(notes, /Updates are never downloaded or installed silently\./);

--- a/tools/nightly-release-notes.test.mjs
+++ b/tools/nightly-release-notes.test.mjs
@@ -6,6 +6,11 @@ import { composeNightlyReleaseNotes } from "./nightly-release-notes.mjs";
 
 const sourceSha = "0123456789abcdef0123456789abcdef01234567";
 const baseOptions = {
+  assetNames: [
+    "nextcloud-native-nightly-android.apk",
+    "nextcloudnative_1.0.1_amd64.deb",
+    "nextcloudnative-1.0.1-1.x86_64.rpm",
+  ],
   availablePlatforms: new Set(["android", "linux"]),
   fragments: [
     parseFragment(
@@ -49,9 +54,9 @@ test("nightly notes are useful, traceable, and omit internal fragments", () => {
     /Direct installs now report when a verified update is available \(issue #237\)\./,
   );
   assert.doesNotMatch(notes, /Release automation now emits richer nightly descriptions/);
-  assert.match(notes, /\| Android \| \.apk \| Available \|/);
-  assert.match(notes, /\| Linux \| \.deb and \.rpm \| Available \|/);
-  assert.match(notes, /\| Windows \| \.msi \| Unavailable \|/);
+  assert.match(notes, /\| Android \| \[APK\]\(.*android\.apk\) \|/);
+  assert.match(notes, /\| Linux \| \[DEB\]\(.*\.deb\) · \[RPM\]\(.*\.rpm\) \|/);
+  assert.match(notes, /\| Windows \| Unavailable \|/);
   assert.match(notes, new RegExp(`/commit/${sourceSha.replaceAll("/", "\\/")}`));
   assert.match(notes, /Updates are never downloaded or installed silently\./);
 });

--- a/tools/promote-download-channel.sh
+++ b/tools/promote-download-channel.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository="${1:?Repository is required.}"
+pointer_tag="${2:?Pointer tag is required.}"
+immutable_tag="${3:?Immutable tag is required.}"
+asset_directory="${4:?Asset directory is required.}"
+
+[[ "$repository" == "Obiente/nc-native" ]]
+[[ "$pointer_tag" == "channel-nightly" ]]
+[[ "$immutable_tag" =~ ^nightly-[0-9]{8}-[0-9]{4}-run[1-9][0-9]*-[a-f0-9]{8}$ ]]
+[[ -d "$asset_directory" ]]
+
+declare -A aliases=(
+    [android]="nextcloud-native-android.apk"
+    [linux-deb]="nextcloud-native-linux-amd64.deb"
+    [linux-rpm]="nextcloud-native-linux-x86_64.rpm"
+    [windows]="nextcloud-native-windows-x86_64.msi"
+    [macos]="nextcloud-native-macos-intel.dmg"
+)
+
+find_single() {
+    local pattern="$1"
+    mapfile -d '' matches < <(find "$asset_directory" -maxdepth 1 -type f -name "$pattern" -print0)
+    [[ "${#matches[@]}" -le 1 ]]
+    [[ "${#matches[@]}" -eq 1 ]] || return 1
+    printf '%s\n' "${matches[0]}"
+}
+
+temporary="$(mktemp -d)"
+trap 'rm -r -- "$temporary"' EXIT
+declare -a uploads=()
+declare -A published_aliases=()
+for platform in android linux-deb linux-rpm windows macos; do
+    case "$platform" in
+        android) pattern='nextcloud-native-*-android.apk' ;;
+        linux-deb) pattern='*.deb' ;;
+        linux-rpm) pattern='*.rpm' ;;
+        windows) pattern='*.msi' ;;
+        macos) pattern='*.dmg' ;;
+    esac
+    if source="$(find_single "$pattern")"; then
+        destination="$temporary/${aliases[$platform]}"
+        cp -- "$source" "$destination"
+        uploads+=("$destination")
+        published_aliases["${aliases[$platform]}"]=true
+    fi
+done
+[[ "${#uploads[@]}" -gt 0 ]]
+
+release_state="$(
+    gh release view "$immutable_tag" --repo "$repository" \
+        --json isDraft,isPrerelease,tagName \
+        --jq '[.isDraft, .isPrerelease, .tagName] | @tsv'
+)"
+test "$release_state" = $'false\ttrue\t'"$immutable_tag"
+pointer_state="$(
+    gh release view "$pointer_tag" --repo "$repository" \
+        --json isDraft,isPrerelease,tagName \
+        --jq '[.isDraft, .isPrerelease, .tagName] | @tsv'
+)"
+test "$pointer_state" = $'false\ttrue\t'"$pointer_tag"
+
+existing_assets="$(
+    gh release view "$pointer_tag" --repo "$repository" --json assets --jq '.assets[].name'
+)"
+for alias in "${aliases[@]}"; do
+    if [[ -z "${published_aliases[$alias]:-}" ]] && grep -Fxq "$alias" <<<"$existing_assets"; then
+        gh release delete-asset "$pointer_tag" "$alias" --repo "$repository" --yes
+    fi
+done
+gh release upload "$pointer_tag" "${uploads[@]}" --repo "$repository" --clobber

--- a/tools/promote-download-channel.sh
+++ b/tools/promote-download-channel.sh
@@ -30,7 +30,6 @@ find_single() {
 temporary="$(mktemp -d)"
 trap 'rm -r -- "$temporary"' EXIT
 declare -a uploads=()
-declare -A published_aliases=()
 for platform in android linux-deb linux-rpm windows macos; do
     case "$platform" in
         android) pattern='nextcloud-native-*-android.apk' ;;
@@ -43,7 +42,6 @@ for platform in android linux-deb linux-rpm windows macos; do
         destination="$temporary/${aliases[$platform]}"
         cp -- "$source" "$destination"
         uploads+=("$destination")
-        published_aliases["${aliases[$platform]}"]=true
     fi
 done
 [[ "${#uploads[@]}" -gt 0 ]]
@@ -61,12 +59,59 @@ pointer_state="$(
 )"
 test "$pointer_state" = $'false\ttrue\t'"$pointer_tag"
 
-existing_assets="$(
-    gh release view "$pointer_tag" --repo "$repository" --json assets --jq '.assets[].name'
-)"
-for alias in "${aliases[@]}"; do
-    if [[ -z "${published_aliases[$alias]:-}" ]] && grep -Fxq "$alias" <<<"$existing_assets"; then
-        gh release delete-asset "$pointer_tag" "$alias" --repo "$repository" --yes
-    fi
+mapfile -t candidate_codes < <(
+    find "$asset_directory" -maxdepth 1 -type f \
+        \( -name 'update-manifest.json' -o -name 'desktop-update-manifest.json' \) \
+        -print0 |
+        sort -z |
+        xargs -0 -r -n1 jq -er '.versionCode | select(type == "number" and floor == . and . > 0)'
+)
+[[ "${#candidate_codes[@]}" -gt 0 ]]
+candidate_code="${candidate_codes[0]}"
+for code in "${candidate_codes[@]}"; do
+    [[ "$code" == "$candidate_code" ]]
 done
+[[ "$candidate_code" =~ ^[1-9][0-9]*$ ]]
+
+mkdir -p "$temporary/existing"
+if gh release download "$pointer_tag" \
+    --repo "$repository" \
+    --pattern download-channel.json \
+    --dir "$temporary/existing" >/dev/null 2>&1; then
+    current_code="$(
+        jq -er \
+            --arg channel nightly-v1 \
+            '
+              select(keys == ["channel", "releaseNotesUrl", "schemaVersion", "versionCode", "versionName"]) |
+              select(.schemaVersion == 1 and .channel == $channel) |
+              select(.versionCode | type == "number" and floor == . and . > 0) |
+              select(.versionName | test("^nightly-[0-9]{8}-[0-9]{4}-run[1-9][0-9]*-[a-f0-9]{8}$")) |
+              select(.releaseNotesUrl == "https://github.com/Obiente/nc-native/releases/tag/" + .versionName) |
+              .versionCode
+            ' \
+            "$temporary/existing/download-channel.json"
+    )"
+    [[ "$current_code" =~ ^[1-9][0-9]*$ ]]
+    if (( current_code > candidate_code )); then
+        printf 'Download channel already has newer version code %s.\n' "$current_code"
+        exit 0
+    fi
+fi
+
+jq -n \
+    --arg version_name "$immutable_tag" \
+    --argjson version_code "$candidate_code" \
+    '{
+      schemaVersion: 1,
+      channel: "nightly-v1",
+      versionName: $version_name,
+      versionCode: $version_code,
+      releaseNotesUrl: ("https://github.com/Obiente/nc-native/releases/tag/" + $version_name)
+    }' >"$temporary/download-channel.json"
+
+# Publish the monotonic marker first. If a package upload is interrupted, an
+# equal-version rerun can finish it while an older rerun remains unable to roll
+# already-updated aliases backward. Missing platforms retain their last verified alias.
+gh release upload "$pointer_tag" "$temporary/download-channel.json" \
+    --repo "$repository" --clobber
 gh release upload "$pointer_tag" "${uploads[@]}" --repo "$repository" --clobber

--- a/tools/promote-download-channel.sh
+++ b/tools/promote-download-channel.sh
@@ -109,9 +109,49 @@ jq -n \
       releaseNotesUrl: ("https://github.com/Obiente/nc-native/releases/tag/" + $version_name)
     }' >"$temporary/download-channel.json"
 
-# Publish the monotonic marker first. If a package upload is interrupted, an
-# equal-version rerun can finish it while an older rerun remains unable to roll
-# already-updated aliases backward. Missing platforms retain their last verified alias.
-gh release upload "$pointer_tag" "$temporary/download-channel.json" \
-    --repo "$repository" --clobber
-gh release upload "$pointer_tag" "${uploads[@]}" --repo "$repository" --clobber
+# gh implements --clobber by deleting the old asset before uploading its
+# replacement. Back up every affected pointer asset so a failed publication can
+# restore the complete previously verified channel rather than leaving a stable
+# download URL missing or partially advanced.
+publish_files=("$temporary/download-channel.json" "${uploads[@]}")
+rollback_directory="$temporary/rollback"
+mkdir -p "$rollback_directory"
+mapfile -t pointer_assets < <(
+    gh release view "$pointer_tag" --repo "$repository" --json assets --jq '.assets[].name'
+)
+declare -A had_existing=()
+for file in "${publish_files[@]}"; do
+    name="$(basename "$file")"
+    if printf '%s\n' "${pointer_assets[@]}" | grep -Fxq -- "$name"; then
+        had_existing["$name"]=1
+        gh release download "$pointer_tag" \
+            --repo "$repository" \
+            --pattern "$name" \
+            --dir "$rollback_directory" >/dev/null
+    else
+        had_existing["$name"]=0
+    fi
+done
+
+if ! gh release upload "$pointer_tag" "${publish_files[@]}" \
+    --repo "$repository" --clobber; then
+    restore_failed=0
+    for file in "${publish_files[@]}"; do
+        name="$(basename "$file")"
+        if [[ "${had_existing[$name]}" == 1 ]]; then
+            if ! gh release upload "$pointer_tag" "$rollback_directory/$name" \
+                --repo "$repository" --clobber; then
+                restore_failed=1
+            fi
+        else
+            gh release delete-asset "$pointer_tag" "$name" \
+                --repo "$repository" --yes >/dev/null 2>&1 || true
+        fi
+    done
+    if (( restore_failed )); then
+        printf 'Download channel upload failed and at least one previous alias could not be restored.\n' >&2
+    else
+        printf 'Download channel upload failed; previous aliases were restored.\n' >&2
+    fi
+    exit 1
+fi

--- a/tools/release-download-table.mjs
+++ b/tools/release-download-table.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readdir, writeFile } from "node:fs/promises";
+import { readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -37,6 +37,7 @@ export function composeReleaseDownloadTable({ assetNames, repository, tag }) {
   const uniqueNames = [...new Set(assetNames)].sort();
   const baseUrl = `https://github.com/${repository}/releases/download/${tag}`;
   const lines = [
+    "<!-- quick-downloads:start -->",
     "## Quick downloads",
     "",
     "Choose the installer for your platform. Read the known limitations below before installing this early test release.",
@@ -49,11 +50,12 @@ export function composeReleaseDownloadTable({ assetNames, repository, tag }) {
       const name = uniqueNames.find((candidate) => pattern.test(candidate));
       return name ? [`[${label}](${baseUrl}/${encodeURIComponent(name)})`] : [];
     });
-    lines.push(`| ${row.platform} | ${links.length > 0 ? links.join(" · ") : "Unavailable"} |`);
+    lines.push(`| ${row.platform} | ${links.length > 0 ? links.join(" / ") : "Unavailable"} |`);
   }
   lines.push(
     "",
     `[Checksums and all release assets](${baseUrl.replace("/download/", "/tag/")})`,
+    "<!-- quick-downloads:end -->",
     "",
   );
   return lines.join("\n");
@@ -75,6 +77,18 @@ async function runCli() {
     tag: argument(args, "--tag"),
   });
   await writeFile(output, table, "utf8");
+  const replaceIn = args.includes("--replace-in")
+    ? path.resolve(argument(args, "--replace-in"))
+    : null;
+  if (replaceIn) {
+    const notes = await readFile(replaceIn, "utf8");
+    const updated = notes.replace(
+      /<!-- quick-downloads:start -->[\s\S]*?<!-- quick-downloads:end -->\n?/,
+      table,
+    );
+    if (updated === notes) fail("release notes do not contain a quick-download table.");
+    await writeFile(replaceIn, updated, "utf8");
+  }
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {

--- a/tools/release-download-table.mjs
+++ b/tools/release-download-table.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import { readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const modulePath = fileURLToPath(import.meta.url);
+
+const packageRows = [
+  { platform: "Android", formats: [{ label: "APK", pattern: /^nextcloud-native-.*-android\.apk$/ }] },
+  {
+    platform: "Linux",
+    formats: [
+      { label: "DEB", pattern: /^nextcloudnative_.*_amd64\.deb$/ },
+      { label: "RPM", pattern: /^nextcloudnative-.*\.x86_64\.rpm$/ },
+    ],
+  },
+  { platform: "Windows", formats: [{ label: "MSI (x86-64)", pattern: /^NextcloudNative-.*\.msi$/ }] },
+  { platform: "macOS preview", formats: [{ label: "DMG (Intel)", pattern: /^NextcloudNative-.*\.dmg$/ }] },
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function validateTag(tag) {
+  if (!/^(?:v0\.[0-9]+\.[0-9]+-(?:alpha|beta|rc)\.[1-9][0-9]*|nightly-[A-Za-z0-9.-]+)$/.test(tag)) {
+    fail("tag is not a supported immutable release tag.");
+  }
+}
+
+export function composeReleaseDownloadTable({ assetNames, repository, tag }) {
+  validateTag(tag);
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    fail("repository must use the owner/name form.");
+  }
+  const uniqueNames = [...new Set(assetNames)].sort();
+  const baseUrl = `https://github.com/${repository}/releases/download/${tag}`;
+  const lines = [
+    "## Quick downloads",
+    "",
+    "Choose the installer for your platform. Read the known limitations below before installing this early test release.",
+    "",
+    "| Platform | Direct download |",
+    "| --- | --- |",
+  ];
+  for (const row of packageRows) {
+    const links = row.formats.flatMap(({ label, pattern }) => {
+      const name = uniqueNames.find((candidate) => pattern.test(candidate));
+      return name ? [`[${label}](${baseUrl}/${encodeURIComponent(name)})`] : [];
+    });
+    lines.push(`| ${row.platform} | ${links.length > 0 ? links.join(" · ") : "Unavailable"} |`);
+  }
+  lines.push(
+    "",
+    `[Checksums and all release assets](${baseUrl.replace("/download/", "/tag/")})`,
+    "",
+  );
+  return lines.join("\n");
+}
+
+function argument(args, name) {
+  const index = args.indexOf(name);
+  if (index < 0 || index + 1 >= args.length) fail(`${name} is required.`);
+  return args[index + 1];
+}
+
+async function runCli() {
+  const args = process.argv.slice(2);
+  const assetsDirectory = path.resolve(argument(args, "--assets"));
+  const output = path.resolve(argument(args, "--output"));
+  const table = composeReleaseDownloadTable({
+    assetNames: await readdir(assetsDirectory),
+    repository: argument(args, "--repository"),
+    tag: argument(args, "--tag"),
+  });
+  await writeFile(output, table, "utf8");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+  runCli().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/release-download-table.mjs
+++ b/tools/release-download-table.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const modulePath = fileURLToPath(import.meta.url);
+const quickDownloadsPattern = /<!-- quick-downloads:start -->[\s\S]*?<!-- quick-downloads:end -->\n?/;
 
 const packageRows = [
   { platform: "Android", formats: [{ label: "APK", pattern: /^nextcloud-native-.*-android\.apk$/ }] },
@@ -61,6 +62,13 @@ export function composeReleaseDownloadTable({ assetNames, repository, tag }) {
   return lines.join("\n");
 }
 
+export function replaceReleaseDownloadTable(notes, table) {
+  if (!quickDownloadsPattern.test(notes)) {
+    fail("release notes do not contain a quick-download table.");
+  }
+  return notes.replace(quickDownloadsPattern, table);
+}
+
 function argument(args, name) {
   const index = args.indexOf(name);
   if (index < 0 || index + 1 >= args.length) fail(`${name} is required.`);
@@ -82,11 +90,7 @@ async function runCli() {
     : null;
   if (replaceIn) {
     const notes = await readFile(replaceIn, "utf8");
-    const updated = notes.replace(
-      /<!-- quick-downloads:start -->[\s\S]*?<!-- quick-downloads:end -->\n?/,
-      table,
-    );
-    if (updated === notes) fail("release notes do not contain a quick-download table.");
+    const updated = replaceReleaseDownloadTable(notes, table);
     await writeFile(replaceIn, updated, "utf8");
   }
 }

--- a/tools/release-download-table.test.mjs
+++ b/tools/release-download-table.test.mjs
@@ -15,9 +15,9 @@ test("release download table links only assets that actually exist", () => {
     tag: "v0.1.0-alpha.2",
   });
 
-  assert.match(table, /^## Quick downloads/);
+  assert.match(table, /^<!-- quick-downloads:start -->\n## Quick downloads/);
   assert.match(table, /\| Android \| \[APK\]\(.*android\.apk\) \|/);
-  assert.match(table, /\| Linux \| \[DEB\]\(.*\.deb\) · \[RPM\]\(.*\.rpm\) \|/);
+  assert.match(table, /\| Linux \| \[DEB\]\(.*\.deb\) \/ \[RPM\]\(.*\.rpm\) \|/);
   assert.match(table, /\| Windows \| \[MSI \(x86-64\)\]\(.*\.msi\) \|/);
   assert.match(table, /\| macOS preview \| Unavailable \|/);
 });

--- a/tools/release-download-table.test.mjs
+++ b/tools/release-download-table.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { composeReleaseDownloadTable } from "./release-download-table.mjs";
+
+test("release download table links only assets that actually exist", () => {
+  const table = composeReleaseDownloadTable({
+    assetNames: [
+      "nextcloud-native-0.1.0-alpha.2-android.apk",
+      "nextcloudnative_1.0.3822_amd64.deb",
+      "nextcloudnative-1.0.3822-1.x86_64.rpm",
+      "NextcloudNative-1.0.3822.msi",
+    ],
+    repository: "Obiente/nc-native",
+    tag: "v0.1.0-alpha.2",
+  });
+
+  assert.match(table, /^## Quick downloads/);
+  assert.match(table, /\| Android \| \[APK\]\(.*android\.apk\) \|/);
+  assert.match(table, /\| Linux \| \[DEB\]\(.*\.deb\) · \[RPM\]\(.*\.rpm\) \|/);
+  assert.match(table, /\| Windows \| \[MSI \(x86-64\)\]\(.*\.msi\) \|/);
+  assert.match(table, /\| macOS preview \| Unavailable \|/);
+});
+
+test("release download table percent-encodes asset names", () => {
+  const table = composeReleaseDownloadTable({
+    assetNames: ["NextcloudNative-preview build.dmg"],
+    repository: "Obiente/nc-native",
+    tag: "nightly-20260813-0800-run1-01234567",
+  });
+  assert.doesNotMatch(table, /preview build/);
+});

--- a/tools/release-download-table.test.mjs
+++ b/tools/release-download-table.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { composeReleaseDownloadTable } from "./release-download-table.mjs";
+import {
+  composeReleaseDownloadTable,
+  replaceReleaseDownloadTable,
+} from "./release-download-table.mjs";
 
 test("release download table links only assets that actually exist", () => {
   const table = composeReleaseDownloadTable({
@@ -29,4 +32,22 @@ test("release download table percent-encodes asset names", () => {
     tag: "nightly-20260813-0800-run1-01234567",
   });
   assert.doesNotMatch(table, /preview build/);
+});
+
+test("release download table replacement accepts unchanged notes", () => {
+  const table = composeReleaseDownloadTable({
+    assetNames: ["nextcloud-native-0.1.0-alpha.2-android.apk"],
+    repository: "Obiente/nc-native",
+    tag: "v0.1.0-alpha.2",
+  });
+  const notes = `${table}## Changes\n\nSomething useful.\n`;
+
+  assert.equal(replaceReleaseDownloadTable(notes, table), notes);
+});
+
+test("release download table replacement rejects a missing marker", () => {
+  assert.throws(
+    () => replaceReleaseDownloadTable("## Changes\n", "replacement"),
+    /do not contain a quick-download table/,
+  );
 });

--- a/tools/test-download-channel-promotion.sh
+++ b/tools/test-download-channel-promotion.sh
@@ -13,37 +13,55 @@ if [[ "$1 $2" == "release view" ]]; then
     tag="$3"
     if [[ " $* " == *" --json isDraft,isPrerelease,tagName "* ]]; then
         printf 'false\ttrue\t%s\n' "$tag"
+    elif [[ " $* " == *" --json assets "* ]]; then
+        find "$FAKE_RELEASE_ASSETS" -maxdepth 1 -type f -printf '%f\n' | sort
     fi
     exit 0
 fi
 if [[ "$1 $2" == "release download" ]]; then
-    [[ -n "${FAKE_POINTER_METADATA:-}" ]] || exit 1
+    pattern=""
     destination=""
     while [[ "$#" -gt 0 ]]; do
-        if [[ "$1" == "--dir" ]]; then destination="$2"; break; fi
+        if [[ "$1" == "--pattern" ]]; then pattern="$2"; shift 2; continue; fi
+        if [[ "$1" == "--dir" ]]; then destination="$2"; shift 2; continue; fi
         shift
     done
-    cp "$FAKE_POINTER_METADATA" "$destination/download-channel.json"
+    [[ -f "$FAKE_RELEASE_ASSETS/$pattern" ]] || exit 1
+    cp "$FAKE_RELEASE_ASSETS/$pattern" "$destination/$pattern"
     exit 0
 fi
 if [[ "$1 $2" == "release upload" ]]; then
     shift 3
     while [[ "$1" != "--repo" ]]; do
-        basename "$1" >>"$FAKE_UPLOADED"
+        name="$(basename "$1")"
+        rm -f "$FAKE_RELEASE_ASSETS/$name"
+        if [[ -n "${FAKE_FAIL_UPLOAD_ONCE:-}" && "$name" == "$FAKE_FAIL_UPLOAD_ONCE" && ! -e "$FAKE_FAILURE_MARKER" ]]; then
+            : >"$FAKE_FAILURE_MARKER"
+            exit 1
+        fi
+        cp "$1" "$FAKE_RELEASE_ASSETS/$name"
+        printf '%s\n' "$name" >>"$FAKE_UPLOADED"
         shift
     done
+    exit 0
+fi
+if [[ "$1 $2" == "release delete-asset" ]]; then
+    rm -f "$FAKE_RELEASE_ASSETS/$4"
     exit 0
 fi
 printf 'Unexpected fake gh invocation: %s\n' "$*" >&2
 exit 1
 EOF
 chmod +x "$temporary/bin/gh"
+mkdir -p "$temporary/release-assets"
 printf android >"$temporary/assets/nextcloud-native-nightly-android.apk"
 printf deb >"$temporary/assets/nextcloudnative_1.2.3_amd64.deb"
 printf msi >"$temporary/assets/NextcloudNative-1.2.3.msi"
 jq -n '{versionCode: 2}' >"$temporary/assets/update-manifest.json"
 
 PATH="$temporary/bin:$PATH" \
+    FAKE_RELEASE_ASSETS="$temporary/release-assets" \
+    FAKE_FAILURE_MARKER="$temporary/upload-failed" \
     FAKE_UPLOADED="$temporary/uploaded" \
     "$project_root/tools/promote-download-channel.sh" \
     Obiente/nc-native \
@@ -68,9 +86,11 @@ jq -n '{
   versionCode: 3,
   releaseNotesUrl: "https://github.com/Obiente/nc-native/releases/tag/nightly-20260814-0800-run2-abcdef12"
 }' >"$newer"
+cp "$newer" "$temporary/release-assets/download-channel.json"
 : >"$temporary/downgrade-uploaded"
 PATH="$temporary/bin:$PATH" \
-    FAKE_POINTER_METADATA="$newer" \
+    FAKE_RELEASE_ASSETS="$temporary/release-assets" \
+    FAKE_FAILURE_MARKER="$temporary/upload-failed" \
     FAKE_UPLOADED="$temporary/downgrade-uploaded" \
     "$project_root/tools/promote-download-channel.sh" \
     Obiente/nc-native \
@@ -79,4 +99,30 @@ PATH="$temporary/bin:$PATH" \
     "$temporary/assets"
 test ! -s "$temporary/downgrade-uploaded"
 
-printf 'Nightly download promotion is monotonic and retains missing-platform aliases.\n'
+rm -f "$temporary/release-assets"/* "$temporary/upload-failed"
+cp "$newer" "$temporary/release-assets/download-channel.json"
+printf old-android >"$temporary/release-assets/nextcloud-native-android.apk"
+printf old-deb >"$temporary/release-assets/nextcloud-native-linux-amd64.deb"
+printf old-msi >"$temporary/release-assets/nextcloud-native-windows-x86_64.msi"
+jq '.versionCode = 4 | .versionName = "nightly-20260815-0800-run3-fedcba98" | .releaseNotesUrl = "https://github.com/Obiente/nc-native/releases/tag/nightly-20260815-0800-run3-fedcba98"' \
+    "$newer" >"$temporary/assets/update-manifest.json"
+: >"$temporary/failed-uploaded"
+if PATH="$temporary/bin:$PATH" \
+    FAKE_RELEASE_ASSETS="$temporary/release-assets" \
+    FAKE_FAILURE_MARKER="$temporary/upload-failed" \
+    FAKE_FAIL_UPLOAD_ONCE="nextcloud-native-windows-x86_64.msi" \
+    FAKE_UPLOADED="$temporary/failed-uploaded" \
+    "$project_root/tools/promote-download-channel.sh" \
+    Obiente/nc-native \
+    channel-nightly \
+    nightly-20260815-0800-run3-fedcba98 \
+    "$temporary/assets"; then
+    echo "A failed alias upload unexpectedly succeeded." >&2
+    exit 1
+fi
+cmp -s "$newer" "$temporary/release-assets/download-channel.json"
+grep -Fxq old-android "$temporary/release-assets/nextcloud-native-android.apk"
+grep -Fxq old-deb "$temporary/release-assets/nextcloud-native-linux-amd64.deb"
+grep -Fxq old-msi "$temporary/release-assets/nextcloud-native-windows-x86_64.msi"
+
+printf 'Nightly download promotion is monotonic, retains missing platforms, and rolls back failed uploads.\n'

--- a/tools/test-download-channel-promotion.sh
+++ b/tools/test-download-channel-promotion.sh
@@ -13,13 +13,17 @@ if [[ "$1 $2" == "release view" ]]; then
     tag="$3"
     if [[ " $* " == *" --json isDraft,isPrerelease,tagName "* ]]; then
         printf 'false\ttrue\t%s\n' "$tag"
-    elif [[ " $* " == *" --json assets "* ]]; then
-        printf '%s\n' 'nextcloud-native-macos-intel.dmg'
     fi
     exit 0
 fi
-if [[ "$1 $2" == "release delete-asset" ]]; then
-    printf '%s\n' "$4" >>"$FAKE_DELETED"
+if [[ "$1 $2" == "release download" ]]; then
+    [[ -n "${FAKE_POINTER_METADATA:-}" ]] || exit 1
+    destination=""
+    while [[ "$#" -gt 0 ]]; do
+        if [[ "$1" == "--dir" ]]; then destination="$2"; break; fi
+        shift
+    done
+    cp "$FAKE_POINTER_METADATA" "$destination/download-channel.json"
     exit 0
 fi
 if [[ "$1 $2" == "release upload" ]]; then
@@ -37,9 +41,9 @@ chmod +x "$temporary/bin/gh"
 printf android >"$temporary/assets/nextcloud-native-nightly-android.apk"
 printf deb >"$temporary/assets/nextcloudnative_1.2.3_amd64.deb"
 printf msi >"$temporary/assets/NextcloudNative-1.2.3.msi"
+jq -n '{versionCode: 2}' >"$temporary/assets/update-manifest.json"
 
 PATH="$temporary/bin:$PATH" \
-    FAKE_DELETED="$temporary/deleted" \
     FAKE_UPLOADED="$temporary/uploaded" \
     "$project_root/tools/promote-download-channel.sh" \
     Obiente/nc-native \
@@ -50,10 +54,29 @@ PATH="$temporary/bin:$PATH" \
 grep -Fxq nextcloud-native-android.apk "$temporary/uploaded"
 grep -Fxq nextcloud-native-linux-amd64.deb "$temporary/uploaded"
 grep -Fxq nextcloud-native-windows-x86_64.msi "$temporary/uploaded"
-grep -Fxq nextcloud-native-macos-intel.dmg "$temporary/deleted"
+grep -Fxq download-channel.json "$temporary/uploaded"
 if grep -Fq nextcloud-native-macos-intel.dmg "$temporary/uploaded"; then
-    echo "A missing platform retained a stale channel alias." >&2
+    echo "A missing platform unexpectedly published an alias." >&2
     exit 1
 fi
 
-printf 'Nightly download promotion publishes stable aliases and removes stale platforms.\n'
+newer="$temporary/newer.json"
+jq -n '{
+  schemaVersion: 1,
+  channel: "nightly-v1",
+  versionName: "nightly-20260814-0800-run2-abcdef12",
+  versionCode: 3,
+  releaseNotesUrl: "https://github.com/Obiente/nc-native/releases/tag/nightly-20260814-0800-run2-abcdef12"
+}' >"$newer"
+: >"$temporary/downgrade-uploaded"
+PATH="$temporary/bin:$PATH" \
+    FAKE_POINTER_METADATA="$newer" \
+    FAKE_UPLOADED="$temporary/downgrade-uploaded" \
+    "$project_root/tools/promote-download-channel.sh" \
+    Obiente/nc-native \
+    channel-nightly \
+    nightly-20260813-0800-run1-01234567 \
+    "$temporary/assets"
+test ! -s "$temporary/downgrade-uploaded"
+
+printf 'Nightly download promotion is monotonic and retains missing-platform aliases.\n'

--- a/tools/test-download-channel-promotion.sh
+++ b/tools/test-download-channel-promotion.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary="$(mktemp -d)"
+trap 'rm -r -- "$temporary"' EXIT
+mkdir -p "$temporary/bin" "$temporary/assets"
+
+cat >"$temporary/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "release view" ]]; then
+    tag="$3"
+    if [[ " $* " == *" --json isDraft,isPrerelease,tagName "* ]]; then
+        printf 'false\ttrue\t%s\n' "$tag"
+    elif [[ " $* " == *" --json assets "* ]]; then
+        printf '%s\n' 'nextcloud-native-macos-intel.dmg'
+    fi
+    exit 0
+fi
+if [[ "$1 $2" == "release delete-asset" ]]; then
+    printf '%s\n' "$4" >>"$FAKE_DELETED"
+    exit 0
+fi
+if [[ "$1 $2" == "release upload" ]]; then
+    shift 3
+    while [[ "$1" != "--repo" ]]; do
+        basename "$1" >>"$FAKE_UPLOADED"
+        shift
+    done
+    exit 0
+fi
+printf 'Unexpected fake gh invocation: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$temporary/bin/gh"
+printf android >"$temporary/assets/nextcloud-native-nightly-android.apk"
+printf deb >"$temporary/assets/nextcloudnative_1.2.3_amd64.deb"
+printf msi >"$temporary/assets/NextcloudNative-1.2.3.msi"
+
+PATH="$temporary/bin:$PATH" \
+    FAKE_DELETED="$temporary/deleted" \
+    FAKE_UPLOADED="$temporary/uploaded" \
+    "$project_root/tools/promote-download-channel.sh" \
+    Obiente/nc-native \
+    channel-nightly \
+    nightly-20260813-0800-run1-01234567 \
+    "$temporary/assets"
+
+grep -Fxq nextcloud-native-android.apk "$temporary/uploaded"
+grep -Fxq nextcloud-native-linux-amd64.deb "$temporary/uploaded"
+grep -Fxq nextcloud-native-windows-x86_64.msi "$temporary/uploaded"
+grep -Fxq nextcloud-native-macos-intel.dmg "$temporary/deleted"
+if grep -Fq nextcloud-native-macos-intel.dmg "$temporary/uploaded"; then
+    echo "A missing platform retained a stale channel alias." >&2
+    exit 1
+fi
+
+printf 'Nightly download promotion publishes stable aliases and removes stale platforms.\n'

--- a/tools/test-nightly-release-workflow.sh
+++ b/tools/test-nightly-release-workflow.sh
@@ -7,6 +7,7 @@ prerelease="$project_root/.github/workflows/prerelease.yml"
 ci="$project_root/.github/workflows/ci.yml"
 nightly_notes="$project_root/tools/nightly-release-notes.mjs"
 promotion="$project_root/tools/promote-app-update-channel.sh"
+download_promotion="$project_root/tools/promote-download-channel.sh"
 msi_repackager="$project_root/tools/repackage-msi-with-uninstall-cleanup.ps1"
 msi_verifier="$project_root/tools/verify-windows-package.ps1"
 ui_build="$project_root/ui/build.gradle.kts"
@@ -109,6 +110,8 @@ require_text "$nightly" 'canonical-release-assets'
 require_text "$nightly" 'if [[ "${canonical_successful}" -ge 3 ]]; then'
 require_text "$nightly" 'if: needs.stage-assets.outputs.already-published != '\''true'\'''
 require_text "$nightly" 'tools/promote-app-update-channel.sh'
+require_text "$nightly" 'tools/promote-download-channel.sh'
+require_text "$nightly" 'channel-nightly'
 require_text "$nightly" 'tools/verify-android-update-manifest-assets.sh'
 require_text "$nightly" 'tools/verify-desktop-update-manifest-assets.sh'
 require_text "$nightly_notes" 'The Windows MSI is currently unsigned.'
@@ -194,6 +197,7 @@ if grep -Fq 'Join-Path $AppImage "lib/app/.jpackage.xml"' "$msi_repackager"; the
     exit 1
 fi
 bash -n "$promotion"
+bash -n "$download_promotion"
 
 if [[ -e "$project_root/tools/sign-windows-package.ps1" ]]; then
     echo "The unsigned Windows release path must not retain a PFX signing helper." >&2

--- a/website/data/github-repository.json
+++ b/website/data/github-repository.json
@@ -1,0 +1,4 @@
+{
+  "stargazersCount": 88,
+  "updatedAt": "2026-08-13T08:06:57Z"
+}

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -19,6 +19,19 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 
+    # Stable public download URLs. "latest" intentionally follows Nightly while
+    # Nightly is the only selectable release channel.
+    location = /d/android-latest { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-android.apk; }
+    location = /d/android-nightly { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-android.apk; }
+    location = /d/linux-deb-latest { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-linux-amd64.deb; }
+    location = /d/linux-deb-nightly { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-linux-amd64.deb; }
+    location = /d/linux-rpm-latest { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-linux-x86_64.rpm; }
+    location = /d/linux-rpm-nightly { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-linux-x86_64.rpm; }
+    location = /d/windows-latest { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-windows-x86_64.msi; }
+    location = /d/windows-nightly { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-windows-x86_64.msi; }
+    location = /d/macos-latest { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-macos-intel.dmg; }
+    location = /d/macos-nightly { return 302 https://github.com/Obiente/nc-native/releases/download/channel-nightly/nextcloud-native-macos-intel.dmg; }
+
     # Preserve the original mixed-platform guide URLs after the platform split.
     location = /guides/getting-started/ { return 301 /guides/; }
     location = /guides/folder-sync/ { return 301 /guides/; }

--- a/website/scripts/public-claims.test.mjs
+++ b/website/scripts/public-claims.test.mjs
@@ -26,9 +26,9 @@ test("machine-readable product claims match current supported platforms and alph
   assert.doesNotMatch(app, /releases\/latest/);
   assert.match(app, /Your Nextcloud deserves/);
   assert.match(app, /Platform status/);
-  assert.match(app, /<span>macOS<span class="sr-only"> preview<\/span><\/span>/);
-  assert.match(app, /<span>iOS<span class="sr-only"> unavailable<\/span><\/span>/);
-  assert.doesNotMatch(app, /short links|moves to a curated Stable release/i);
+  assert.match(app, /aria-label="macOS preview"[^>]*>.*<span aria-hidden="true">macOS<\/span>/);
+  assert.match(app, /aria-label="iOS unavailable"[^>]*>.*<span aria-hidden="true">iOS<\/span>/);
+  assert.doesNotMatch(app, /Nightly is the (?:default|current) release path|short links|curated Stable release/i);
   assert.match(app, /AGPL-3\.0-or-later/);
   assert.doesNotMatch(app, /No Obiente account|No hosted intermediary|Obiente never carries your data/);
   assert.match(app, /Built by <strong>Obiente<\/strong>\. Independent and/);

--- a/website/scripts/public-claims.test.mjs
+++ b/website/scripts/public-claims.test.mjs
@@ -26,8 +26,8 @@ test("machine-readable product claims match current supported platforms and alph
   assert.doesNotMatch(app, /releases\/latest/);
   assert.match(app, /Your Nextcloud deserves/);
   assert.match(app, /Platform status/);
-  assert.match(app, /class="platform-pending"[^>]*>.*<span>macOS<\/span>/);
-  assert.match(app, /class="platform-pending"[^>]*>.*<span>iOS<\/span>/);
+  assert.match(app, /<span>macOS<span class="sr-only"> preview<\/span><\/span>/);
+  assert.match(app, /<span>iOS<span class="sr-only"> unavailable<\/span><\/span>/);
   assert.doesNotMatch(app, /short links|moves to a curated Stable release/i);
   assert.match(app, /AGPL-3\.0-or-later/);
   assert.doesNotMatch(app, /No Obiente account|No hosted intermediary|Obiente never carries your data/);

--- a/website/scripts/public-claims.test.mjs
+++ b/website/scripts/public-claims.test.mjs
@@ -28,6 +28,7 @@ test("machine-readable product claims match current supported platforms and alph
   assert.match(app, /Platform status/);
   assert.match(app, /class="platform-pending"[^>]*>.*<span>macOS<\/span>/);
   assert.match(app, /class="platform-pending"[^>]*>.*<span>iOS<\/span>/);
+  assert.doesNotMatch(app, /short links|moves to a curated Stable release/i);
   assert.match(app, /AGPL-3\.0-or-later/);
   assert.doesNotMatch(app, /No Obiente account|No hosted intermediary|Obiente never carries your data/);
   assert.match(app, /Built by <strong>Obiente<\/strong>\. Independent and/);

--- a/website/scripts/public-claims.test.mjs
+++ b/website/scripts/public-claims.test.mjs
@@ -26,8 +26,8 @@ test("machine-readable product claims match current supported platforms and alph
   assert.doesNotMatch(app, /releases\/latest/);
   assert.match(app, /Your Nextcloud deserves/);
   assert.match(app, /Platform status/);
-  assert.match(app, /class="platform-pending"[^>]*>.*<span>macOS preview<\/span>/);
-  assert.match(app, /class="platform-pending"[^>]*>.*<span>iOS planned<\/span>/);
+  assert.match(app, /class="platform-pending"[^>]*>.*<span>macOS<\/span>/);
+  assert.match(app, /class="platform-pending"[^>]*>.*<span>iOS<\/span>/);
   assert.match(app, /AGPL-3\.0-or-later/);
   assert.doesNotMatch(app, /No Obiente account|No hosted intermediary|Obiente never carries your data/);
   assert.match(app, /Built by <strong>Obiente<\/strong>\. Independent and/);

--- a/website/scripts/public-claims.test.mjs
+++ b/website/scripts/public-claims.test.mjs
@@ -28,6 +28,8 @@ test("machine-readable product claims match current supported platforms and alph
   assert.match(app, /Platform status/);
   assert.match(app, /aria-label="macOS preview"[^>]*>.*<span aria-hidden="true">macOS<\/span>/);
   assert.match(app, /aria-label="iOS unavailable"[^>]*>.*<span aria-hidden="true">iOS<\/span>/);
+  assert.match(app, /name: "macOS",/);
+  assert.doesNotMatch(app, /name: "macOS preview",/);
   assert.doesNotMatch(app, /Nightly is the (?:default|current) release path|short links|curated Stable release/i);
   assert.match(app, /AGPL-3\.0-or-later/);
   assert.doesNotMatch(app, /No Obiente account|No hosted intermediary|Obiente never carries your data/);

--- a/website/scripts/website-accessibility.test.mjs
+++ b/website/scripts/website-accessibility.test.mjs
@@ -73,3 +73,27 @@ test("roadmap links and indexed details remain available with truthful fallback 
   assert.match(app, /class="roadmap-source-document"/);
   assert.match(app, /v-html="currentDoc\.html"/);
 });
+
+test("downloads use stable channel URLs and GitHub stars retain a useful fallback", async () => {
+  const [app, nginx] = await Promise.all([
+    readFile(path.join(websiteRoot, "src", "App.vue"), "utf8"),
+    readFile(path.join(websiteRoot, "nginx.conf"), "utf8"),
+  ]);
+
+  for (const route of [
+    "android-latest",
+    "android-nightly",
+    "linux-deb-latest",
+    "linux-rpm-latest",
+    "windows-latest",
+    "macos-latest",
+  ]) {
+    assert.match(nginx, new RegExp(`location = /d/${route}`));
+  }
+  assert.match(nginx, /releases\/download\/channel-nightly\/nextcloud-native-android\.apk/);
+  assert.match(app, /const githubStars = ref\(null\)/);
+  assert.match(app, /"Star on GitHub"/);
+  assert.match(app, /repository\.stargazers_count/);
+  assert.match(app, /href: "\/d\/android-latest"/);
+  assert.match(app, /id="downloads"/);
+});

--- a/website/scripts/website-accessibility.test.mjs
+++ b/website/scripts/website-accessibility.test.mjs
@@ -74,7 +74,7 @@ test("roadmap links and indexed details remain available with truthful fallback 
   assert.match(app, /v-html="currentDoc\.html"/);
 });
 
-test("downloads use stable channel URLs and GitHub stars retain a useful fallback", async () => {
+test("downloads use stable channel URLs and a privacy-safe GitHub star snapshot", async () => {
   const [app, nginx] = await Promise.all([
     readFile(path.join(websiteRoot, "src", "App.vue"), "utf8"),
     readFile(path.join(websiteRoot, "nginx.conf"), "utf8"),
@@ -91,9 +91,8 @@ test("downloads use stable channel URLs and GitHub stars retain a useful fallbac
     assert.match(nginx, new RegExp(`location = /d/${route}`));
   }
   assert.match(nginx, /releases\/download\/channel-nightly\/nextcloud-native-android\.apk/);
-  assert.match(app, /const githubStars = ref\(null\)/);
-  assert.match(app, /"Star on GitHub"/);
-  assert.match(app, /repository\.stargazers_count/);
+  assert.match(app, /githubRepository\.stargazersCount/);
+  assert.doesNotMatch(app, /api\.github\.com/);
   assert.match(app, /href: "\/d\/android-latest"/);
   assert.match(app, /id="downloads"/);
 });

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -692,10 +692,10 @@ const frequentlyAsked = [
                   <p>Platform status</p>
                   <ul>
                     <li><WindowsLogo :size="21" weight="fill" aria-hidden="true" /><span>Windows</span></li>
-                    <li class="platform-pending"><AppleLogo :size="21" weight="fill" aria-hidden="true" /><span>macOS</span></li>
+                    <li class="platform-pending"><AppleLogo :size="21" weight="fill" aria-hidden="true" /><span>macOS<span class="sr-only"> preview</span></span></li>
                     <li><LinuxLogo :size="21" weight="fill" aria-hidden="true" /><span>Linux</span></li>
                     <li><AndroidLogo :size="21" weight="fill" aria-hidden="true" /><span>Android</span></li>
-                    <li class="platform-pending"><DeviceMobile :size="21" weight="fill" aria-hidden="true" /><span>iOS</span></li>
+                    <li class="platform-pending"><DeviceMobile :size="21" weight="fill" aria-hidden="true" /><span>iOS<span class="sr-only"> unavailable</span></span></li>
                   </ul>
                 </div>
               </div>

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -100,7 +100,7 @@ const downloadPlatforms = [
   },
   {
     id: "macos",
-    name: "macOS preview",
+    name: "macOS",
     detail: "Intel - sign-in unavailable",
     format: "DMG",
     href: "/d/macos-latest",

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -32,6 +32,7 @@ import { guides } from "./generated/guides.js";
 import { news } from "./generated/news.js";
 import { changelog } from "./generated/changelog.js";
 import { marketingCaptures } from "./generated/captures.js";
+import githubRepository from "../data/github-repository.json";
 import {
   guidePlatformHubForPath,
   guidePlatformHubs,
@@ -60,12 +61,10 @@ const props = defineProps({
 });
 
 const githubUrl = "https://github.com/Obiente/nc-native";
-const githubStars = ref(null);
-const githubStarLabel = computed(() =>
-  githubStars.value === null
-    ? "Star on GitHub"
-    : `${new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(githubStars.value)} stars`,
-);
+const githubStarLabel = `${new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+}).format(githubRepository.stargazersCount)} stars`;
 const downloadPlatforms = [
   {
     id: "android",
@@ -78,7 +77,7 @@ const downloadPlatforms = [
   {
     id: "windows",
     name: "Windows",
-    detail: "x86-64 · unsigned MSI",
+    detail: "x86-64 - unsigned MSI",
     format: "MSI",
     href: "/d/windows-latest",
     icon: WindowsLogo,
@@ -86,7 +85,7 @@ const downloadPlatforms = [
   {
     id: "linux-deb",
     name: "Linux",
-    detail: "Debian and Ubuntu · x86-64",
+    detail: "Debian and Ubuntu - x86-64",
     format: "DEB",
     href: "/d/linux-deb-latest",
     icon: LinuxLogo,
@@ -94,7 +93,7 @@ const downloadPlatforms = [
   {
     id: "linux-rpm",
     name: "Linux",
-    detail: "Fedora and RHEL · x86-64",
+    detail: "Fedora and RHEL - x86-64",
     format: "RPM",
     href: "/d/linux-rpm-latest",
     icon: LinuxLogo,
@@ -102,7 +101,7 @@ const downloadPlatforms = [
   {
     id: "macos",
     name: "macOS preview",
-    detail: "Intel · sign-in unavailable",
+    detail: "Intel - sign-in unavailable",
     format: "DMG",
     href: "/d/macos-latest",
     icon: AppleLogo,
@@ -156,17 +155,6 @@ onMounted(() => {
   systemTheme.value = themeMediaQuery.matches ? "light" : "dark";
   themeMediaQuery.addEventListener("change", themeMediaListener);
   applyDocumentTheme();
-
-  fetch("https://api.github.com/repos/Obiente/nc-native", {
-    headers: { Accept: "application/vnd.github+json" },
-  })
-    .then((response) => (response.ok ? response.json() : Promise.reject(new Error("GitHub unavailable"))))
-    .then((repository) => {
-      if (Number.isInteger(repository.stargazers_count)) {
-        githubStars.value = repository.stargazers_count;
-      }
-    })
-    .catch(() => {});
 
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
   if (!reducedMotion.matches && "IntersectionObserver" in window) {

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -692,10 +692,10 @@ const frequentlyAsked = [
                   <p>Platform status</p>
                   <ul>
                     <li><WindowsLogo :size="21" weight="fill" aria-hidden="true" /><span>Windows</span></li>
-                    <li class="platform-pending"><AppleLogo :size="21" weight="fill" aria-hidden="true" /><span>macOS preview</span></li>
+                    <li class="platform-pending"><AppleLogo :size="21" weight="fill" aria-hidden="true" /><span>macOS</span></li>
                     <li><LinuxLogo :size="21" weight="fill" aria-hidden="true" /><span>Linux</span></li>
                     <li><AndroidLogo :size="21" weight="fill" aria-hidden="true" /><span>Android</span></li>
-                    <li class="platform-pending"><DeviceMobile :size="21" weight="fill" aria-hidden="true" /><span>iOS planned</span></li>
+                    <li class="platform-pending"><DeviceMobile :size="21" weight="fill" aria-hidden="true" /><span>iOS</span></li>
                   </ul>
                 </div>
               </div>

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -730,9 +730,8 @@ const frequentlyAsked = [
               <p class="eyebrow">Get the current build</p>
               <h2>Download for your platform.</h2>
               <p>
-                Nightly is the default release path for now. The short links below
-                always resolve to the current verified package and will remain stable
-                when Latest moves to a curated Stable release later.
+                Nightly is the default release path for now. Choose the package
+                that matches your operating system and distribution.
               </p>
             </div>
             <div class="download-grid">

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -730,7 +730,7 @@ const frequentlyAsked = [
               <p class="eyebrow">Get the current build</p>
               <h2>Download for your platform.</h2>
               <p>
-                Nightly is the default release path for now. Choose the package
+                Nightly is the current release path. Choose the package
                 that matches your operating system and distribution.
               </p>
             </div>

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -692,10 +692,10 @@ const frequentlyAsked = [
                   <p>Platform status</p>
                   <ul>
                     <li><WindowsLogo :size="21" weight="fill" aria-hidden="true" /><span>Windows</span></li>
-                    <li class="platform-pending"><AppleLogo :size="21" weight="fill" aria-hidden="true" /><span>macOS<span class="sr-only"> preview</span></span></li>
+                    <li class="platform-pending" aria-label="macOS preview"><AppleLogo :size="21" weight="fill" aria-hidden="true" /><span aria-hidden="true">macOS</span></li>
                     <li><LinuxLogo :size="21" weight="fill" aria-hidden="true" /><span>Linux</span></li>
                     <li><AndroidLogo :size="21" weight="fill" aria-hidden="true" /><span>Android</span></li>
-                    <li class="platform-pending"><DeviceMobile :size="21" weight="fill" aria-hidden="true" /><span>iOS<span class="sr-only"> unavailable</span></span></li>
+                    <li class="platform-pending" aria-label="iOS unavailable"><DeviceMobile :size="21" weight="fill" aria-hidden="true" /><span aria-hidden="true">iOS</span></li>
                   </ul>
                 </div>
               </div>
@@ -729,10 +729,6 @@ const frequentlyAsked = [
             <div class="section-heading compact">
               <p class="eyebrow">Get the current build</p>
               <h2>Download for your platform.</h2>
-              <p>
-                Nightly is the current release path. Choose the package
-                that matches your operating system and distribution.
-              </p>
             </div>
             <div class="download-grid">
               <a

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -21,6 +21,7 @@ import {
   PhMagnifyingGlass as MagnifyingGlass,
   PhMoon as Moon,
   PhShieldCheck as ShieldCheck,
+  PhStar as Star,
   PhSquaresFour as SquaresFour,
   PhSun as Sun,
   PhWindowsLogo as WindowsLogo,
@@ -59,6 +60,54 @@ const props = defineProps({
 });
 
 const githubUrl = "https://github.com/Obiente/nc-native";
+const githubStars = ref(null);
+const githubStarLabel = computed(() =>
+  githubStars.value === null
+    ? "Star on GitHub"
+    : `${new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(githubStars.value)} stars`,
+);
+const downloadPlatforms = [
+  {
+    id: "android",
+    name: "Android",
+    detail: "Android 8.0 or newer",
+    format: "APK",
+    href: "/d/android-latest",
+    icon: AndroidLogo,
+  },
+  {
+    id: "windows",
+    name: "Windows",
+    detail: "x86-64 · unsigned MSI",
+    format: "MSI",
+    href: "/d/windows-latest",
+    icon: WindowsLogo,
+  },
+  {
+    id: "linux-deb",
+    name: "Linux",
+    detail: "Debian and Ubuntu · x86-64",
+    format: "DEB",
+    href: "/d/linux-deb-latest",
+    icon: LinuxLogo,
+  },
+  {
+    id: "linux-rpm",
+    name: "Linux",
+    detail: "Fedora and RHEL · x86-64",
+    format: "RPM",
+    href: "/d/linux-rpm-latest",
+    icon: LinuxLogo,
+  },
+  {
+    id: "macos",
+    name: "macOS preview",
+    detail: "Intel · sign-in unavailable",
+    format: "DMG",
+    href: "/d/macos-latest",
+    icon: AppleLogo,
+  },
+];
 const captureByScenario = new Map(
   marketingCaptures.map((capture) => [capture.scenario, capture]),
 );
@@ -107,6 +156,17 @@ onMounted(() => {
   systemTheme.value = themeMediaQuery.matches ? "light" : "dark";
   themeMediaQuery.addEventListener("change", themeMediaListener);
   applyDocumentTheme();
+
+  fetch("https://api.github.com/repos/Obiente/nc-native", {
+    headers: { Accept: "application/vnd.github+json" },
+  })
+    .then((response) => (response.ok ? response.json() : Promise.reject(new Error("GitHub unavailable"))))
+    .then((repository) => {
+      if (Number.isInteger(repository.stargazers_count)) {
+        githubStars.value = repository.stargazers_count;
+      }
+    })
+    .catch(() => {});
 
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
   if (!reducedMotion.matches && "IntersectionObserver" in window) {
@@ -654,12 +714,12 @@ const frequentlyAsked = [
 
               <ul class="hero-trust">
                 <li>
-                  <GithubLogo :size="21" weight="fill" aria-hidden="true" />
+                  <Star :size="21" weight="fill" aria-hidden="true" />
                   <span>
-                    <strong>Open source</strong>
+                    <strong>{{ githubStarLabel }}</strong>
                     <small>
-                      AGPL-3.0-or-later
-                      <a :href="githubUrl" target="_blank" rel="noreferrer">View source</a>
+                      Support the project
+                      <a :href="githubUrl" target="_blank" rel="noreferrer">Star repository</a>
                     </small>
                   </span>
                 </li>
@@ -675,6 +735,40 @@ const frequentlyAsked = [
                 </nav>
               </div>
             </div>
+          </section>
+
+          <section id="downloads" class="download-section section-width" data-reveal>
+            <div class="section-heading compact">
+              <p class="eyebrow">Get the current build</p>
+              <h2>Download for your platform.</h2>
+              <p>
+                Nightly is the default release path for now. The short links below
+                always resolve to the current verified package and will remain stable
+                when Latest moves to a curated Stable release later.
+              </p>
+            </div>
+            <div class="download-grid">
+              <a
+                v-for="platform in downloadPlatforms"
+                :id="`download-${platform.id}`"
+                :key="platform.id"
+                class="download-card"
+                :href="platform.href"
+              >
+                <component :is="platform.icon" :size="28" weight="fill" aria-hidden="true" />
+                <span>
+                  <strong>{{ platform.name }}</strong>
+                  <small>{{ platform.detail }}</small>
+                </span>
+                <b>{{ platform.format }}</b>
+                <ArrowRight :size="18" weight="bold" aria-hidden="true" />
+              </a>
+            </div>
+            <p class="download-caveat">
+              Alpha software: keep another copy of important data. Check the
+              <a href="https://github.com/Obiente/nc-native/releases" target="_blank" rel="noreferrer">release notes and checksums</a>
+              before installing.
+            </p>
           </section>
 
           <section id="experience" class="native-promise section-width" data-reveal>

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -2912,6 +2912,85 @@ h1 span {
   border-block: 1px solid var(--outline);
 }
 
+.download-section {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.62fr) minmax(560px, 1.38fr);
+  gap: clamp(36px, 5vw, 76px);
+  padding-top: 88px;
+  padding-bottom: 88px;
+}
+
+.download-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.download-card {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 13px;
+  padding: 18px;
+  border: 1px solid var(--outline);
+  border-radius: 16px;
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 10px 28px rgb(0 0 0 / 12%);
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.download-card:hover,
+.download-card:focus-visible {
+  border-color: color-mix(in srgb, var(--primary) 55%, var(--outline));
+  color: var(--text);
+  box-shadow: 0 16px 38px rgb(0 0 0 / 20%);
+  transform: translateY(-2px);
+}
+
+.download-card > svg:first-child {
+  color: var(--primary);
+}
+
+.download-card span {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.download-card strong,
+.download-card small {
+  overflow-wrap: anywhere;
+}
+
+.download-card small {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.download-card b {
+  padding: 5px 7px;
+  border-radius: 7px;
+  background: var(--surface-high);
+  color: var(--text-soft);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+}
+
+.download-caveat {
+  grid-column: 2;
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.download-caveat a {
+  color: var(--primary);
+  font-weight: 700;
+}
+
 .hero-foundation-platforms {
   min-width: 0;
   padding: 20px 28px 20px 0;
@@ -4494,6 +4573,15 @@ h1 span {
 }
 
 @media (max-width: 1120px) {
+  .download-section {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+
+  .download-caveat {
+    grid-column: 1;
+  }
+
   .product-hero {
     min-height: auto;
     grid-template-columns: 1fr;
@@ -4783,6 +4871,14 @@ h1 span {
 }
 
 @media (max-width: 760px) {
+  .download-section {
+    padding-block: 62px;
+  }
+
+  .download-grid {
+    grid-template-columns: 1fr;
+  }
+
   .guide-platform-nav {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Summary

- add version-independent Latest and Nightly download URLs for every packaged platform
- promote each successful nightly package to stable channel asset aliases and remove stale unavailable aliases
- add quick direct-download tables to generated releases and the README
- add a responsive website download section plus a resilient GitHub star count and repository link

For now, every Latest URL deliberately follows Nightly. The public routes can later be repointed to Stable without changing shared links.

## Validation

- `bash tools/check-repository.sh`
- `npm run build` in `website/`
- `bash tools/test-nightly-release-workflow.sh`
- `bash tools/test-prerelease-update-contract.sh`
- `node --test tools/release-download-table.test.mjs tools/nightly-release-notes.test.mjs`