### PR TITLE
fix(sync): bound Android background retries

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncEngine.kt
@@ -17,6 +17,7 @@ import dev.obiente.nextcloudnative.app.FileSyncExecutionState
 import dev.obiente.nextcloudnative.app.FileSyncLocalRoot
 import dev.obiente.nextcloudnative.app.FileSyncNetworkState
 import dev.obiente.nextcloudnative.app.FileSyncPairRunState
+import dev.obiente.nextcloudnative.app.FileSyncRejectionScope
 import dev.obiente.nextcloudnative.app.FileSyncDecisionChoice
 import dev.obiente.nextcloudnative.app.FileSyncDirection
 import dev.obiente.nextcloudnative.app.FileSyncOperation
@@ -354,13 +355,20 @@ internal class AndroidFileSyncEngine(context: Context) {
     ): FileSyncCenterActionResult {
         var persisted = store.load()
         val initialPair = persisted.coordinator.pairs.firstOrNull { it.id == pairId }
-            ?: return FileSyncCenterActionResult.Rejected("The folder sync pair no longer exists.")
+            ?: return FileSyncCenterActionResult.Rejected(
+                "The folder sync pair no longer exists.",
+                FileSyncRejectionScope.Preflight,
+            )
         if (initialPair.accountId != NextcloudDocumentIds.accountKey(session)) {
-            return FileSyncCenterActionResult.Rejected("This folder sync pair belongs to another account.")
+            return FileSyncCenterActionResult.Rejected(
+                "This folder sync pair belongs to another account.",
+                FileSyncRejectionScope.Preflight,
+            )
         }
         if (!supportsAndroidFileSyncDirection(initialPair.localRootId, initialPair.configuration.direction)) {
             return FileSyncCenterActionResult.Rejected(
                 "This detected media-folder pair is not upload-only. Remove it and add it again.",
+                FileSyncRejectionScope.Preflight,
             )
         }
         return withAndroidMediaBackupLedger(appContext, initialPair) { mediaLedger ->

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorker.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorker.kt
@@ -101,16 +101,11 @@ internal class NextcloudFileSyncWorker(
                     component = SupportDiagnosticComponent.Sync,
                     operation = "sync.background-run",
                     outcome = "needs-attention",
-                    fields = listOf(
-                        SupportDiagnosticFieldDraft("pair", pairId, SupportDiagnosticValuePrivacy.Identifier),
-                        SupportDiagnosticFieldDraft("failure_scope", "items"),
-                        SupportDiagnosticFieldDraft("failed_count", pair.failedCount.toString()),
-                        SupportDiagnosticFieldDraft("conflict_count", pair.conflicts.size.toString()),
-                        SupportDiagnosticFieldDraft(
-                            "result",
-                            if (result is FileSyncCenterActionResult.Rejected) "rejected" else "completed",
-                        ),
-                        SupportDiagnosticFieldDraft("retry_scheduled", "false"),
+                    fields = backgroundSyncCompletionDiagnosticFields(
+                        pairId = pairId,
+                        failedCount = pair.failedCount,
+                        conflictCount = pair.conflicts.size,
+                        result = result,
                     ),
                 ),
             )
@@ -196,6 +191,29 @@ internal fun backgroundSyncFailureDisposition(runAttemptCount: Int): BackgroundS
         BackgroundSyncWorkerDisposition.Retry
     } else {
         BackgroundSyncWorkerDisposition.WaitForNextPeriod
+    }
+}
+
+internal fun backgroundSyncCompletionDiagnosticFields(
+    pairId: String,
+    failedCount: Int,
+    conflictCount: Int,
+    result: FileSyncCenterActionResult,
+): List<SupportDiagnosticFieldDraft> {
+    require(failedCount >= 0)
+    require(conflictCount >= 0)
+    val rejection = result as? FileSyncCenterActionResult.Rejected
+    val preflightRejected = rejection != null && failedCount == 0
+    return buildList {
+        add(SupportDiagnosticFieldDraft("pair", pairId, SupportDiagnosticValuePrivacy.Identifier))
+        add(SupportDiagnosticFieldDraft("failure_scope", if (preflightRejected) "preflight" else "items"))
+        add(SupportDiagnosticFieldDraft("failed_count", failedCount.toString()))
+        add(SupportDiagnosticFieldDraft("conflict_count", conflictCount.toString()))
+        add(SupportDiagnosticFieldDraft("result", if (rejection != null) "rejected" else "completed"))
+        if (preflightRejected) {
+            add(SupportDiagnosticFieldDraft("rejection_reason", rejection.reason))
+        }
+        add(SupportDiagnosticFieldDraft("retry_scheduled", "false"))
     }
 }
 

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorker.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorker.kt
@@ -50,6 +50,7 @@ internal class NextcloudFileSyncWorker(
         val engine = AndroidFileSyncEngine(applicationContext)
         val result = runCatching { engine.runPair(session, userId, pairId) }
             .getOrElse { failure ->
+                val disposition = backgroundSyncFailureDisposition(runAttemptCount)
                 services.recordSupportDiagnosticForAccountIdentity(
                     accountId,
                     SupportDiagnosticEventDraft(
@@ -63,11 +64,17 @@ internal class NextcloudFileSyncWorker(
                                 pairId,
                                 SupportDiagnosticValuePrivacy.Identifier,
                             ),
+                            SupportDiagnosticFieldDraft("failure_scope", "run"),
+                            SupportDiagnosticFieldDraft("work_attempt", runAttemptCount.toString()),
+                            SupportDiagnosticFieldDraft(
+                                "retry_scheduled",
+                                (disposition == BackgroundSyncWorkerDisposition.Retry).toString(),
+                            ),
                         ),
                         exception = failure.toSupportDiagnosticExceptionDraft(),
                     ),
                 )
-                return@withContext Result.retry()
+                return@withContext disposition.toWorkerResult()
             }
         val pair = engine.loadCenter(session, userId).pairs.firstOrNull { it.id == pairId }
             ?: return@withContext Result.success()
