### PR TITLE
fix(website): refresh repository stars at runtime

### DIFF
--- a/changes/unreleased/369-live-star-count.md
+++ b/changes/unreleased/369-live-star-count.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 369
+pull: none
+platforms: website
+user-facing: yes
+
+Keep the repository star count current without a rebuild through a cached same-origin refresh, while retaining a validated bundled count during GitHub outages.

--- a/changes/unreleased/369-live-star-count.md
+++ b/changes/unreleased/369-live-star-count.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 369
-pull: none
+pull: 371
 platforms: website
 user-facing: yes
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -14,7 +14,10 @@ FROM nginx:stable-alpine
 
 RUN apk add --no-cache curl
 
-COPY website/nginx.conf /etc/nginx/conf.d/default.conf
+ENV NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1 \
+    NGINX_ENVSUBST_FILTER=^NGINX_LOCAL_RESOLVERS$
+
+COPY website/nginx.conf /etc/nginx/templates/default.conf.template
 COPY --from=build /source/website/dist /usr/share/nginx/html
 COPY --from=build /source/website/dist-indexnow /opt/indexnow
 COPY --chmod=755 website/docker/indexnow-notify.sh /docker-entrypoint.d/40-indexnow-notify.sh

--- a/website/README.md
+++ b/website/README.md
@@ -137,6 +137,14 @@ For a local check, `docker compose -f website/compose.yml up --build` provides
 the same image. In production, place the container behind the Obiente reverse
 proxy and terminate TLS there.
 
+The container exposes `/api/github-repository` as a cached, same-origin proxy
+for the public `Obiente/nc-native` repository metadata. The website uses it to
+refresh the displayed star count without a deployment. Nginx refreshes the
+upstream response at most once every ten minutes and can serve its last cached
+response during temporary GitHub failures. The prerendered count remains the
+fallback before the first successful request. Production must therefore allow
+outbound HTTPS from the website container to `api.github.com`.
+
 ### IndexNow
 
 Production images prepare an IndexNow payload from the canonical sitemap and

--- a/website/README.md
+++ b/website/README.md
@@ -143,7 +143,10 @@ refresh the displayed star count without a deployment. Nginx refreshes the
 upstream response at most once every ten minutes and can serve its last cached
 response during temporary GitHub failures. The prerendered count remains the
 fallback before the first successful request. Production must therefore allow
-outbound HTTPS from the website container to `api.github.com`.
+outbound HTTPS from the website container to `api.github.com`. The container
+derives its upstream resolvers from `/etc/resolv.conf` and resolves GitHub only
+when this optional endpoint is requested, so upstream DNS failures do not stop
+the static website from starting.
 
 ### IndexNow
 

