### PR TITLE
fix(sync): converge Android conflict replacement

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncRemoteTree.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileSyncRemoteTree.kt
@@ -176,7 +176,7 @@ internal class AndroidFileSyncRemoteTree(
                 "The server file changed after the sync scan."
             }
             require(!current.isDirectory) { "The server item changed type." }
-            webDav.replaceFileAtomically(
+            webDav.replaceFile(
                 session,
                 userId,
                 fullPath(relativePath),

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudDocumentWebDav.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/NextcloudDocumentWebDav.kt
@@ -261,6 +261,25 @@ internal class NextcloudDocumentWebDav(
         )
     }
 
+    fun replaceFile(
+        session: NextcloudSession,
+        userId: String,
+        path: String,
+        source: File,
+        expectedEtag: String,
+    ): DocumentMutationResult {
+        require(expectedEtag.isNotBlank()) { "An ETag is required for conflict-protected replacement." }
+        val checksum = source.sha256ChecksumForDav()
+        return execute(
+            request = requestBuilder(session, buildNextcloudFileUrl(session.serverUrl, userId, path))
+                .header("If-Match", expectedEtag)
+                .apply { checksum?.let { header("OC-Checksum", it) } }
+                .put(source.asRequestBody(OCTET_STREAM))
+                .build(),
+            operation = "replace file",
+        )
+    }
+
     fun createFolder(session: NextcloudSession, userId: String, path: String) {
         execute(
             request = requestBuilder(session, buildNextcloudFileUrl(session.serverUrl, userId, path))

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudDocumentWebDavTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/NextcloudDocumentWebDavTest.kt
@@ -173,6 +173,37 @@ class NextcloudDocumentWebDavTest {
     }
 
     @Test
+    fun replacementUsesDestinationGuardedPut() = RecordingServer().use { server ->
+        server.enqueue(204, mapOf("ETag" to "\"saved-2\""))
+        val source = Files.createTempFile("ncn-replace-put-", ".txt").toFile()
+        try {
+            source.writeText("edited")
+            val result = NextcloudDocumentWebDav().replaceFile(
+                server.session,
+                "alice",
+                "Documents/report.txt",
+                source,
+                "\"old-1\"",
+            )
+
+            assertEquals("\"saved-2\"", result.etag)
+            assertEquals(1, server.requestCount)
+            val request = server.request(0)
+            assertEquals("PUT", request.method)
+            assertEquals("/remote.php/dav/files/alice/Documents/report.txt", request.path)
+            assertEquals("\"old-1\"", request.header("If-Match"))
+            assertEquals(null, request.header("If-None-Match"))
+            assertEquals(
+                "SHA256:1fb9f4097256db2d7b1e13aff79cee44339891a31c556b9cf6093885773b3618",
+                request.header("OC-Checksum"),
+            )
+            assertEquals("edited", request.body?.utf8())
+        } finally {
+            source.delete()
+        }
+    }
+
+    @Test
     fun replacementStagesThenConditionallyMovesOverExpectedEtag() = RecordingServer().use { server ->
         server.enqueue(201, mapOf("ETag" to "\"staged-1\""))
         server.enqueue(201, mapOf("ETag" to "\"saved-2\""))

--- a/changes/unreleased/115-android-conflict-replacement-put.md
+++ b/changes/unreleased/115-android-conflict-replacement-put.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 115
+pull: none
+platforms: android
+user-facing: yes
+
+Android folder sync now applies the selected device copy with a revision-guarded upload that works across supported Nextcloud servers.

--- a/changes/unreleased/115-android-conflict-replacement-put.md
+++ b/changes/unreleased/115-android-conflict-replacement-put.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 115
-pull: none
+pull: 410
 platforms: android
 user-facing: yes
 

--- a/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCoordinatorTest.kt
+++ b/ui/src/commonTest/kotlin/dev/obiente/nextcloudnative/app/FileSyncCoordinatorTest.kt
@@ -55,6 +55,16 @@ class FileSyncCoordinatorTest {
 
         assertEquals(listOf(verified), state.pair().baselines)
         assertEquals(emptyList(), state.pair().workItems)
+
+        state = scanFileSyncPair(
+            state,
+            PAIR_ID,
+            listOf(local("Vault/today.md", "local-2")),
+            listOf(remote("Vault/today.md", "remote-3")),
+            nowEpochMillis = 30,
+        )
+        assertEquals(listOf(verified), state.pair().baselines)
+        assertEquals(emptyList(), state.pair().workItems)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace Android folder-sync conflicts with a direct destination `PUT` guarded by the reviewed `If-Match` ETag
- retain `OC-Checksum`, bounded WebDAV error mapping, and post-write authoritative metadata refresh
- prove the successful replacement advances the baseline and the next identical scan queues no work
- keep the staged atomic replacement API for unrelated callers

## Cause

Android still used a temporary upload followed by conditional WebDAV `MOVE` over the destination. Some compatible Nextcloud servers reject that replacement shape. The failed operation remained retryable and repeatedly returned to the same unsupported transport path, so the conflict never converged. Desktop already moved this workflow to a guarded destination `PUT`; this PR applies the same safe transport contract to Android folder sync.

Relates to #115.

## Validation

On the dedicated build host:

- full `:ui:desktopTest`
- full `:androidApp:testDebugUnitTest`
- `:androidApp:compileDebugAndroidTestKotlin`
- `:androidApp:assembleDebug`
- `bash tools/check-repository.sh`

All tests, compilation, assembly, and repository gates passed. The first assembly attempt exhausted accumulated build-host disk space after tests had passed; generated outputs from completed validation worktrees were removed and the interrupted assembly then completed successfully.

## Data safety

- `If-Match` binds the write to the exact server generation reviewed by the user
- HTTP 412 remains a fail-closed conflict and cannot overwrite a newer remote file
- the operation completes only after rereading authoritative local and remote revisions
- no account identity, path, ETag, file content, or server URL is added to diagnostics
