### PR TITLE
fix(diagnostics): record update rejection stages

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidNextcloudServices.kt
@@ -673,7 +673,12 @@ internal class AndroidNextcloudServices(
                             is AppUpdateInstallResult.Rejected -> "rejected"
                         },
                         durationMillis = elapsedMillis(started),
-                        fields = listOf(SupportDiagnosticFieldDraft("release", release.versionName)),
+                        fields = buildList {
+                            add(SupportDiagnosticFieldDraft("release", release.versionName))
+                            if (result is AppUpdateInstallResult.Rejected) {
+                                add(SupportDiagnosticFieldDraft("reason", result.diagnosticCode))
+                            }
+                        },
                     ),
                 )
                 result

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClient.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidProjectContentClient.kt
@@ -276,9 +276,15 @@ internal class AndroidProjectContentClient(
 
     suspend fun beginUpdate(release: AppUpdateRelease): AppUpdateInstallResult {
         val androidRelease = release as? AndroidDirectRelease
-            ?: return AppUpdateInstallResult.Rejected("This is not an Android update package.")
+            ?: return AppUpdateInstallResult.Rejected(
+                "This is not an Android update package.",
+                "android-package-type",
+            )
         if (!updateMutex.tryLock()) {
-            return AppUpdateInstallResult.Rejected("An app update is already in progress.")
+            return AppUpdateInstallResult.Rejected(
+                "An app update is already in progress.",
+                "android-already-running",
+            )
         }
         try {
             return beginUpdateLocked(androidRelease)
@@ -291,10 +297,13 @@ internal class AndroidProjectContentClient(
     private suspend fun beginUpdateLocked(release: AndroidDirectRelease): AppUpdateInstallResult {
         val support = support()
         if (!support.canCheckDirectUpdates) {
-            return AppUpdateInstallResult.Rejected(support.explanation)
+            return AppUpdateInstallResult.Rejected(support.explanation, "android-distribution-ineligible")
         }
         if (!isNewerAndroidRelease(support.currentVersionCode, release)) {
-            return AppUpdateInstallResult.Rejected("This release is not newer than the installed app.")
+            return AppUpdateInstallResult.Rejected(
+                "This release is not newer than the installed app.",
+                "android-release-ineligible",
+            )
         }
         val selectedChannel = updateChannel()
         runCatching {
@@ -302,10 +311,14 @@ internal class AndroidProjectContentClient(
         }.getOrElse {
             return AppUpdateInstallResult.Rejected(
                 "The update metadata is invalid for the selected ${selectedChannel.name} channel.",
+                "android-metadata",
             )
         }
         val foregroundActivity = activity
-            ?: return AppUpdateInstallResult.Rejected("Open the app before installing an update.")
+            ?: return AppUpdateInstallResult.Rejected(
+                "Open the app before installing an update.",
+                "android-no-foreground-activity",
+            )
         if (!appContext.packageManager.canRequestPackageInstalls()) {
             val message =
                 "Allow installs from Nextcloud Native, then return and confirm the update again."
@@ -335,6 +348,7 @@ internal class AndroidProjectContentClient(
             activePartial = temporary,
         )
         updateCancellationRequested = false
+        var diagnosticStage = "download"
         return try {
             val resumedFromBytes = settleUpdatePartial(
                 file = temporary,
@@ -370,9 +384,11 @@ internal class AndroidProjectContentClient(
                 versionName = release.versionName,
                 versionCode = release.versionCode,
             )
+            diagnosticStage = "verification"
             verifyDownloadedApk(release, temporary)
             if (staged.exists()) check(staged.delete())
             check(temporary.renameTo(staged)) { "Could not stage the verified update." }
+            diagnosticStage = "installer-handoff"
             val uri = FileProvider.getUriForFile(
                 appContext,
                 "${appContext.packageName}.sharedfiles",
@@ -435,7 +451,10 @@ internal class AndroidProjectContentClient(
                 downloadedBytes = retainedBytes,
                 canResume = recoverable && retainedBytes in 1 until release.apkSize,
             )
-            AppUpdateInstallResult.Rejected(failure.message ?: "The update could not be verified.")
+            AppUpdateInstallResult.Rejected(
+                failure.message ?: "The update could not be verified.",
+                "android-$diagnosticStage",
+            )
         } finally {
             updateCancellationRequested = false
         }

--- a/changes/unreleased/update-install-diagnostic-reasons.md
+++ b/changes/unreleased/update-install-diagnostic-reasons.md
@@ -1,6 +1,6 @@
 category: internal
 issue: 351
-pull: none
+pull: 402
 platforms: android, linux, macos, windows
 user-facing: no
 

--- a/changes/unreleased/update-install-diagnostic-reasons.md
+++ b/changes/unreleased/update-install-diagnostic-reasons.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 351
+pull: none
+platforms: android, linux, macos, windows
+user-facing: no
+
+Record a bounded update-install failure stage in support diagnostics without including package paths or URLs.

--- a/changes/unreleased/update-install-diagnostic-reasons.md
+++ b/changes/unreleased/update-install-diagnostic-reasons.md
@@ -1,4 +1,4 @@
-category: fix
+category: internal
 issue: 351
 pull: none
 platforms: android, linux, macos, windows

--- a/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt
+++ b/ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt
@@ -258,7 +258,10 @@ sealed interface AppUpdateInstallResult {
     data object Installed : AppUpdateInstallResult
     data class Cancelled(val canResume: Boolean) : AppUpdateInstallResult
     data class PermissionRequired(val message: String) : AppUpdateInstallResult
-    data class Rejected(val message: String) : AppUpdateInstallResult
+    data class Rejected(
+        val message: String,
+        val diagnosticCode: String = "rejected",
+    ) : AppUpdateInstallResult
 }
 
 private val publicContentJson = Json {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdates.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdates.kt
@@ -269,19 +269,30 @@ internal class DesktopAppUpdater(
 
     suspend fun beginUpdate(release: AppUpdateRelease): AppUpdateInstallResult {
         val desktopRelease = release as? DesktopDirectRelease
-            ?: return AppUpdateInstallResult.Rejected("This is not a desktop update package.")
+            ?: return AppUpdateInstallResult.Rejected(
+                "This is not a desktop update package.",
+                "desktop-package-type",
+            )
         if (desktopRelease.updateChannel != updateChannel()) {
             return AppUpdateInstallResult.Rejected(
                 "The update channel changed. Check again before downloading this package.",
+                "desktop-channel-changed",
             )
         }
         if (!updateMutex.tryLock()) {
-            return AppUpdateInstallResult.Rejected("An app update is already in progress.")
+            return AppUpdateInstallResult.Rejected(
+                "An app update is already in progress.",
+                "desktop-already-running",
+            )
         }
+        var diagnosticStage = "preflight"
         try {
             val support = support()
             if (!support.canCheckDirectUpdates || !isNewerAppRelease(support.currentVersionCode, desktopRelease)) {
-                return AppUpdateInstallResult.Rejected("This release cannot update the installed desktop package.")
+                return AppUpdateInstallResult.Rejected(
+                    "This release cannot update the installed desktop package.",
+                    "desktop-release-ineligible",
+                )
             }
             val selectedTarget = requireNotNull(target)
             check(desktopRelease.asset.platform == selectedTarget.platform)
@@ -290,6 +301,7 @@ internal class DesktopAppUpdater(
             check(updateDirectory.isDirectory || updateDirectory.mkdirs()) {
                 "Could not create the desktop app-update cache."
             }
+            diagnosticStage = "cache"
             val packageFile = File(updateDirectory, desktopRelease.asset.url.substringAfterLast('/'))
             val temporary = File(updateDirectory, "${packageFile.name}.part")
             cleanupDesktopUpdatePackages(updateDirectory, activePartial = temporary)
@@ -302,6 +314,7 @@ internal class DesktopAppUpdater(
                 totalBytes = desktopRelease.asset.size,
                 resumedFromBytes = 0,
             )
+            diagnosticStage = "download"
             downloadDesktopUpdatePackage(
                 client = client,
                 release = desktopRelease,
@@ -322,6 +335,7 @@ internal class DesktopAppUpdater(
                 desktopRelease.versionName,
                 desktopRelease.versionCode,
             )
+            diagnosticStage = "verification"
             check(temporary.sha256() == desktopRelease.asset.sha256) {
                 "Update checksum verification failed."
             }
@@ -330,11 +344,13 @@ internal class DesktopAppUpdater(
                 packageFile.toPath(),
                 StandardCopyOption.REPLACE_EXISTING,
             )
+            diagnosticStage = "installer-preparation"
             prepareInstaller(packageFile, desktopRelease)
             mutableInstallState.value = AppUpdateInstallState.Installing(
                 desktopRelease.versionName,
                 desktopRelease.versionCode,
             )
+            diagnosticStage = "installer-handoff"
             return when (openInstaller(packageFile)) {
                 DesktopPackageInstallerOutcome.InstallerHandoffStarted -> {
                     mutableInstallState.value = AppUpdateInstallState.ConfirmationOpened(
@@ -345,6 +361,7 @@ internal class DesktopAppUpdater(
                     AppUpdateInstallResult.ConfirmationOpened
                 }
                 DesktopPackageInstallerOutcome.InstallationCompleted -> {
+                    diagnosticStage = "installed-version-verification"
                     val installedVersion = installedPackageVersion(selectedTarget)
                     requireInstalledDesktopPackageVersion(installedVersion, desktopRelease.packageVersion)
                     mutableInstallState.value = AppUpdateInstallState.Installed(
@@ -393,6 +410,7 @@ internal class DesktopAppUpdater(
             )
             return AppUpdateInstallResult.Rejected(
                 failure.message ?: "The desktop update could not be verified.",
+                "desktop-$diagnosticStage",
             )
         } finally {
             cancellationRequested = false

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -3449,7 +3449,12 @@ class DesktopNextcloudServices(
                             is AppUpdateInstallResult.Rejected -> result.message
                             else -> null
                         },
-                        fields = listOf(SupportDiagnosticFieldDraft("release", release.versionName)),
+                        fields = buildList {
+                            add(SupportDiagnosticFieldDraft("release", release.versionName))
+                            if (result is AppUpdateInstallResult.Rejected) {
+                                add(SupportDiagnosticFieldDraft("reason", result.diagnosticCode))
+                            }
+                        },
                     ),
                 )
                 result

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdatesTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdatesTest.kt
@@ -500,6 +500,7 @@ class DesktopAppUpdatesTest {
             val result = runBlocking { updater.beginUpdate(alphaRelease) }
             val rejected = assertIs<AppUpdateInstallResult.Rejected>(result)
             assertTrue(rejected.message.contains("channel changed", ignoreCase = true))
+            assertEquals("desktop-channel-changed", rejected.diagnosticCode)
         } finally {
             node.removeNode()
             directory.deleteRecursively()

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -409,7 +409,7 @@
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformImage.kt": "5c1ebb3dc168c0a53d6db05c54b7329a571dec808aef3de7fba1a52bd93b2d3d",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PlatformVideoPlayback.kt": "8f103ac182fdca3c78f1ffe7a3b15f06f05abb3be173747255fe4a9c84726758",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PreviewMemoryCache.kt": "19d2205dc43f8a245f5fb9cfc3e65cf55430f13fb091eb9d6812d4d05946180f",
-        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt": "7ca3b1fcd58e4df202e34480b2cca1f14ff727872370cbb5f460d8b187f80fd7",
+        "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ProjectNewsAndUpdates.kt": "7226d90f680dbae6756e2f53617a309a10c256eb99d89137a9902b84ffe2fa12",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/PublicContentDigest.kt": "175cbd645bb72bbf59085e5f749835397f29d6a39a289015fb5b7071d5a0688d",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RawPhotoPreview.kt": "73c49576766e266ac5b29e072db6b2e987c2a11107460f7a8019fb8ef4f923ff",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/RecognizeBridge.kt": "f1e61f89764735da946cce69fb4beb3309fe97d97e5a985c3641d7f38715f197",


### PR DESCRIPTION
## Summary

- add bounded rejection codes and install-stage diagnostics for Android and desktop app updates
- distinguish eligibility, download, verification, installer preparation, handoff, and installed-version verification failures
- keep diagnostic values privacy-safe and independent of exception text, paths, URLs, or package contents

A private Linux updater report showed repeated rejected install attempts without enough bounded stage information to identify where installation stopped.

Follow-up to #351.

## Validation

On the dedicated build host at `afb710eadd67de3d6165d258c9757d3ca283c7b3`:

- `bash tools/check-repository.sh`
- `bash tools/test-prerelease-update-contract.sh`
- `./gradlew --no-daemon :ui:desktopTest :androidApp:testDebugUnitTest :androidApp:verifyReleaseLintGate --max-workers=1 -Pkotlin.incremental=false`

All passed. Gradle reported `BUILD SUCCESSFUL` with 123 actionable tasks.