--- a/website/data/github-repository.json
+++ b/website/data/github-repository.json
@@ -1,4 +1,4 @@
 {
-  "stargazersCount": 88,
-  "updatedAt": "2026-08-13T08:06:57Z"
+  "stargazersCount": 147,
+  "updatedAt": "2026-08-13T19:14:55Z"
 }

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -9,6 +9,8 @@ server {
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+    resolver ${NGINX_LOCAL_RESOLVERS} valid=300s;
+    resolver_timeout 5s;
 
     location /assets/ {
         try_files $uri =404;
@@ -28,7 +30,8 @@ server {
     location = /api/github-repository {
         limit_except GET { deny all; }
 
-        proxy_pass https://api.github.com/repos/Obiente/nc-native;
+        set $github_repository_upstream api.github.com;
+        proxy_pass https://$github_repository_upstream/repos/Obiente/nc-native;
         proxy_ssl_server_name on;
         proxy_ssl_name api.github.com;
         proxy_set_header Host api.github.com;
@@ -37,6 +40,7 @@ server {
         proxy_set_header Authorization "";
         proxy_set_header Cookie "";
         proxy_set_header User-Agent "nextcloud-native-website";
+        proxy_set_header X-GitHub-Api-Version "2022-11-28";
         proxy_connect_timeout 5s;
         proxy_read_timeout 10s;
 
@@ -47,7 +51,6 @@ server {
         proxy_cache_revalidate on;
         proxy_cache_use_stale error timeout invalid_header updating http_403 http_429 http_500 http_502 http_503 http_504;
         proxy_cache_valid 200 10m;
-        proxy_cache_valid any 1m;
         proxy_ignore_headers Cache-Control Expires Set-Cookie;
         proxy_hide_header Cache-Control;
         proxy_hide_header Expires;

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -35,6 +35,7 @@ server {
         proxy_set_header Accept "application/vnd.github+json";
         proxy_set_header Accept-Encoding "";
         proxy_set_header Authorization "";
+        proxy_set_header Cookie "";
         proxy_set_header User-Agent "nextcloud-native-website";
         proxy_connect_timeout 5s;
         proxy_read_timeout 10s;
@@ -44,8 +45,7 @@ server {
         proxy_cache_lock on;
         proxy_cache_lock_timeout 5s;
         proxy_cache_revalidate on;
-        proxy_cache_background_update on;
-        proxy_cache_use_stale error timeout invalid_header updating http_429 http_500 http_502 http_503 http_504;
+        proxy_cache_use_stale error timeout invalid_header updating http_403 http_429 http_500 http_502 http_503 http_504;
         proxy_cache_valid 200 10m;
         proxy_cache_valid any 1m;
         proxy_ignore_headers Cache-Control Expires Set-Cookie;

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -1,3 +1,9 @@
+proxy_cache_path /var/cache/nginx/github
+    keys_zone=github_repository:1m
+    max_size=1m
+    inactive=24h
+    use_temp_path=off;
+
 server {
     listen 80;
     server_name _;
@@ -17,6 +23,45 @@ server {
     location = /indexnow-deployment.txt {
         try_files $uri =404;
         add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
+    location = /api/github-repository {
+        limit_except GET { deny all; }
+
+        proxy_pass https://api.github.com/repos/Obiente/nc-native;
+        proxy_ssl_server_name on;
+        proxy_ssl_name api.github.com;
+        proxy_set_header Host api.github.com;
+        proxy_set_header Accept "application/vnd.github+json";
+        proxy_set_header Accept-Encoding "";
+        proxy_set_header Authorization "";
+        proxy_set_header User-Agent "nextcloud-native-website";
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 10s;
+
+        proxy_cache github_repository;
+        proxy_cache_key github_repository;
+        proxy_cache_lock on;
+        proxy_cache_lock_timeout 5s;
+        proxy_cache_revalidate on;
+        proxy_cache_background_update on;
+        proxy_cache_use_stale error timeout invalid_header updating http_429 http_500 http_502 http_503 http_504;
+        proxy_cache_valid 200 10m;
+        proxy_cache_valid any 1m;
+        proxy_ignore_headers Cache-Control Expires Set-Cookie;
+        proxy_hide_header Cache-Control;
+        proxy_hide_header Expires;
+        proxy_hide_header Set-Cookie;
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header X-Content-Type-Options;
+        proxy_hide_header X-RateLimit-Limit;
+        proxy_hide_header X-RateLimit-Remaining;
+        proxy_hide_header X-RateLimit-Reset;
+        proxy_hide_header X-RateLimit-Resource;
+        proxy_hide_header X-RateLimit-Used;
+
+        add_header Cache-Control "public, max-age=300, stale-while-revalidate=86400" always;
+        add_header X-Content-Type-Options "nosniff" always;
     }
 
     # Stable public download URLs. "latest" intentionally follows Nightly while

--- a/website/scripts/generate-content.mjs
+++ b/website/scripts/generate-content.mjs
@@ -32,6 +32,7 @@ import {
   validateCaptureManifest,
   websiteCapturePath,
 } from "./marketing-captures.mjs";
+import { resolveGithubRepositoryData } from "./github-repository-data.mjs";
 
 const websiteRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = path.resolve(websiteRoot, "..");
@@ -40,6 +41,7 @@ const publicDirectory = path.join(websiteRoot, "public");
 const newsDirectory = path.join(websiteRoot, "content", "news");
 const guideDirectory = path.join(websiteRoot, "content", "guides");
 const roadmapSnapshotFile = path.join(websiteRoot, "data", "roadmap-snapshot.json");
+const repositorySnapshotFile = path.join(websiteRoot, "data", "github-repository.json");
 const changelogFile = path.join(repositoryRoot, "CHANGELOG.md");
 const changelogRoute = "/changelog/";
 await mkdir(generatedDirectory, { recursive: true });
@@ -480,7 +482,7 @@ async function githubJson(url) {
     signal: AbortSignal.timeout(8_000),
   });
   if (!response.ok) {
-    throw new Error(`GitHub roadmap request failed with HTTP ${response.status}.`);
+    throw new Error(`GitHub API request failed with HTTP ${response.status}.`);
   }
   return response.json();
 }
@@ -526,6 +528,20 @@ async function allProjectItems() {
 }
 
 const fallbackRoadmap = repositoryRoadmapFallback(projectUrl);
+
+const githubRepositoryResult = await resolveGithubRepositoryData({
+  loadLive: () => githubJson("https://api.github.com/repos/Obiente/nc-native"),
+  loadSnapshot: async () => JSON.parse(await readFile(repositorySnapshotFile, "utf8")),
+});
+if (githubRepositoryResult.warning) {
+  console.warn(
+    `Using bundled GitHub repository snapshot: ${githubRepositoryResult.warning}`,
+  );
+}
+await writeFile(
+  path.join(generatedDirectory, "github-repository.js"),
+  `// Generated from public GitHub repository metadata with a bundled fallback. Do not edit.\nexport const githubRepository = Object.freeze(${JSON.stringify(githubRepositoryResult.repository, null, 2)});\n`,
+);
 
 let roadmap = fallbackRoadmap;
 try {

--- a/website/scripts/github-repository-data.mjs
+++ b/website/scripts/github-repository-data.mjs
@@ -1,0 +1,85 @@
+function validTimestamp(value) {
+  return (
+    typeof value === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/u.test(value) &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function normalizedRepository(stargazersCount, updatedAt, source) {
+  if (!Number.isInteger(stargazersCount) || stargazersCount < 0) {
+    throw new TypeError(`The ${source} repository star count is invalid.`);
+  }
+  if (!validTimestamp(updatedAt)) {
+    throw new TypeError(`The ${source} repository update timestamp is invalid.`);
+  }
+  return Object.freeze({ stargazersCount, updatedAt });
+}
+
+export function normalizeGithubRepositoryResponse(response) {
+  if (!response || typeof response !== "object" || Array.isArray(response)) {
+    throw new TypeError("The GitHub repository response is not an object.");
+  }
+  return normalizedRepository(
+    response.stargazers_count,
+    response.updated_at,
+    "GitHub",
+  );
+}
+
+export function normalizeGithubRepositorySnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+    throw new TypeError("The bundled repository snapshot is not an object.");
+  }
+  return normalizedRepository(
+    snapshot.stargazersCount,
+    snapshot.updatedAt,
+    "bundled",
+  );
+}
+
+export async function fetchGithubRepository({
+  fetchImpl = globalThis.fetch,
+  endpoint = "/api/github-repository",
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    throw new TypeError("A repository metadata fetch implementation is required.");
+  }
+  const response = await fetchImpl(endpoint, {
+    cache: "no-cache",
+    headers: {
+      Accept: "application/vnd.github+json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Repository metadata request failed with HTTP ${response.status}.`);
+  }
+  return normalizeGithubRepositoryResponse(await response.json());
+}
+
+export async function resolveGithubRepositoryData({ loadLive, loadSnapshot }) {
+  if (typeof loadLive !== "function" || typeof loadSnapshot !== "function") {
+    throw new TypeError("Repository metadata loaders are required.");
+  }
+  try {
+    return {
+      repository: normalizeGithubRepositoryResponse(await loadLive()),
+      source: "github",
+      warning: null,
+    };
+  } catch (liveError) {
+    try {
+      return {
+        repository: normalizeGithubRepositorySnapshot(await loadSnapshot()),
+        source: "snapshot",
+        warning: liveError instanceof Error ? liveError.message : String(liveError),
+      };
+    } catch (snapshotError) {
+      throw new Error(
+        `GitHub repository metadata and its bundled fallback are unavailable: ${
+          liveError instanceof Error ? liveError.message : String(liveError)
+        }; ${snapshotError instanceof Error ? snapshotError.message : String(snapshotError)}`,
+      );
+    }
+  }
+}

--- a/website/scripts/github-repository-data.test.mjs
+++ b/website/scripts/github-repository-data.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  fetchGithubRepository,
+  normalizeGithubRepositoryResponse,
+  normalizeGithubRepositorySnapshot,
+  resolveGithubRepositoryData,
+} from "./github-repository-data.mjs";
+
+const snapshot = Object.freeze({
+  stargazersCount: 88,
+  updatedAt: "2026-08-13T08:06:57Z",
+});
+
+test("GitHub repository metadata is normalized for the website", () => {
+  assert.deepEqual(
+    normalizeGithubRepositoryResponse({
+      stargazers_count: 147,
+      updated_at: "2026-08-13T19:14:55Z",
+    }),
+    {
+      stargazersCount: 147,
+      updatedAt: "2026-08-13T19:14:55Z",
+    },
+  );
+  assert.deepEqual(normalizeGithubRepositorySnapshot(snapshot), snapshot);
+});
+
+test("malformed GitHub repository metadata is rejected", () => {
+  for (const response of [
+    null,
+    [],
+    { stargazers_count: -1, updated_at: "2026-08-13T19:14:55Z" },
+    { stargazers_count: 1.5, updated_at: "2026-08-13T19:14:55Z" },
+    { stargazers_count: "147", updated_at: "2026-08-13T19:14:55Z" },
+    { stargazers_count: 147, updated_at: "not-a-date" },
+  ]) {
+    assert.throws(() => normalizeGithubRepositoryResponse(response), TypeError);
+  }
+});
+
+test("the runtime refresh uses the cached same-origin endpoint", async () => {
+  const requests = [];
+  const repository = await fetchGithubRepository({
+    fetchImpl: async (url, options) => {
+      requests.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          stargazers_count: 148,
+          updated_at: "2026-08-13T19:30:00Z",
+        }),
+      };
+    },
+  });
+
+  assert.deepEqual(repository, {
+    stargazersCount: 148,
+    updatedAt: "2026-08-13T19:30:00Z",
+  });
+  assert.deepEqual(requests, [
+    {
+      url: "/api/github-repository",
+      options: {
+        cache: "no-cache",
+        headers: { Accept: "application/vnd.github+json" },
+      },
+    },
+  ]);
+});
+
+test("the runtime refresh rejects upstream and response failures", async () => {
+  await assert.rejects(
+    fetchGithubRepository({
+      fetchImpl: async () => ({ ok: false, status: 503 }),
+    }),
+    /HTTP 503/,
+  );
+  await assert.rejects(
+    fetchGithubRepository({
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ stargazers_count: -1, updated_at: "invalid" }),
+      }),
+    }),
+    /star count/,
+  );
+});
+
+test("a successful live refresh wins over the bundled snapshot", async () => {
+  let snapshotRead = false;
+  const result = await resolveGithubRepositoryData({
+    loadLive: async () => ({
+      stargazers_count: 147,
+      updated_at: "2026-08-13T19:14:55Z",
+    }),
+    loadSnapshot: async () => {
+      snapshotRead = true;
+      return snapshot;
+    },
+  });
+
+  assert.equal(result.source, "github");
+  assert.equal(result.warning, null);
+  assert.equal(result.repository.stargazersCount, 147);
+  assert.equal(snapshotRead, false);
+});
+
+test("transport failures preserve the bundled snapshot", async () => {
+  const result = await resolveGithubRepositoryData({
+    loadLive: async () => {
+      throw new Error("GitHub API request failed with HTTP 403.");
+    },
+    loadSnapshot: async () => snapshot,
+  });
+
+  assert.equal(result.source, "snapshot");
+  assert.match(result.warning, /HTTP 403/);
+  assert.deepEqual(result.repository, snapshot);
+});
+
+test("malformed live responses preserve the bundled snapshot", async () => {
+  const result = await resolveGithubRepositoryData({
+    loadLive: async () => ({ stargazers_count: "many", updated_at: null }),
+    loadSnapshot: async () => snapshot,
+  });
+
+  assert.equal(result.source, "snapshot");
+  assert.match(result.warning, /star count/);
+  assert.deepEqual(result.repository, snapshot);
+});
+
+test("content generation fails when both live and bundled metadata are invalid", async () => {
+  await assert.rejects(
+    resolveGithubRepositoryData({
+      loadLive: async () => {
+        throw new Error("network unavailable");
+      },
+      loadSnapshot: async () => ({ stargazersCount: -1, updatedAt: "invalid" }),
+    }),
+    /metadata and its bundled fallback are unavailable/,
+  );
+});

--- a/website/scripts/website-accessibility.test.mjs
+++ b/website/scripts/website-accessibility.test.mjs
@@ -93,7 +93,9 @@ test("downloads use stable channel URLs and a privacy-safe live GitHub star coun
   assert.match(nginx, /releases\/download\/channel-nightly\/nextcloud-native-android\.apk/);
   assert.match(nginx, /location = \/api\/github-repository/);
   assert.match(nginx, /proxy_cache github_repository/);
-  assert.match(nginx, /proxy_cache_use_stale/);
+  assert.match(nginx, /proxy_set_header Cookie ""/);
+  assert.match(nginx, /proxy_cache_use_stale[^;]*http_403/);
+  assert.doesNotMatch(nginx, /proxy_cache_background_update on/);
   assert.match(app, /fetchGithubRepository/);
   assert.match(app, /setInterval\(refreshGithubRepository/);
   assert.match(app, /\.\/generated\/github-repository\.js/);

--- a/website/scripts/website-accessibility.test.mjs
+++ b/website/scripts/website-accessibility.test.mjs
@@ -75,8 +75,9 @@ test("roadmap links and indexed details remain available with truthful fallback 
 });
 
 test("downloads use stable channel URLs and a privacy-safe live GitHub star count", async () => {
-  const [app, nginx] = await Promise.all([
+  const [app, dockerfile, nginx] = await Promise.all([
     readFile(path.join(websiteRoot, "src", "App.vue"), "utf8"),
+    readFile(path.join(websiteRoot, "Dockerfile"), "utf8"),
     readFile(path.join(websiteRoot, "nginx.conf"), "utf8"),
   ]);
 
@@ -92,10 +93,17 @@ test("downloads use stable channel URLs and a privacy-safe live GitHub star coun
   }
   assert.match(nginx, /releases\/download\/channel-nightly\/nextcloud-native-android\.apk/);
   assert.match(nginx, /location = \/api\/github-repository/);
+  assert.match(nginx, /resolver \$\{NGINX_LOCAL_RESOLVERS\} valid=300s/);
+  assert.match(nginx, /resolver_timeout 5s/);
+  assert.match(nginx, /proxy_pass https:\/\/\$github_repository_upstream/);
   assert.match(nginx, /proxy_cache github_repository/);
   assert.match(nginx, /proxy_set_header Cookie ""/);
+  assert.match(nginx, /proxy_set_header X-GitHub-Api-Version "2022-11-28"/);
   assert.match(nginx, /proxy_cache_use_stale[^;]*http_403/);
+  assert.doesNotMatch(nginx, /proxy_cache_valid any/);
   assert.doesNotMatch(nginx, /proxy_cache_background_update on/);
+  assert.match(dockerfile, /NGINX_ENTRYPOINT_LOCAL_RESOLVERS=1/);
+  assert.match(dockerfile, /COPY website\/nginx\.conf \/etc\/nginx\/templates\/default\.conf\.template/);
   assert.match(app, /fetchGithubRepository/);
   assert.match(app, /setInterval\(refreshGithubRepository/);
   assert.match(app, /\.\/generated\/github-repository\.js/);

--- a/website/scripts/website-accessibility.test.mjs
+++ b/website/scripts/website-accessibility.test.mjs
@@ -74,7 +74,7 @@ test("roadmap links and indexed details remain available with truthful fallback 
   assert.match(app, /v-html="currentDoc\.html"/);
 });
 
-test("downloads use stable channel URLs and a privacy-safe GitHub star snapshot", async () => {
+test("downloads use stable channel URLs and a privacy-safe live GitHub star count", async () => {
   const [app, nginx] = await Promise.all([
     readFile(path.join(websiteRoot, "src", "App.vue"), "utf8"),
     readFile(path.join(websiteRoot, "nginx.conf"), "utf8"),
@@ -91,7 +91,13 @@ test("downloads use stable channel URLs and a privacy-safe GitHub star snapshot"
     assert.match(nginx, new RegExp(`location = /d/${route}`));
   }
   assert.match(nginx, /releases\/download\/channel-nightly\/nextcloud-native-android\.apk/);
-  assert.match(app, /githubRepository\.stargazersCount/);
+  assert.match(nginx, /location = \/api\/github-repository/);
+  assert.match(nginx, /proxy_cache github_repository/);
+  assert.match(nginx, /proxy_cache_use_stale/);
+  assert.match(app, /fetchGithubRepository/);
+  assert.match(app, /setInterval\(refreshGithubRepository/);
+  assert.match(app, /\.\/generated\/github-repository\.js/);
+  assert.match(app, /currentGithubRepository\.value\.stargazersCount/);
   assert.doesNotMatch(app, /api\.github\.com/);
   assert.match(app, /href: "\/d\/android-latest"/);
   assert.match(app, /id="downloads"/);

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -32,7 +32,8 @@ import { guides } from "./generated/guides.js";
 import { news } from "./generated/news.js";
 import { changelog } from "./generated/changelog.js";
 import { marketingCaptures } from "./generated/captures.js";
-import githubRepository from "../data/github-repository.json";
+import { githubRepository } from "./generated/github-repository.js";
+import { fetchGithubRepository } from "../scripts/github-repository-data.mjs";
 import {
   guidePlatformHubForPath,
   guidePlatformHubs,
@@ -61,10 +62,11 @@ const props = defineProps({
 });
 
 const githubUrl = "https://github.com/Obiente/nc-native";
-const githubStarLabel = `${new Intl.NumberFormat("en", {
+const currentGithubRepository = ref(githubRepository);
+const githubStarLabel = computed(() => `${new Intl.NumberFormat("en", {
   notation: "compact",
   maximumFractionDigits: 1,
-}).format(githubRepository.stargazersCount)} stars`;
+}).format(currentGithubRepository.value.stargazersCount)} stars`);
 const downloadPlatforms = [
   {
     id: "android",
@@ -132,7 +134,20 @@ const themeIcon = computed(() => {
 let themeMediaQuery;
 let themeMediaListener;
 let revealObserver;
+let repositoryRefreshTimer;
 const motionEnhanced = ref(false);
+
+async function refreshGithubRepository() {
+  try {
+    currentGithubRepository.value = await fetchGithubRepository();
+  } catch {
+    // Keep the validated build-time snapshot when the live endpoint is unavailable.
+  }
+}
+
+function refreshGithubRepositoryWhenVisible() {
+  if (document.visibilityState === "visible") void refreshGithubRepository();
+}
 
 function applyDocumentTheme() {
   if (typeof document === "undefined") return;
@@ -146,6 +161,10 @@ function cycleTheme() {
 }
 
 onMounted(() => {
+  void refreshGithubRepository();
+  repositoryRefreshTimer = window.setInterval(refreshGithubRepository, 5 * 60 * 1000);
+  document.addEventListener("visibilitychange", refreshGithubRepositoryWhenVisible);
+
   const savedTheme = window.localStorage.getItem("nextcloud-native-theme");
   if (themeOptions.includes(savedTheme)) themePreference.value = savedTheme;
   themeMediaQuery = window.matchMedia("(prefers-color-scheme: light)");
@@ -178,6 +197,8 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  window.clearInterval(repositoryRefreshTimer);
+  document.removeEventListener("visibilitychange", refreshGithubRepositoryWhenVisible);
   themeMediaQuery?.removeEventListener("change", themeMediaListener);
   revealObserver?.disconnect();
 });


### PR DESCRIPTION
## Summary

- refresh the repository star count at runtime through a same-origin endpoint
- cache GitHub responses for ten minutes and serve stale data during temporary upstream failures
- retain a validated pre-rendered fallback so the website remains usable before or without a successful refresh

## Validation

- `npm run --prefix website test` (49 tests)
- `npm run --prefix website build` (client, SSR, 31 prerendered routes, 222 capture assets)
- `bash tools/check-repository.sh`
- `docker build -f website/Dockerfile -t nc-native-website-star-count:final .`
- production image smoke test: homepage and repository endpoint returned HTTP 200; repeated requests used one Nginx cache entry

## Deployment note

The website container needs outbound HTTPS access to `api.github.com`. The displayed count can intentionally lag GitHub by up to ten minutes.

Closes #369