### PR TITLE
fix(linux): replace stale development service

### DIFF
--- a/changes/unreleased/388-nightly-instance-handoff.md
+++ b/changes/unreleased/388-nightly-instance-handoff.md
@@ -1,0 +1,7 @@
+category: fix
+issue: none
+pull: 388
+platforms: desktop
+user-facing: yes
+
+Let an explicitly launched Linux Nightly replace a stale background service from a development build so in-app updates use the installed release identity.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLogin.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLogin.kt
@@ -154,6 +154,19 @@ internal class DesktopStartOnLoginController(
         return true
     }
 
+    internal fun refreshLinuxUserServiceLauncher(): Boolean {
+        if (platform != DesktopStartOnLoginPlatform.Linux) return true
+        val launcher = launcherPath?.takeIf(String::isNotBlank) ?: return true
+        val service = File(linuxConfigHome, "systemd/user/$LINUX_USER_SERVICE_NAME")
+        if (!service.isFile || linuxUserServiceUsesLauncher(service, launcher)) return true
+        if (
+            !runCatching {
+                processRunner(listOf("systemctl", "--user", "stop", LINUX_USER_SERVICE_NAME)) == 0
+            }.getOrDefault(false)
+        ) return false
+        return runCatching { configureLinux(enabled = true, launcher = launcher).configured }.getOrDefault(false)
+    }
+
     private fun removeLinuxUserService() {
         val userDirectory = File(linuxConfigHome, "systemd/user")
         val service = File(userDirectory, LINUX_USER_SERVICE_NAME)
@@ -245,6 +258,13 @@ internal fun isCurrentProcessOwnedByLinuxUserService(
 
 private const val LINUX_USER_SERVICE_NAME = "nextcloud-native.service"
 
+private fun linuxUserServiceUsesLauncher(service: File, launcher: String): Boolean {
+    val expected = "ExecStart=${systemdExecArgument(launcher)} --background --service"
+    return runCatching {
+        service.useLines { lines -> lines.any { line -> line == expected } }
+    }.getOrDefault(false)
+}
+
 /** Lets the portable XDG launch request enter the supervised unit when one was configured. */
 internal fun handoffLinuxAutostartToUserService(
     osName: String = System.getProperty("os.name").orEmpty(),
@@ -271,6 +291,7 @@ internal fun handoffLinuxForegroundLaunchToUserService(
     osName: String = System.getProperty("os.name").orEmpty(),
     userHome: File = File(System.getProperty("user.home")),
     linuxConfigHome: File = linuxDesktopConfigHome(userHome),
+    launcherPath: String? = packagedDesktopLauncherPath(),
     processRunner: (List<String>) -> Int = { command ->
         ProcessBuilder(command).redirectErrorStream(true).start().also { process ->
             process.inputStream.bufferedReader().use { it.readText() }
@@ -280,6 +301,16 @@ internal fun handoffLinuxForegroundLaunchToUserService(
 ): Boolean {
     if (!osName.lowercase().contains("linux")) return false
     if (!File(linuxConfigHome, "systemd/user/$LINUX_USER_SERVICE_NAME").isFile) return false
+    val launcherReady = DesktopStartOnLoginController(
+        osName = osName,
+        userHome = userHome,
+        linuxConfigHome = linuxConfigHome,
+        launcherPath = launcherPath,
+        processRunner = processRunner,
+        linuxSystemdAvailable = { true },
+        linuxGraphicalSessionManaged = { true },
+    ).refreshLinuxUserServiceLauncher()
+    if (!launcherReady) return false
     val started = runCatching {
         processRunner(listOf("systemctl", "--user", "start", LINUX_USER_SERVICE_NAME)) == 0
     }.getOrDefault(false)

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLoginTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopStartOnLoginTest.kt
@@ -189,6 +189,68 @@ class DesktopStartOnLoginTest {
     }
 
     @Test
+    fun linuxForegroundLaunchReplacesAServiceFromAnotherBuild() {
+        val root = createTempDirectory("nextcloud-native-startup-foreground-refresh").toFile()
+        val configHome = File(root, ".config")
+        val service = File(configHome, "systemd/user/nextcloud-native.service").apply {
+            parentFile.mkdirs()
+        }
+        val staleLauncher = File(root, "development/NextcloudNative").apply {
+            parentFile.mkdirs()
+            writeText("development launcher")
+        }
+        val installedLauncher = File(root, "installed/NextcloudNative").apply {
+            parentFile.mkdirs()
+            writeText("installed launcher")
+        }
+        service.writeText(
+            """
+                [Service]
+                ExecStart=${systemdExecArgument(staleLauncher.absolutePath)} --background --service
+            """.trimIndent() + "\n",
+        )
+        val commands = mutableListOf<List<String>>()
+        var forwarded = false
+
+        assertTrue(
+            handoffLinuxForegroundLaunchToUserService(
+                osName = "Linux",
+                userHome = root,
+                linuxConfigHome = configHome,
+                launcherPath = installedLauncher.absolutePath,
+                processRunner = { command ->
+                    commands += command
+                    0
+                },
+                activationForwarder = {
+                    forwarded = true
+                    true
+                },
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                listOf("systemctl", "--user", "stop", "nextcloud-native.service"),
+                listOf("systemctl", "--user", "daemon-reload"),
+                listOf("systemctl", "--user", "start", "nextcloud-native.service"),
+            ),
+            commands,
+        )
+        assertTrue(
+            service.readText().contains(
+                "ExecStart=${systemdExecArgument(installedLauncher.absolutePath)} --background --service",
+            ),
+        )
+        assertTrue(
+            File(configHome, "autostart/nextcloud-native.desktop").readText().contains(
+                "Exec=${desktopEntryExecArgument(installedLauncher.absolutePath)} --autostart",
+            ),
+        )
+        assertTrue(forwarded)
+    }
+
+    @Test
     fun explicitQuitStopsTheConfiguredUserServiceWithoutWaitingForItself() {
         val root = createTempDirectory("nextcloud-native-startup-explicit-quit").toFile()
         File(root, ".config/systemd/user").mkdirs()


### PR DESCRIPTION
## Summary

- detect when the Linux user service points to a different Nextcloud Native launcher
- stop the stale service and atomically refresh its systemd and desktop autostart registrations
- restart and activate the explicitly launched installed build
- cover replacement of a development-build service with an installed release launcher

## Root cause

Installing a Nightly package did not replace an already running background service registered by a source-built distribution. Foreground launches handed off to that stale process, so the app continued to identify itself as a development build even though the installed package contained the correct release and direct-update metadata.

## User impact

Explicitly launching an installed Nightly now repairs a stale Start on login registration before handing off activation. The installed build can then use its intended direct update channel without requiring the user to manually remove the old service.

## Validation

- `ssh build`: `./gradlew --no-daemon --max-workers=1 -Pkotlin.incremental=false :ui:desktopTest --tests "dev.obiente.nextcloudnative.app.DesktopStartOnLoginTest"`
- `ssh build`: release-marked `:ui:createDistributable`
- verified the generated launcher config contains the requested Nightly version name and code, `releaseBuild=true`, and `directPackageUpdates=true`
- `node tools/changelog-fragments.mjs validate` (`Validated 103 changelog fragments.`)
- `git diff --check`

## Risk

The repair is limited to Linux foreground launches when an existing `nextcloud-native.service` names another launcher. If stopping or refreshing that service fails, the normal foreground startup path remains available and the existing registration is not partially replaced.
