### PR TITLE
fix(android): honor device certificate authorities

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/Theme.NextcloudNative">

--- a/androidApp/src/main/res/xml/network_security_config.xml
+++ b/androidApp/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidNetworkSecurityConfigTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidNetworkSecurityConfigTest.kt
@@ -1,0 +1,58 @@
+package dev.obiente.nextcloudnative
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AndroidNetworkSecurityConfigTest {
+    @Test
+    fun manifestUsesAnAppWideSystemAndUserCertificatePolicy() {
+        val sourceDirectory = androidMainSourceDirectory()
+        val manifest = parseXml(sourceDirectory.resolve("AndroidManifest.xml"))
+        val application = manifest.getElementsByTagName("application").item(0)
+        assertEquals(
+            "@xml/network_security_config",
+            application.attributes.getNamedItemNS(ANDROID_XML_NAMESPACE, "networkSecurityConfig").nodeValue,
+        )
+
+        val configuration = parseXml(sourceDirectory.resolve("res/xml/network_security_config.xml"))
+        val baseConfig = configuration.getElementsByTagName("base-config")
+        assertEquals(1, baseConfig.length)
+        assertEquals(
+            "false",
+            baseConfig.item(0).attributes.getNamedItem("cleartextTrafficPermitted").nodeValue,
+        )
+        assertEquals(0, configuration.getElementsByTagName("domain-config").length)
+        assertEquals(0, configuration.getElementsByTagName("debug-overrides").length)
+        val certificateSources = configuration.getElementsByTagName("certificates")
+            .let { nodes ->
+                (0 until nodes.length).map { index ->
+                    nodes.item(index).attributes.getNamedItem("src").nodeValue
+                }
+            }
+        assertEquals(listOf("system", "user"), certificateSources)
+    }
+
+    private fun androidMainSourceDirectory(): File {
+        val workingDirectory = File(requireNotNull(System.getProperty("user.dir")))
+        val candidates = listOf(
+            workingDirectory.resolve("src/main"),
+            workingDirectory.resolve("androidApp/src/main"),
+        )
+        return candidates.firstOrNull { it.resolve("AndroidManifest.xml").isFile }
+            ?: error("Could not locate the Android main source directory.")
+    }
+
+    private fun parseXml(file: File) = DocumentBuilderFactory.newInstance().apply {
+        isNamespaceAware = true
+        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+    }.newDocumentBuilder().parse(file).also { document ->
+        assertTrue(document.documentElement != null, "${file.name} must contain a root element.")
+    }
+
+    private companion object {
+        const val ANDROID_XML_NAMESPACE = "http://schemas.android.com/apk/res/android"
+    }
+}

--- a/changes/unreleased/360-android-user-ca-trust.md
+++ b/changes/unreleased/360-android-user-ca-trust.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 360
-pull: none
+pull: 395
 platforms: android
 user-facing: yes
 

--- a/changes/unreleased/360-android-user-ca-trust.md
+++ b/changes/unreleased/360-android-user-ca-trust.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 360
+pull: none
+platforms: android
+user-facing: yes
+
+Android now honors certificate authorities that the device owner explicitly installed, matching the trust used by the system browser for private Nextcloud servers.


### PR DESCRIPTION
## Outcome

Android connections now use the system certificate authorities plus certificate authorities explicitly installed by the device owner. Private Nextcloud servers that already work in the Android browser no longer fail only because Nextcloud Native targets a modern Android API level.

Cleartext traffic remains disabled. This does not bypass hostname, expiry, or certificate-chain validation, and it does not silently trust an arbitrary certificate presented by a server.

Closes #360.

## Validation

Validated from a clean current `origin/main` worktree on the dedicated Debian 13 build host with Java 21 and the Android SDK:

- `:androidApp:testDebugUnitTest`
- `:androidApp:assembleDebug`
- `bash tools/check-repository.sh`

The regression test verifies that the manifest selects one app-wide network security policy, that both system and device-owner CA stores are present, and that cleartext remains explicitly disabled.

## Scope and risk

- Android only; desktop trust behavior is unchanged.
- Trust is expanded only to CA certificates the device owner deliberately installed.
- Per-server approval for an otherwise untrusted self-signed leaf remains tracked separately in #344.