@@ -82,7 +89,11 @@ internal class NextcloudFileSyncWorker(
                 ),
             )
         }
-        if (pair.failedCount > 0 || result is FileSyncCenterActionResult.Rejected) {
+        val completionDisposition = backgroundSyncCompletionDisposition(
+            failedCount = pair.failedCount,
+            resultRejected = result is FileSyncCenterActionResult.Rejected,
+        )
+        if (completionDisposition == BackgroundSyncWorkerDisposition.WaitForNextPeriod) {
             services.recordSupportDiagnosticForAccountIdentity(
                 accountId,
                 SupportDiagnosticEventDraft(
@@ -92,18 +103,22 @@ internal class NextcloudFileSyncWorker(
                     outcome = "needs-attention",
                     fields = listOf(
                         SupportDiagnosticFieldDraft("pair", pairId, SupportDiagnosticValuePrivacy.Identifier),
+                        SupportDiagnosticFieldDraft("failure_scope", "items"),
                         SupportDiagnosticFieldDraft("failed_count", pair.failedCount.toString()),
                         SupportDiagnosticFieldDraft("conflict_count", pair.conflicts.size.toString()),
                         SupportDiagnosticFieldDraft(
                             "result",
                             if (result is FileSyncCenterActionResult.Rejected) "rejected" else "completed",
                         ),
+                        SupportDiagnosticFieldDraft("retry_scheduled", "false"),
                     ),
                 ),
             )
-            Result.retry()
+            // Per-item failures and attempt counts are durable coordinator state. An immediate
+            // WorkManager retry bypasses the periodic cadence and re-executes known failed work.
+            completionDisposition.toWorkerResult()
         } else {
-            Result.success()
+            completionDisposition.toWorkerResult()
         }
     }
 
@@ -156,3 +171,39 @@ internal class NextcloudFileSyncWorker(
         const val KEY_USER_ID = "user_id"
     }
 }
+
+internal enum class BackgroundSyncWorkerDisposition {
+    Retry,
+    WaitForNextPeriod,
+    Complete,
+}
+
+internal fun backgroundSyncCompletionDisposition(
+    failedCount: Int,
+    resultRejected: Boolean,
+): BackgroundSyncWorkerDisposition {
+    require(failedCount >= 0)
+    return if (failedCount > 0 || resultRejected) {
+        BackgroundSyncWorkerDisposition.WaitForNextPeriod
+    } else {
+        BackgroundSyncWorkerDisposition.Complete
+    }
+}
+
+internal fun backgroundSyncFailureDisposition(runAttemptCount: Int): BackgroundSyncWorkerDisposition {
+    require(runAttemptCount >= 0)
+    return if (runAttemptCount < MAX_BACKGROUND_SYNC_IMMEDIATE_RETRIES) {
+        BackgroundSyncWorkerDisposition.Retry
+    } else {
+        BackgroundSyncWorkerDisposition.WaitForNextPeriod
+    }
+}
+
+private fun BackgroundSyncWorkerDisposition.toWorkerResult(): androidx.work.ListenableWorker.Result = when (this) {
+    BackgroundSyncWorkerDisposition.Retry -> androidx.work.ListenableWorker.Result.retry()
+    BackgroundSyncWorkerDisposition.WaitForNextPeriod,
+    BackgroundSyncWorkerDisposition.Complete,
+    -> androidx.work.ListenableWorker.Result.success()
+}
+
+private const val MAX_BACKGROUND_SYNC_IMMEDIATE_RETRIES = 2

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorker.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorker.kt
@@ -11,6 +11,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import dev.obiente.nextcloudnative.app.FileSyncCenterActionResult
+import dev.obiente.nextcloudnative.app.FileSyncRejectionScope
 import dev.obiente.nextcloudnative.app.SupportDiagnosticComponent
 import dev.obiente.nextcloudnative.app.SupportDiagnosticEventDraft
 import dev.obiente.nextcloudnative.app.SupportDiagnosticFieldDraft
