### PR TITLE
fix(tests): stabilize Windows support intake waits

### DIFF
--- a/changes/unreleased/398-windows-support-intake-test-stability.md
+++ b/changes/unreleased/398-windows-support-intake-test-stability.md
@@ -1,0 +1,7 @@
+category: internal
+issue: none
+pull: 398
+platforms: windows
+user-facing: no
+
+Windows CI now gives asynchronous support-intake request startup enough time on slower hosted runners.

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
@@ -1079,7 +1079,10 @@ class JvmSupportIntakeTest {
             val submission = launch(Dispatchers.Default) {
                 fixture.intake.submit("A refresh failed.", "nightly", emptyList())
             }
-            assertEquals("POST", requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS)).method)
+            assertEquals(
+                "POST",
+                requireNotNull(fixture.server.takeRequest(WINDOWS_REQUEST_START_TIMEOUT_SECONDS, TimeUnit.SECONDS)).method,
+            )
 
             assertTrue(fixture.intake.cancel())
             assertIs<SupportDiagnosticsSubmissionState.Cancelling>(fixture.intake.states().value)
@@ -2244,7 +2247,9 @@ class JvmSupportIntakeTest {
             val submission = launch(Dispatchers.Default) {
                 fixture.intake.submit("A refresh failed.", "nightly", emptyList())
             }
-            val upload = requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS))
+            val upload = requireNotNull(
+                fixture.server.takeRequest(WINDOWS_REQUEST_START_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+            )
             assertTrue(fixture.intake.cancel())
             submission.join()
             assertIs<SupportDiagnosticsSubmissionState.RetryableFailure>(fixture.intake.states().value)
@@ -2763,6 +2768,7 @@ class JvmSupportIntakeTest {
     }
 
     private companion object {
+        const val WINDOWS_REQUEST_START_TIMEOUT_SECONDS = 10L
         const val TEST_ACCOUNT_IDENTITY = "0123456789abcdef0123456789abcdef"
         const val OTHER_ACCOUNT_IDENTITY = "fedcba9876543210fedcba9876543210"
     }


### PR DESCRIPTION
## Summary

- give the two observed asynchronous support-upload startup requests enough time on slower Windows runners
- retain the existing request synchronization and all cancellation assertions
- keep this CI stabilization separate from the Android sync behavior in #390

## Evidence

#390 failed its Windows job twice at the initial MockWebServer request wait, each time in a different support-intake cancellation test. The Linux/Android job stayed green, and #390 does not change support-intake code.

## Validation

Dedicated build-host validation will run the two focused desktop tests repeatedly, the full desktop suite, repository hygiene, and prerelease contracts.

## Scope

Test timing only. Production support intake behavior is unchanged.