### PR TITLE
fix(diagnostics): classify pending login polls

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
@@ -98,6 +98,8 @@ import dev.obiente.nextcloudnative.app.NextcloudNotePresence
 import dev.obiente.nextcloudnative.app.createNoteRequest
 import dev.obiente.nextcloudnative.app.deleteNoteRequest
 import dev.obiente.nextcloudnative.app.NextcloudPlatformServices
+import dev.obiente.nextcloudnative.app.loginPollPendingDiagnostic
+import dev.obiente.nextcloudnative.app.shouldRecordHttpStatusDiagnostic
 import dev.obiente.nextcloudnative.app.NextcloudPerson
 import dev.obiente.nextcloudnative.app.syntheticMemoriesPersonFile
 import dev.obiente.nextcloudnative.app.NextcloudServerInfo
@@ -447,6 +449,7 @@ internal class AndroidNextcloudServices(
     private val httpClient = OkHttpClient.Builder().trackJvmNetworkFailures().build()
     private val loginPollHttpClient = httpClient.newBuilder().retryOnConnectionFailure(false).build()
     private val loginPollFallbackTokens = ConcurrentHashMap.newKeySet<String>()
+    private val loginPollPendingTokens = ConcurrentHashMap.newKeySet<String>()
     private val noRedirectHttpClient = httpClient.newBuilder()
         .followRedirects(false)
         .followSslRedirects(false)
@@ -1328,6 +1331,7 @@ internal class AndroidNextcloudServices(
                 body = formBody,
                 contentType = "application/x-www-form-urlencoded",
                 client = loginPollHttpClient,
+                diagnosticIgnoredHttpStatuses = setOf(404),
                 onNetworkFailure = { networkFailure = it },
             )
         }
@@ -1378,7 +1382,12 @@ internal class AndroidNextcloudServices(
                 return@withContext initialResult
             }
         }