@@ -203,7 +204,7 @@ internal fun backgroundSyncCompletionDiagnosticFields(
     require(failedCount >= 0)
     require(conflictCount >= 0)
     val rejection = result as? FileSyncCenterActionResult.Rejected
-    val preflightRejected = rejection != null && failedCount == 0
+    val preflightRejected = rejection?.scope == FileSyncRejectionScope.Preflight
     return buildList {
         add(SupportDiagnosticFieldDraft("pair", pairId, SupportDiagnosticValuePrivacy.Identifier))
         add(SupportDiagnosticFieldDraft("failure_scope", if (preflightRejected) "preflight" else "items"))

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorkerTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorkerTest.kt
@@ -1,0 +1,39 @@
+package dev.obiente.nextcloudnative
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class NextcloudFileSyncWorkerTest {
+    @Test
+    fun `run failures receive only bounded immediate retries`() {
+        assertEquals(BackgroundSyncWorkerDisposition.Retry, backgroundSyncFailureDisposition(0))
+        assertEquals(BackgroundSyncWorkerDisposition.Retry, backgroundSyncFailureDisposition(1))
+        assertEquals(BackgroundSyncWorkerDisposition.WaitForNextPeriod, backgroundSyncFailureDisposition(2))
+        assertEquals(BackgroundSyncWorkerDisposition.WaitForNextPeriod, backgroundSyncFailureDisposition(20))
+    }
+
+    @Test
+    fun `negative WorkManager attempt counts fail closed`() {
+        assertFailsWith<IllegalArgumentException> { backgroundSyncFailureDisposition(-1) }
+    }
+
+    @Test
+    fun `persisted item failures wait for the next periodic run`() {
+        assertEquals(
+            BackgroundSyncWorkerDisposition.WaitForNextPeriod,
+            backgroundSyncCompletionDisposition(failedCount = 1, resultRejected = false),
+        )
+        assertEquals(
+            BackgroundSyncWorkerDisposition.WaitForNextPeriod,
+            backgroundSyncCompletionDisposition(failedCount = 0, resultRejected = true),
+        )
+        assertEquals(
+            BackgroundSyncWorkerDisposition.Complete,
+            backgroundSyncCompletionDisposition(failedCount = 0, resultRejected = false),
+        )
+        assertFailsWith<IllegalArgumentException> {
+            backgroundSyncCompletionDisposition(failedCount = -1, resultRejected = false)
+        }
+    }
+}

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorkerTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorkerTest.kt
@@ -1,5 +1,7 @@
 package dev.obiente.nextcloudnative
 
+import dev.obiente.nextcloudnative.app.FileSyncCenterActionResult
+import dev.obiente.nextcloudnative.app.SupportDiagnosticValuePrivacy
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -35,5 +37,36 @@ class NextcloudFileSyncWorkerTest {
         assertFailsWith<IllegalArgumentException> {
             backgroundSyncCompletionDisposition(failedCount = -1, resultRejected = false)
         }
+    }
+
+    @Test
+    fun `preflight rejections retain their safe reason and distinct scope`() {
+        val reason = "This detected media-folder pair is not upload-only. Remove it and add it again."
+        val fields = backgroundSyncCompletionDiagnosticFields(
+            pairId = "pair-1",
+            failedCount = 0,
+            conflictCount = 0,
+            result = FileSyncCenterActionResult.Rejected(reason),
+        )
+
+        assertEquals("preflight", fields.single { it.name == "failure_scope" }.value)
+        assertEquals(reason, fields.single { it.name == "rejection_reason" }.value)
+        assertEquals(
+            SupportDiagnosticValuePrivacy.Identifier,
+            fields.single { it.name == "pair" }.privacy,
+        )
+    }
+
+    @Test
+    fun `item failures are not mislabeled with a preflight reason`() {
+        val fields = backgroundSyncCompletionDiagnosticFields(
+            pairId = "pair-1",
+            failedCount = 2,
+            conflictCount = 1,
+            result = FileSyncCenterActionResult.Rejected("2 operations failed."),
+        )
+
+        assertEquals("items", fields.single { it.name == "failure_scope" }.value)
+        assertEquals(null, fields.singleOrNull { it.name == "rejection_reason" })
     }
 }

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorkerTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudFileSyncWorkerTest.kt
@@ -1,6 +1,7 @@
 package dev.obiente.nextcloudnative
 
 import dev.obiente.nextcloudnative.app.FileSyncCenterActionResult
+import dev.obiente.nextcloudnative.app.FileSyncRejectionScope
 import dev.obiente.nextcloudnative.app.SupportDiagnosticValuePrivacy
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -44,13 +45,14 @@ class NextcloudFileSyncWorkerTest {
         val reason = "This detected media-folder pair is not upload-only. Remove it and add it again."
         val fields = backgroundSyncCompletionDiagnosticFields(
             pairId = "pair-1",
-            failedCount = 0,
+            failedCount = 3,
             conflictCount = 0,
-            result = FileSyncCenterActionResult.Rejected(reason),
+            result = FileSyncCenterActionResult.Rejected(reason, FileSyncRejectionScope.Preflight),
         )
 
         assertEquals("preflight", fields.single { it.name == "failure_scope" }.value)
         assertEquals(reason, fields.single { it.name == "rejection_reason" }.value)
+        assertEquals("3", fields.single { it.name == "failed_count" }.value)
         assertEquals(
             SupportDiagnosticValuePrivacy.Identifier,
             fields.single { it.name == "pair" }.privacy,

--- a/changes/unreleased/126-android-sync-failure-backoff.md
+++ b/changes/unreleased/126-android-sync-failure-backoff.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 126
+pull: none
+platforms: android
+user-facing: yes
+
+Android folder sync now waits for its normal periodic schedule after persisted item failures and bounds immediate retries when an entire background run fails.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt
@@ -244,7 +244,10 @@ sealed interface FileSyncCenterActionResult {
         }
     }
 
-    data class Rejected(val reason: String) : FileSyncCenterActionResult {
+    data class Rejected(
+        val reason: String,
+        val scope: FileSyncRejectionScope = FileSyncRejectionScope.Items,
+    ) : FileSyncCenterActionResult {
         init {
             require(reason.isSafeFileSyncCenterText(1_024))
         }
@@ -255,6 +258,11 @@ sealed interface FileSyncCenterActionResult {
             require(reason.isSafeFileSyncCenterText(1_024))
         }
     }
+}
+
+enum class FileSyncRejectionScope {
+    Preflight,
+    Items,
 }
 
 fun FileSyncPair.toCenterSummary(

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -315,7 +315,7 @@
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileShareDialog.kt": "0a0d071a79c18f12bb0bac2b026aed3901a3a68a13b8ee0d01b3dcd442cb2007",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileShareRecipientPicker.kt": "49e2af9e3c5d69629b167d2ed588103debbada7aba0e4bf4237d88afb5db7585",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSharing.kt": "b1aa1b070e011f1c935db2666682171a3d1fd51e324b192feb64d2edee1910d9",
-        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt": "6580c3ae3f32102337dc9279b212417acb9d79495ac05d80460bbc11b0af08bf",
+        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCenter.kt": "1f90accf796e854771f6d965259a58575c5dd67c37f25fe634f1861b17455d2a",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCoordinator.kt": "89bbebe6c310a61865a590340532417f7b454a940eae92ee72552ecfc2a0d486",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncCoordinatorSnapshot.kt": "5feb33ae361d2d20af8badf58a2e7d54bee42de8b52e61590883f76a986dd14e",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/FileSyncExperience.kt": "a08560f00781ed4118f48ea224b0965bae0b9a88bc281f1ec7a89f68cbffe94e",


### PR DESCRIPTION
## Outcome

Android folder sync no longer re-executes persisted item failures through WorkManager's short retry cadence. Known item failures wait for the normal periodic run, while an exception that aborts the complete scan/run receives at most two immediate retries before also returning to the periodic schedule.

The background-run diagnostic now distinguishes whole-run failures from persisted item failures and records the WorkManager attempt plus whether an immediate retry was scheduled.

Advances #126.

## Root cause

`NextcloudFileSyncWorker` returned `Result.retry()` both when the complete engine invocation threw and when the coordinator had already persisted failed work. The latter bypassed the intended 15-minute periodic cadence and asked WorkManager to repeat known failed operations using its 30-second exponential backoff. Whole-run failures had no bound on immediate retries and the diagnostic exposed neither the attempt nor the retry decision.

## Validation

Validated from the current merged `origin/main` on the dedicated Debian 13 build host with Java 21 and the Android SDK:

- `:androidApp:testDebugUnitTest`
- `:androidApp:assembleDebug`
- `bash tools/check-repository.sh`

New unit coverage verifies the two-retry bound, periodic deferral for persisted item failures and rejected results, successful completion, and invalid-count guards.

## Scope and risk

- Android periodic folder sync only.
- Sync coordinator retry counts and visible failed/conflict state remain durable and unchanged.
- Network and power constraints remain unchanged.
- A successful worker result for persisted failures acknowledges only that scheduled execution completed; it does not mark the failed sync items successful. The next periodic run continues recovery.
