### PR TITLE
fix(tests): stabilize Windows support expiry waits

### DIFF
--- a/changes/unreleased/windows-support-expiry-test-stability.md
+++ b/changes/unreleased/windows-support-expiry-test-stability.md
@@ -1,0 +1,7 @@
+category: internal
+issue: 351
+pull: none
+platforms: windows
+user-facing: no
+
+Allow Windows support-intake lifecycle tests enough time for asynchronous requests and receipt expiry.

--- a/changes/unreleased/windows-support-expiry-test-stability.md
+++ b/changes/unreleased/windows-support-expiry-test-stability.md
@@ -1,6 +1,6 @@
 category: internal
 issue: 351
-pull: none
+pull: 400
 platforms: windows
 user-facing: no
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
@@ -1148,17 +1148,17 @@ class JvmSupportIntakeTest {
     @Test
     fun expiresCompletedReceiptWhileTheProcessRemainsOpen() = runBlocking {
         testFixture().use { fixture ->
-            val retentionUntil = Instant.now().plusSeconds(2)
+            val retentionUntil = Instant.now().plusSeconds(10)
             fixture.server.enqueue(receiptResponse(fixture.statusUrl, retentionUntil = retentionUntil))
 
             fixture.intake.submit("A refresh failed.", "nightly", emptyList())
 
             assertIs<SupportDiagnosticsSubmissionState.Submitted>(fixture.intake.states().value)
             assertEquals(1, fixture.completedDescriptors().size)
-            withTimeout(5_000) {
+            withTimeout(15_000) {
                 fixture.intake.states().first { it is SupportDiagnosticsSubmissionState.Idle }
             }
-            withTimeout(5_000) {
+            withTimeout(15_000) {
                 while (fixture.completedDescriptors().isNotEmpty()) delay(10)
             }
             assertTrue(fixture.completedDescriptors().isEmpty())
@@ -1611,7 +1611,7 @@ class JvmSupportIntakeTest {
         testFixture(
             afterUploadResponse = {
                 responseCompleted.countDown()
-                assertTrue(allowResponseResult.await(2, TimeUnit.SECONDS))
+                assertTrue(allowResponseResult.await(10, TimeUnit.SECONDS))
             },
         ).use { fixture ->
             fixture.server.enqueue(MockResponse.Builder().code(503).build())
@@ -1620,15 +1620,15 @@ class JvmSupportIntakeTest {
             val submission = launch(Dispatchers.Default) {
                 fixture.intake.submit("A refresh failed.", "nightly", emptyList())
             }
-            val upload = requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS))
-            assertTrue(responseCompleted.await(2, TimeUnit.SECONDS))
+            val upload = requireNotNull(fixture.server.takeRequest(10, TimeUnit.SECONDS))
+            assertTrue(responseCompleted.await(10, TimeUnit.SECONDS))
 
             assertTrue(fixture.intake.cancel())
             allowResponseResult.countDown()
             submission.join()
 
             assertIs<SupportDiagnosticsSubmissionState.Cancelled>(fixture.intake.states().value)
-            val cancellation = requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS))
+            val cancellation = requireNotNull(fixture.server.takeRequest(10, TimeUnit.SECONDS))
             assertEquals("DELETE", cancellation.method)
             assertEquals("/api/v1/receipts", cancellation.url.encodedPath)
             assertEquals(upload.headers["Idempotency-Key"], cancellation.headers["Idempotency-Key"])

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
@@ -1405,15 +1405,15 @@ class JvmSupportIntakeTest {
             val submission = launch(Dispatchers.Default) {
                 fixture.intake.submit("A refresh failed.", "nightly", emptyList())
             }
-            val upload = requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS))
-            val reconciliation = requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS))
+            val upload = requireNotNull(fixture.server.takeRequest(10, TimeUnit.SECONDS))
+            val reconciliation = requireNotNull(fixture.server.takeRequest(10, TimeUnit.SECONDS))
             assertEquals("GET", reconciliation.method)
 
             assertTrue(fixture.intake.cancel())
             submission.join()
 
             assertIs<SupportDiagnosticsSubmissionState.Cancelled>(fixture.intake.states().value)
-            val cancellation = requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS))
+            val cancellation = requireNotNull(fixture.server.takeRequest(10, TimeUnit.SECONDS))
             assertEquals("DELETE", cancellation.method)
             assertEquals("/api/v1/receipts", cancellation.url.encodedPath)
             assertEquals(upload.headers["Idempotency-Key"], cancellation.headers["Idempotency-Key"])


### PR DESCRIPTION
## Summary

- give the completed-receipt expiry test enough retention time for slower Windows runners
- give cancellation tests enough time to observe upload, reconciliation, and authoritative tombstone requests
- keep production support-intake behavior unchanged

## Context

Follow-up to #351.

These support-intake tests failed in otherwise unrelated Windows checks for #399 and #403. They used two-second wall-clock boundaries around asynchronous HTTP handling; the Windows runner could legitimately cross those boundaries before the assertion observed the response.

## Validation

On the dedicated build host:

- `bash tools/check-repository.sh`
- `bash tools/test-prerelease-update-contract.sh`
- focused reruns of `JvmSupportIntakeTest.expiresCompletedReceiptWhileTheProcessRemainsOpen`, `JvmSupportIntakeTest.cancellationAfterUploadResponseCompletesSendsAuthoritativeTombstone`, and `JvmSupportIntakeTest.cancellationDuringReceiptReconciliationSendsAuthoritativeTombstone`
- full `:ui:desktopTest`

The original two-test change was fully green, including hosted Windows. The added reconciliation test is being revalidated at `ba8ca0fc1404a44d4d7c330f5258e35f471eb529`.
