### PR TITLE
fix(updates): use native Linux package managers

### DIFF
--- a/changes/unreleased/379-linux-direct-update-install.md
+++ b/changes/unreleased/379-linux-direct-update-install.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 379
+pull: none
+platforms: linux
+user-facing: yes
+
+Direct Linux updates now use DNF for RPM packages and APT for DEB packages through normal system authorization instead of relying on a failing PackageKit transaction.

--- a/changes/unreleased/379-linux-direct-update-install.md
+++ b/changes/unreleased/379-linux-direct-update-install.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 379
-pull: none
+pull: 408
 platforms: linux
 user-facing: yes
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdates.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdates.kt
@@ -492,7 +492,7 @@ private fun File.isDesktopUpdatePartial(): Boolean {
 internal val DESKTOP_APP_UPDATE_CHECK_INTERVAL_MILLIS: Long = TimeUnit.HOURS.toMillis(6)
 
 private val DESKTOP_UPDATE_PACKAGE_EXTENSIONS = setOf("deb", "rpm", "msi", "dmg", "pkg")
-private val DESKTOP_LINUX_PACKAGE_FORMATS = setOf("deb", "rpm")
+internal val DESKTOP_LINUX_PACKAGE_FORMATS = setOf("deb", "rpm")
 private const val DESKTOP_PACKAGE_NAME = "nextcloudnative"
 private const val DESKTOP_PACKAGE_QUERY_TIMEOUT_MILLIS = 500L
 private const val DESKTOP_PACKAGE_QUERY_MAX_OUTPUT_CHARACTERS = 64
@@ -885,46 +885,6 @@ private fun writeWindowsInstallerHandoffScript(directory: File): File {
         Files.deleteIfExists(temporary)
     }
     return target
-}
-
-internal fun runLinuxNativePackageInstaller(
-    packageFile: File,
-    commandResolver: (File) -> List<String>? = ::linuxNativePackageInstallerCommand,
-    commandRunner: (List<String>) -> Int = ::runNativePackageInstallerCommand,
-): Boolean {
-    val command = commandResolver(packageFile) ?: return false
-    check(Files.isRegularFile(packageFile.toPath(), LinkOption.NOFOLLOW_LINKS)) {
-        "The verified Linux update package is no longer a regular file."
-    }
-    val exitCode = commandRunner(command)
-    check(exitCode == 0) { "The system package transaction failed with exit code $exitCode." }
-    return true
-}
-
-private fun runNativePackageInstallerCommand(command: List<String>): Int {
-    val process = ProcessBuilder(command).inheritIO().start()
-    return try {
-        process.waitFor()
-    } catch (interrupted: InterruptedException) {
-        process.destroy()
-        Thread.currentThread().interrupt()
-        throw IOException("The system package transaction was interrupted.", interrupted)
-    }
-}
-
-internal fun linuxNativePackageInstallerCommand(
-    packageFile: File,
-    executableAvailable: (File) -> Boolean = { executable -> executable.isFile && executable.canExecute() },
-): List<String>? {
-    if (packageFile.extension.lowercase() !in DESKTOP_LINUX_PACKAGE_FORMATS) return null
-    val packageKitClient = File("/usr/bin/pkcon")
-    if (!executableAvailable(packageKitClient)) return null
-    return listOf(
-        packageKitClient.absolutePath,
-        "--noninteractive",
-        "install-local",
-        packageFile.toPath().toAbsolutePath().normalize().toString(),
-    )
 }
 
 private fun File.sha256(): String {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxDesktopPackageInstaller.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxDesktopPackageInstaller.kt
@@ -1,0 +1,91 @@
+package dev.obiente.nextcloudnative.app
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.LinkOption
+
+internal fun runLinuxNativePackageInstaller(
+    packageFile: File,
+    commandResolver: (File) -> List<String>? = ::linuxNativePackageInstallerCommand,
+    commandRunner: (List<String>) -> Int = ::runNativePackageInstallerCommand,
+): Boolean {
+    check(Files.isRegularFile(packageFile.toPath(), LinkOption.NOFOLLOW_LINKS)) {
+        "The verified Linux update package is no longer a regular file."
+    }
+    val command = commandResolver(packageFile) ?: return false
+    val exitCode = commandRunner(command)
+    check(exitCode == 0) { "The system package transaction failed with exit code $exitCode." }
+    return true
+}
+
+private fun runNativePackageInstallerCommand(command: List<String>): Int {
+    val process = ProcessBuilder(command).inheritIO().start()
+    return try {
+        process.waitFor()
+    } catch (interrupted: InterruptedException) {
+        process.destroy()
+        Thread.currentThread().interrupt()
+        throw IOException("The system package transaction was interrupted.", interrupted)
+    }
+}
+
+internal fun linuxNativePackageInstallerCommand(
+    packageFile: File,
+    executableAvailable: (File) -> Boolean = { executable -> executable.isFile && executable.canExecute() },
+): List<String>? {
+    val format = packageFile.extension.lowercase()
+    if (format !in DESKTOP_LINUX_PACKAGE_FORMATS) return null
+    val authorizationBroker = File("/usr/bin/pkexec")
+    if (!executableAvailable(authorizationBroker)) return null
+    val packagePath = packageFile.toPath().toAbsolutePath().normalize().toString()
+    return when (format) {
+        "rpm" -> rpmPackageInstallerCommand(authorizationBroker, packagePath, executableAvailable)
+        "deb" -> debPackageInstallerCommand(authorizationBroker, packagePath, executableAvailable)
+        else -> null
+    }
+}
+
+private fun rpmPackageInstallerCommand(
+    authorizationBroker: File,
+    packagePath: String,
+    executableAvailable: (File) -> Boolean,
+): List<String>? {
+    val dnf5 = File("/usr/bin/dnf5")
+    if (executableAvailable(dnf5)) {
+        return listOf(
+            authorizationBroker.absolutePath,
+            dnf5.absolutePath,
+            "--assumeyes",
+            "install",
+            "--no-allow-downgrade",
+            packagePath,
+        )
+    }
+    val dnf = File("/usr/bin/dnf")
+    if (!executableAvailable(dnf)) return null
+    return listOf(
+        authorizationBroker.absolutePath,
+        dnf.absolutePath,
+        "--assumeyes",
+        "install",
+        packagePath,
+    )
+}
+
+private fun debPackageInstallerCommand(
+    authorizationBroker: File,
+    packagePath: String,
+    executableAvailable: (File) -> Boolean,
+): List<String>? {
+    val aptGet = File("/usr/bin/apt-get")
+    if (!executableAvailable(aptGet)) return null
+    return listOf(
+        authorizationBroker.absolutePath,
+        aptGet.absolutePath,
+        "--yes",
+        "--no-remove",
+        "install",
+        packagePath,
+    )
+}

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdatesTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopAppUpdatesTest.kt
@@ -16,24 +16,54 @@ import kotlin.test.assertIs
 
 class DesktopAppUpdatesTest {
     @Test
-    fun linuxUpdatesUseAnAuthorizedPackageServiceWithoutShellParsing() {
-        val packageFile = File("/tmp/update path;still-one-argument.rpm")
-        val packageKit = File("/usr/bin/pkcon")
+    fun linuxUpdatesUseTheFormatSpecificPackageManagerWithoutShellParsing() {
+        val rpmPackage = File("/tmp/update path;still-one-argument.rpm")
+        val debPackage = File("/tmp/update path;still-one-argument.deb")
+        val pkexec = File("/usr/bin/pkexec")
+        val dnf5 = File("/usr/bin/dnf5")
+        val dnf = File("/usr/bin/dnf")
+        val aptGet = File("/usr/bin/apt-get")
 
         assertEquals(
             listOf(
-                packageKit.absolutePath,
-                "--noninteractive",
-                "install-local",
-                packageFile.toPath().toAbsolutePath().normalize().toString(),
+                pkexec.absolutePath,
+                dnf5.absolutePath,
+                "--assumeyes",
+                "install",
+                "--no-allow-downgrade",
+                rpmPackage.toPath().toAbsolutePath().normalize().toString(),
             ),
-            linuxNativePackageInstallerCommand(packageFile) { executable -> executable == packageKit },
+            linuxNativePackageInstallerCommand(rpmPackage) { executable ->
+                executable == pkexec || executable == dnf5 || executable == dnf
+            },
         )
         assertEquals(
-            "install-local",
-            linuxNativePackageInstallerCommand(File("/tmp/nextcloudnative.deb")) { true }?.get(2),
+            listOf(
+                pkexec.absolutePath,
+                dnf.absolutePath,
+                "--assumeyes",
+                "install",
+                rpmPackage.toPath().toAbsolutePath().normalize().toString(),
+            ),
+            linuxNativePackageInstallerCommand(rpmPackage) { executable ->
+                executable == pkexec || executable == dnf
+            },
         )
-        assertNull(linuxNativePackageInstallerCommand(packageFile) { false })
+        assertEquals(
+            listOf(
+                pkexec.absolutePath,
+                aptGet.absolutePath,
+                "--yes",
+                "--no-remove",
+                "install",
+                debPackage.toPath().toAbsolutePath().normalize().toString(),
+            ),
+            linuxNativePackageInstallerCommand(debPackage) { executable ->
+                executable == pkexec || executable == aptGet
+            },
+        )
+        assertNull(linuxNativePackageInstallerCommand(rpmPackage) { executable -> executable == dnf5 })
+        assertNull(linuxNativePackageInstallerCommand(debPackage) { executable -> executable == pkexec })
         assertNull(linuxNativePackageInstallerCommand(File("/tmp/nextcloudnative.pkg")) { true })
     }
 
@@ -64,6 +94,30 @@ class DesktopAppUpdatesTest {
             }
             assertTrue(failure.message.orEmpty().contains("exit code 5"))
             assertFalse(runLinuxNativePackageInstaller(packageFile, commandResolver = { null }))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun linuxPackageTransactionsRejectReplacedPackageFiles() {
+        val directory = Files.createTempDirectory("desktop-update-symlink-test").toFile()
+        val target = directory.resolve("outside.rpm").apply { writeText("unverified") }
+        val packageFile = directory.resolve("nextcloudnative.rpm")
+        try {
+            Files.createSymbolicLink(packageFile.toPath(), target.toPath())
+            var commandResolved = false
+            val failure = kotlin.test.assertFailsWith<IllegalStateException> {
+                runLinuxNativePackageInstaller(
+                    packageFile = packageFile,
+                    commandResolver = {
+                        commandResolved = true
+                        listOf("unexpected")
+                    },
+                )
+            }
+            assertTrue(failure.message.orEmpty().contains("no longer a regular file"))
+            assertFalse(commandResolved)
         } finally {
             directory.deleteRecursively()
         }


### PR DESCRIPTION
## Summary

- replace the rejected generic PackageKit transaction with format-specific privileged installation
- use DNF5 or DNF for RPM packages and APT for DEB packages through normal PolicyKit authorization
- preserve the system-handler fallback when a native manager or `pkexec` is unavailable
- validate the verified package again before resolving or launching a privileged command

## Cause

The failing Linux path selected `/usr/bin/pkcon` solely from its presence and treated any nonzero `install-local` transaction as a terminal rejection. Existing diagnostics identify this install-handoff stage but do not show a manifest or download failure. This change uses the package manager that owns the downloaded format and retains the existing bounded failure reporting.

Closes #379.

## Validation

On the dedicated build host:

- `bash tools/check-repository.sh`
- `./gradlew --no-daemon --max-workers=1 -Pkotlin.incremental=false :ui:desktopTest --tests dev.obiente.nextcloudnative.app.DesktopAppUpdatesTest`
- `:ui:createDistributable` completed successfully

Native packaging could not be completed on that host for environment reasons: DEB packaging requires the absent `fakeroot` executable, and the installed `jpackage` reports RPM as unsupported. Hosted Linux packaging remains required and must not be represented as locally validated.

## Safety

- no shell is used; the package path remains one process argument
- DNF5 refuses downgrades and APT refuses removals
- missing authorization or manager tools fall back to the desktop system handler
- checksum, manifest, installed-version, and diagnostic contracts are unchanged
