### PR TITLE
fix(home): keep desktop overview scrollable

### DIFF
--- a/changes/unreleased/desktop-home-scroll.md
+++ b/changes/unreleased/desktop-home-scroll.md
@@ -1,0 +1,7 @@
+category: fix
+issue: none
+pull: 392
+platforms: linux, windows
+user-facing: yes
+
+Keep the complete Home overview scrollable within the desktop window.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt
@@ -260,6 +260,7 @@ internal fun NativeDashboardPresentation(
                     editing = customizeWorkspace,
                     sectionLabels = sectionLabels,
                     onLayoutChanged = updateWorkspaceLayout,
+                    modifier = Modifier.weight(1f),
                 ) { section ->
                     when (section.id) {
                         HomeSectionIds.QuickActions -> DashboardQuickActionsCard(
@@ -707,6 +708,7 @@ private fun HomeWorkspaceSurface(
     editing: Boolean,
     sectionLabels: Map<HomeSectionId, String>,
     onLayoutChanged: (HomeWorkspaceLayout, Boolean) -> Unit,
+    modifier: Modifier = Modifier,
     sectionContent: @Composable (HomeWorkspaceSection) -> Unit,
 ) {
     val sectionBounds = remember(layout.scope) { mutableStateMapOf<HomeSectionId, Rect>() }
@@ -820,6 +822,7 @@ private fun HomeWorkspaceSurface(
                 sections = layout.visibleSections,
                 state = state,
                 onViewportChanged = { workspaceViewport = it },
+                modifier = modifier,
                 sectionContent = content,
             )
         }
@@ -836,6 +839,7 @@ private fun HomeWorkspaceSurface(
                 sections = layout.visibleSections,
                 state = state,
                 onViewportChanged = { workspaceViewport = it },
+                modifier = modifier,
                 sectionContent = content,
             )
         }
@@ -852,6 +856,7 @@ private fun HomeWorkspaceSurface(
                 sections = layout.visibleSections,
                 state = state,
                 onViewportChanged = { workspaceViewport = it },
+                modifier = modifier,
                 sectionContent = content,
             )
         }
@@ -877,11 +882,12 @@ private fun MobileHomeWorkspace(
     sections: List<HomeWorkspaceSection>,
     state: LazyListState,
     onViewportChanged: (Rect) -> Unit,
+    modifier: Modifier,
     sectionContent: @Composable (HomeWorkspaceSection) -> Unit,
 ) {
     LazyColumn(
         state = state,
-        modifier = Modifier.fillMaxSize().onGloballyPositioned { coordinates ->
+        modifier = modifier.fillMaxSize().onGloballyPositioned { coordinates ->
             onViewportChanged(coordinates.boundsInWindow())
         },
         contentPadding = PaddingValues(
@@ -903,12 +909,13 @@ private fun TabletHomeWorkspace(
     sections: List<HomeWorkspaceSection>,
     state: LazyStaggeredGridState,
     onViewportChanged: (Rect) -> Unit,
+    modifier: Modifier,
     sectionContent: @Composable (HomeWorkspaceSection) -> Unit,
 ) {
     LazyVerticalStaggeredGrid(
         state = state,
         columns = StaggeredGridCells.Adaptive(300.dp),
-        modifier = Modifier.fillMaxSize().onGloballyPositioned { coordinates ->
+        modifier = modifier.fillMaxSize().onGloballyPositioned { coordinates ->
             onViewportChanged(coordinates.boundsInWindow())
         },
         contentPadding = PaddingValues(NextcloudSpacing.Large),
@@ -926,12 +933,13 @@ private fun DesktopHomeWorkspace(
     sections: List<HomeWorkspaceSection>,
     state: LazyStaggeredGridState,
     onViewportChanged: (Rect) -> Unit,
+    modifier: Modifier,
     sectionContent: @Composable (HomeWorkspaceSection) -> Unit,
 ) {
     LazyVerticalStaggeredGrid(
         state = state,
         columns = StaggeredGridCells.Adaptive(340.dp),
-        modifier = Modifier.fillMaxSize().onGloballyPositioned { coordinates ->
+        modifier = modifier.fillMaxSize().onGloballyPositioned { coordinates ->
             onViewportChanged(coordinates.boundsInWindow())
         },
         contentPadding = PaddingValues(

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -273,7 +273,7 @@
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/CalendarWorkspacePresentation.kt": "35660659bd1f6e6b47879f651cae91ad8b1c9a8a13749c361d8e7f8a2cd269f5",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatus.kt": "8e56d2a1815182b6c2f30c3640a5b92dc6bc06f8bf797b0484430dce495dd85f",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusPresentation.kt": "96eb3aa478be8932e695e2dfe2067cc7b8dccf5ffa6cc1370f2db27b8119e0ff",
-        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt": "6dfe5db2d8f00b98fa2de982d7370387771c6a91f2c36a6ef3c08c47f79a63f8",
+        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DashboardStatusScreens.kt": "717d97fc18e68c04d2aac4d10fe0aeda76693fe8ef7d24dd6442d43483493f68",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DeckAsyncSafety.kt": "f6d939c1d1cf41b2421aad6906e9de7fb64800b146906312210472eebd22a93e",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DeckCardDraftPersistence.kt": "127ff173d1bd2e0ab3983e3ec8284e8cd6976b58476b4d9537794923517511ae",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/DeckCardOrdering.kt": "05c093d91943d6434df1f7ba4d55f1284f88fb637feaec22bf671e0e207b1a5d",


### PR DESCRIPTION
## Summary

- constrain the Home workspace to the space remaining below its header and status controls
- preserve lazy scrolling and drag auto-scroll across phone, tablet, and desktop layouts
- prevent lower overview rows from being clipped outside Linux and Windows desktop windows

## Validation

Run on the dedicated `ssh build` host from a clean `origin/main` worktree:

- `:ui:desktopTest` (2,468 tests; 1 pre-existing skip)
- `:ui:createDistributable`
- `bash tools/check-repository.sh`
- `bash tools/test-prerelease-update-contract.sh`