-        if (response.status == 404) return@withContext LoginPollResult.Pending
+        if (response.status == 404) {
+            if (loginPollPendingTokens.add(challenge.token)) {
+                recordSupportDiagnostic(loginPollPendingDiagnostic(usedFallback))
+            }
+            return@withContext LoginPollResult.Pending
+        }
         if (response.status !in 200..299) {
             val result = LoginPollResult.FatalFailure(
                 "Login approval failed (HTTP ${response.status}). Please try again.",
@@ -1423,6 +1432,7 @@ internal class AndroidNextcloudServices(
 
     override fun finishLoginPolling(challenge: LoginChallenge) {
         loginPollFallbackTokens -= challenge.token
+        loginPollPendingTokens -= challenge.token
     }
 
     override suspend fun awaitLoginNetworkAvailability() {
@@ -3448,6 +3458,7 @@ internal class AndroidNextcloudServices(
         streamingBody: RequestBody? = null,
         onNetworkFailure: (JvmNetworkFailureDiagnostic) -> Unit = {},
         onFailurePhase: (JvmNetworkFailurePhase) -> Unit = {},
+        diagnosticIgnoredHttpStatuses: Set<Int> = emptySet(),
     ): HttpResponse {
         val started = System.nanoTime()
         require((expectedSuccessResponseBytes == null) == (expectedSuccessResponseStatus == null))
@@ -3505,7 +3516,7 @@ internal class AndroidNextcloudServices(
                     contentRange = response.header("Content-Range"),
                 )
             }
-            if (result.status !in 200..399) {
+            if (shouldRecordHttpStatusDiagnostic(result.status, diagnosticIgnoredHttpStatuses)) {
                 recordRequestDiagnostic(
                     session,
                     SupportDiagnosticEventDraft(

--- a/changes/unreleased/login-poll-diagnostics.md
+++ b/changes/unreleased/login-poll-diagnostics.md
@@ -1,0 +1,7 @@
+category: internal
+issue: none
+pull: 394
+platforms: android, linux, windows
+user-facing: no
+
+Classify Login Flow 404 polling responses as a bounded pending state instead of repeated network warnings.

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LoginPolling.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LoginPolling.kt
@@ -41,3 +41,28 @@ internal fun loginPollRetryDelayMillis(consecutiveFailures: Int): Long {
     }
     return delayMillis
 }
+
+fun loginPollPendingDiagnostic(usedFallback: Boolean): SupportDiagnosticEventDraft =
+    SupportDiagnosticEventDraft(
+        severity = SupportDiagnosticSeverity.Info,
+        component = SupportDiagnosticComponent.Authentication,
+        operation = "login.poll",
+        outcome = "pending",
+        code = "HTTP:404",
+        fields = listOf(
+            SupportDiagnosticFieldDraft(
+                "endpoint_role",
+                if (usedFallback) "fallback" else "primary",
+            ),
+            SupportDiagnosticFieldDraft("protocol_state", "awaiting-browser-approval"),
+        ),
+    )
+
+fun shouldRecordHttpStatusDiagnostic(
+    status: Int,
+    ignoredStatuses: Set<Int> = emptySet(),
+): Boolean {
+    require(status in 100..599)
+    require(ignoredStatuses.all { it in 100..599 })
+    return status !in 200..399 && status !in ignoredStatuses
+}

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LoginPollingTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/LoginPollingTest.kt
@@ -4,10 +4,28 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class LoginPollingTest {
+    @Test
+    fun `pending diagnostic identifies protocol state without endpoint data`() {
+        val primary = loginPollPendingDiagnostic(usedFallback = false)
+        val fallback = loginPollPendingDiagnostic(usedFallback = true)
+
+        assertEquals("pending", primary.outcome)
+        assertEquals("HTTP:404", primary.code)
+        assertEquals("primary", primary.fields.single { it.name == "endpoint_role" }.value)
+        assertEquals("fallback", fallback.fields.single { it.name == "endpoint_role" }.value)
+        assertEquals("awaiting-browser-approval", primary.fields.single { it.name == "protocol_state" }.value)
+        assertNull(primary.message)
+        assertNull(primary.exception)
+        assertTrue(!shouldRecordHttpStatusDiagnostic(404, setOf(404)))
+        assertTrue(shouldRecordHttpStatusDiagnostic(401, setOf(404)))
+        assertTrue(shouldRecordHttpStatusDiagnostic(500))
+    }
+
     @Test
     fun transientDnsFailuresRetryWithoutLosingTheApprovalWindow() = runBlocking {
         val session = NextcloudSession("https://cloud.example.com", "person", "secret")

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -1070,6 +1070,7 @@ class DesktopNextcloudServices(
     )
     private val loginPollHttpClient = httpClient.newBuilder().retryOnConnectionFailure(false).build()
     private val loginPollFallbackTokens = ConcurrentHashMap.newKeySet<String>()
+    private val loginPollPendingTokens = ConcurrentHashMap.newKeySet<String>()
     private val fileMutationHttpExecutor = DesktopHttpMutationExecutor(httpClient)
     private val noRedirectHttpClient = httpClient.newBuilder()
         .followRedirects(false)
@@ -4068,6 +4069,7 @@ class DesktopNextcloudServices(
                 body = "token=" + encodeForm(challenge.token),
                 contentType = "application/x-www-form-urlencoded",
                 client = loginPollHttpClient,
+                diagnosticIgnoredHttpStatuses = setOf(404),
                 onNetworkFailure = { networkFailure = it },
             )
         }
@@ -4118,7 +4120,12 @@ class DesktopNextcloudServices(
                 return@withContext initialResult
             }
         }
-        if (response.status == 404) return@withContext LoginPollResult.Pending
+        if (response.status == 404) {
+            if (loginPollPendingTokens.add(challenge.token)) {
+                recordSupportDiagnostic(loginPollPendingDiagnostic(usedFallback))
+            }
+            return@withContext LoginPollResult.Pending
+        }
         if (response.status !in 200..299) {
             val result = LoginPollResult.FatalFailure(
                 "Login approval failed (HTTP ${response.status}). Please try again.",
@@ -4163,6 +4170,7 @@ class DesktopNextcloudServices(
 
     override fun finishLoginPolling(challenge: LoginChallenge) {
         loginPollFallbackTokens -= challenge.token
+        loginPollPendingTokens -= challenge.token
     }
 
     override suspend fun loadServerInfo(session: NextcloudSession): NextcloudServerInfo =
@@ -5669,6 +5677,7 @@ class DesktopNextcloudServices(
         onAmbiguousMutationResult: () -> Unit = {},
         onNetworkFailure: (JvmNetworkFailureDiagnostic) -> Unit = {},
         onFailurePhase: (JvmNetworkFailurePhase) -> Unit = {},
+        diagnosticIgnoredHttpStatuses: Set<Int> = emptySet(),
     ): HttpResponse {
         val started = System.nanoTime()
         require((expectedSuccessResponseBytes == null) == (expectedSuccessResponseStatus == null))
@@ -5734,7 +5743,7 @@ class DesktopNextcloudServices(
                     consume = ::consumeResponse,
                 )
             }
-            if (result.status !in 200..399) {
+            if (shouldRecordHttpStatusDiagnostic(result.status, diagnosticIgnoredHttpStatuses)) {
                 recordDesktopRequestDiagnostic(
                     session,
                     SupportDiagnosticEventDraft(

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -334,7 +334,7 @@
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LivePhotos.kt": "380a1f135dd50b1746967a6805b69dd4e48ab77dc864aeef394440c021c223d7",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LocalFileUpload.kt": "985c5403fe0c149d81eead75b1504a8c8e9fc1981e8f54d56a9407f00ed81ee7",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LoginDiagnostics.kt": "4eac0172e469d673d594c9fd83a85bf275e7c945ec1bd85cf8ea18679f9444bc",
-        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LoginPolling.kt": "7b8813b078d362f90b92fa6a374018d70b75e5ad650b80aba7b610fc138b9ba6",
+        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/LoginPolling.kt": "fa07ee68e4111f0222ae5e0c4d1be453d1ae5d92dd2cd20ec92dccc4e4173962",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MarkdownEditing.kt": "74ed912eef556a53b7eb0008946aa5b4425cb69456bea75368d309a39052a331",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MarketingBudgetCaptureScenario.kt": "e28c89ee88d466abab6a8412d87d0ae2c0c5812a2b7b4104851f8d0ae0f640fc",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/MarketingCalendarWorkspaceScenario.kt": "1c903f197dabca8b18f35366543e67e4cc0989c5b2c5aed41f67bebb9fc7d482",


### PR DESCRIPTION
## Summary

- stop recording Login Flow v2 HTTP 404 pending responses as repeated network warnings
- emit one bounded authentication event per login attempt with the primary or fallback endpoint role
- identify the protocol state as awaiting browser approval without storing a URL, endpoint, token, or response body
- clear the diagnostic deduplication state when polling finishes

## Support evidence

The supplied Windows report contained 183 identical `HTTP:404` network warnings for one opaque URL. In Login Flow v2 that status means approval is still pending, so the report looked like a broken endpoint while omitting the useful protocol phase.

## Validation

Run on the dedicated `ssh build` host from a clean `origin/main` worktree:

- `:ui:desktopTest` (2,469 tests; 1 pre-existing skip)
- `:ui:createDistributable`
- `:androidApp:testDebugUnitTest`
- `:androidApp:assembleDebug`
- `bash tools/check-repository.sh`
- `bash tools/test-prerelease-update-contract.sh`