### PR TITLE
fix(sync): replace conflicts with guarded uploads

### DIFF
--- a/changes/unreleased/378-conflict-replacement-put.md
+++ b/changes/unreleased/378-conflict-replacement-put.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 378
+pull: none
+platforms: desktop
+user-facing: yes
+
+Choosing the device copy for a file conflict now publishes it with a revision-guarded WebDAV upload instead of depending on a server-specific staged MOVE replacement.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTree.kt
@@ -447,31 +447,14 @@ internal class DesktopFileSyncRemoteTree(
         expectedEtag: String,
         vararg mutationRelativePaths: String,
     ) {
-        val parent = path.substringBeforeLast('/', "")
-        val stagingPath = listOf(parent, ".nextcloud-native-${UUID.randomUUID()}.upload")
-            .filter(String::isNotBlank).joinToString("/")
-        val stagingUrl = fileUrl(stagingPath)
-        val destinationUrl = fileUrl(path)
-        val stagedEtag = createFile(stagingPath, source)
-        try {
-            val builder = requestBuilder(stagingUrl)
-                .header("Destination", destinationUrl)
-                .header("Overwrite", "T")
-                .header("If", "<$destinationUrl> ([$expectedEtag])")
-            stagedEtag?.let { builder.header("If-Match", it) }
-            executeMutation(
-                builder.method("MOVE", EMPTY_BODY).build(),
-                "replace file",
-                *mutationRelativePaths,
-            )
-        } catch (failure: Throwable) {
-            runCatching {
-                val cleanup = requestBuilder(stagingUrl)
-                stagedEtag?.let { cleanup.header("If-Match", it) }
-                execute(cleanup.delete().build(), "remove staged upload")
-            }
-            throw failure
-        }
+        executeMutation(
+            requestBuilder(fileUrl(path))
+                .header("If-Match", safeEtag(expectedEtag))
+                .put(source.asRequestBody(OCTET_STREAM))
+                .build(),
+            "replace file",
+            *mutationRelativePaths,
+        )
     }
 
     private fun executeMutationForEtag(

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTreeTest.kt
@@ -3,6 +3,7 @@ package dev.obiente.nextcloudnative.app
 import java.io.IOException
 import java.net.InetAddress
 import java.net.ServerSocket
+import java.nio.file.Files
 import java.util.concurrent.Executors
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,6 +17,54 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 
 class DesktopFileSyncRemoteTreeTest {
+    @Test
+    fun `replacing an existing file uses a destination guarded put`() {
+        val methods = mutableListOf<String>()
+        val conditionalHeaders = mutableListOf<String?>()
+        var listingCount = 0
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            methods += chain.request().method
+            conditionalHeaders += chain.request().header("If-Match")
+            when (chain.request().method) {
+                "PROPFIND" -> {
+                    listingCount += 1
+                    response(
+                        chain.request(),
+                        207,
+                        """
+                        <d:multistatus xmlns:d="DAV:">
+                          <d:response><d:href>/remote.php/dav/files/alice/note.md</d:href>
+                            <d:propstat><d:prop><d:getetag>${if (listingCount == 1) "old-etag" else "new-etag"}</d:getetag>
+                              <d:getcontentlength>7</d:getcontentlength><d:resourcetype/></d:prop>
+                            </d:propstat></d:response>
+                        </d:multistatus>
+                        """.trimIndent(),
+                    )
+                }
+                "PUT" -> response(chain.request(), 204)
+                else -> error("Unexpected ${chain.request().method} request")
+            }
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            session = NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            userId = "alice",
+            remoteRootPath = "",
+            client = client,
+        )
+        val source = Files.createTempFile("nextcloud-sync-replacement", ".tmp").toFile()
+        try {
+            source.writeText("updated")
+
+            val result = tree.writeFile("note.md", source, expectedRemoteEtag = "old-etag")
+
+            assertEquals("new-etag", result.etag)
+            assertEquals(listOf("PROPFIND", "PUT", "PROPFIND"), methods)
+            assertEquals(listOf(null, "old-etag", null), conditionalHeaders)
+        } finally {
+            assertTrue(source.delete())
+        }
+    }
+
     @Test
     fun `definitive mutation rejection preserves cached metadata`() {
         val invalidated = mutableListOf<String>()


### PR DESCRIPTION
## Outcome

Choosing the device copy for a desktop sync conflict now replaces the remote file through a revision-guarded WebDAV upload, so compatible Nextcloud servers no longer reject the resolution because of the staged MOVE replacement strategy.

## Root cause

The desktop sync adapter staged replacement bytes under a temporary remote name and then attempted a conditional MOVE over the destination. Private support diagnostics captured repeated `UseLocal` resolutions reaching an upload and returning the same failure without completing. The staged MOVE path adds server-specific conditional-DAV behavior even though a normal file PUT supports the required destination precondition directly.

The replacement now sends the staged local bytes to the destination with `If-Match` bound to the exact ETag observed during conflict review. A changed destination still fails closed, and the existing mutation executor continues to distinguish definitive rejection from an ambiguous network result.

Addresses #378.

## Validation

Validated on the dedicated Debian 13 build host with Java 21:

- `:ui:desktopTest`
- `:ui:createDistributable`
- `bash tools/check-repository.sh`

The focused regression test verifies the `PROPFIND -> PUT If-Match -> PROPFIND` reconciliation sequence and the returned authoritative revision.

## Scope and risk

- Desktop file sync only; Android behavior is unchanged.
- Existing-file replacement changes from staged MOVE to destination PUT.
- Creation, delete, directory replacement, keep-both, stale-decision guards, and post-upload byte verification remain unchanged.
