### PR TITLE
fix(windows): stop failed Cloud Files retry loops

### DIFF
--- a/changes/unreleased/333-windows-cloud-files-automatic-retry.md
+++ b/changes/unreleased/333-windows-cloud-files-automatic-retry.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 333
-pull: none
+pull: 409
 platforms: windows
 user-facing: yes
 

--- a/changes/unreleased/333-windows-cloud-files-automatic-retry.md
+++ b/changes/unreleased/333-windows-cloud-files-automatic-retry.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 333
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows Cloud Files now keeps a failed automatic activation visible until the user retries instead of repeatedly inspecting the same damaged provider root.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -1761,7 +1761,7 @@ class DesktopNextcloudServices(
             (isLinuxDesktop() || isWindowsDesktop()) &&
             preferences.getBoolean(providerPreferenceKey, false) &&
             synchronized(virtualFileProviderLock) {
-                linuxVirtualFileMountIdentity != accountId && windowsCloudFilesIdentity != accountId
+                linuxVirtualFileMountIdentity != accountId && windowsCloudFilesIdentity != accountId && windowsCloudFilesAutomaticActivationAllowed(isWindowsDesktop(), windowsCloudFilesFailure)
             }
         ) {
             runCatching { activateVirtualFileProvider(session, userId) }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesActivationPolicy.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesActivationPolicy.kt
@@ -1,0 +1,6 @@
+package dev.obiente.nextcloudnative.app
+
+internal fun windowsCloudFilesAutomaticActivationAllowed(
+    windowsDesktop: Boolean,
+    previousFailure: String?,
+): Boolean = !windowsDesktop || previousFailure == null

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesActivationPolicyTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesActivationPolicyTest.kt
@@ -1,0 +1,37 @@
+package dev.obiente.nextcloudnative.app
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WindowsCloudFilesActivationPolicyTest {
+    @Test
+    fun `failed Windows activation waits for an explicit retry`() {
+        assertFalse(
+            windowsCloudFilesAutomaticActivationAllowed(
+                windowsDesktop = true,
+                previousFailure = "Synthetic Cloud Files activation failure",
+            ),
+        )
+    }
+
+    @Test
+    fun `Windows activation can start automatically before a failure`() {
+        assertTrue(
+            windowsCloudFilesAutomaticActivationAllowed(
+                windowsDesktop = true,
+                previousFailure = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `Windows failure state does not change another desktop adapter`() {
+        assertTrue(
+            windowsCloudFilesAutomaticActivationAllowed(
+                windowsDesktop = false,
+                previousFailure = "Synthetic Cloud Files activation failure",
+            ),
+        )
+    }
+}

--- a/website/content/guides/windows-cloud-files.md
+++ b/website/content/guides/windows-cloud-files.md
@@ -28,7 +28,7 @@ On Windows, Nextcloud Native integrates with the Cloud Files API so remote conte
 
 Open **Settings**, choose **Sync & storage**, then open **Virtual files**. Activate the system provider if it is not already active. When registration succeeds, the location is reported as **Nextcloud Native in File Explorer**. The root is account-scoped, and signing out disconnects the provider for that account.
 
-If activation fails, keep the failure message and retry only after checking that the app is the current installed version. Do not manually delete a registered sync root or copy provider metadata between accounts. Recovery handles stale registrations, legacy roots, and damaged Cloud Files metadata while preserving the existing local root and its data.
+If activation fails, keep the failure message and retry only after checking that the app is the current installed version. The app keeps a failed automatic activation visible instead of retrying it on every settings refresh. Use the explicit activation action when you are ready to retry. Do not manually delete a registered sync root or copy provider metadata between accounts. Recovery handles stale registrations, legacy roots, and damaged Cloud Files metadata while preserving the existing local root and its data.
 
 ## 2. Open placeholders, keep content local, or free eligible space
 


### PR DESCRIPTION
## Summary

- stop automatic Windows Cloud Files activation after the first failed attempt in the process
- retain the failure for the settings UI instead of repeatedly inspecting the same damaged root
- preserve explicit user-controlled retry and the existing non-destructive recovery path
- document the retry behavior and add a pure platform policy regression

## Cause

A retained `vfp-active` preference caused every storage/settings snapshot reload to recreate the Windows provider even after activation had failed. Corrupt placeholder metadata therefore triggered repeated native inspection and activation attempts. This is separate from the earlier placeholder-creation collision: the defect here is the service owner's unbounded automatic retry after a terminal attempt.

Relates to #333.

## Validation

On the dedicated build host:

- `bash tools/check-repository.sh`
- `:ui:desktopTest` with `WindowsCloudFilesActivationPolicyTest`, `WindowsCloudFilesProviderTest`, and `DesktopVirtualFileProviderPreferencesTest`
- `:ui:createDistributable`

Result: `BUILD SUCCESSFUL`.

The hosted Windows job remains responsible for native Windows tests, MSI packaging, metadata verification, and runtime CFAPI coverage.

## Safety

- no root, placeholder, hydrated file, or local content is deleted or overwritten
- the original activation failure and corruption diagnostics remain available
- explicit retry still uses the complete fail-closed preservation and rebuild path
- restarting permits one new automatic attempt so a repaired application can recover
