### PR TITLE
fix(linux): initialize Compose display scaling

### DIFF
--- a/changes/unreleased/linux-wayland-display-scaling.md
+++ b/changes/unreleased/linux-wayland-display-scaling.md
@@ -1,6 +1,6 @@
 category: fix
 issue: none
-pull: none
+pull: 411
 platforms: linux
 user-facing: yes
 

--- a/changes/unreleased/linux-wayland-display-scaling.md
+++ b/changes/unreleased/linux-wayland-display-scaling.md
@@ -1,0 +1,7 @@
+category: fix
+issue: none
+pull: none
+platforms: linux
+user-facing: yes
+
+Initialize Compose desktop display scaling before Linux bootstrap work can enter Swing or AWT.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt
@@ -13,7 +13,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.configureSwingGlobalsForCompose
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.res.painterResource
@@ -56,7 +58,19 @@ import javax.swing.SwingUtilities
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
-fun main(arguments: Array<String>) {
+fun main(arguments: Array<String>) = runDesktopEntryPoint(arguments)
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun runDesktopEntryPoint(
+    arguments: Array<String>,
+    configureComposePlatform: () -> Unit = { configureSwingGlobalsForCompose() },
+    launch: (Array<String>) -> Unit = ::launchDesktopProcess,
+) {
+    configureComposePlatform()
+    launch(arguments)
+}
+
+private fun launchDesktopProcess(arguments: Array<String>) {
     val supportDiagnosticsRoot = desktopSupportDiagnosticsDirectory()
     installDesktopBootstrapUncaughtDiagnosticHandler(supportDiagnosticsRoot)
     if (arguments.contentEquals(arrayOf("--unregister-windows-sync-root"))) {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DesktopWindowActivationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DesktopWindowActivationTest.kt
@@ -9,6 +9,19 @@ import kotlin.test.assertEquals
 
 class DesktopWindowActivationTest {
     @Test
+    fun `compose platform is configured before desktop bootstrap`() {
+        val events = mutableListOf<String>()
+
+        runDesktopEntryPoint(
+            arguments = arrayOf("--background"),
+            configureComposePlatform = { events += "configure" },
+            launch = { arguments -> events += "launch:${arguments.single()}" },
+        )
+
+        assertEquals(listOf("configure", "launch:--background"), events)
+    }
+
+    @Test
     fun `restore leaves a normal window unchanged`() {
         assertEquals(Frame.NORMAL, restoredDesktopFrameState(Frame.NORMAL))
     }

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -536,7 +536,7 @@
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DesktopBackgroundSettingsVisualQaMain.kt": "7d90dc22854409b9837b82ba739f7221d425554531a962296ff9e75b0a178c2d",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/DynamicBoardInteractionPreviewMain.kt": "7402f5b4bf3bbf3cf20761eaa10eca9131fb6e63da2988d0aa6038942d706c53",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/FileSyncTrayVisualQaMain.kt": "a0533aec3f991b48d57f69ddf7e95124b969631b6a55110f550826ac46ffc1ad",
-        "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt": "77cc53f0d028dd3ff1aab452837971fd7bdfd196c797004defd87c3c6572a09e",
+        "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/Main.kt": "a0039b4e882ac9925baa92cf09bd74f27cda4ad24c89ef93f20873d410c99267",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/MarketingCaptureMain.kt": "e7e7987845a14273fbf61ec75df2e5aa5646c36d173788ad580e0b7cef85d740",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/MarketingCaptureOwnership.kt": "67cf94e6f215167a2384f14086d135532961c7e91cecb69be8f15e4ee6324606",
         "ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/nativeui/preview/NativeTiffMarketingCapture.kt": "6970352c6e42d09b793c55ea296991d756d232f216d8d152aa00319b2ddb8d20",


### PR DESCRIPTION
## Summary

- initialize Compose Desktop's Swing globals before any desktop bootstrap path can enter Swing or AWT
- preserve automatic Linux DPI detection instead of hard-coding a scale factor
- make the process-start ordering deterministic and directly testable

## Cause

Compose Desktop requires its global Swing configuration to run before Swing or AWT initialization when an application performs bootstrap work ahead of `application`. The desktop entry point installed diagnostics, handled update and single-instance states, and could open Swing dialogs before that ordering was explicit. On Linux Wayland/HiDPI sessions this can leave the process with incorrectly initialized display scaling.

## Validation so far

On the dedicated build host:

- `DesktopWindowActivationTest`, including configure-before-launch ordering
- `:ui:createDistributable`

Both passed. This PR is temporarily a draft only while its own PR number is added to the user-facing changelog and the complete repository gate is run.

## Scope

This does not force `sun.java2d.uiScale`, `GDK_SCALE`, or another fixed value. It enables Compose/Skiko's normal Linux auto-DPI initialization early enough to observe the actual desktop environment, including mixed-DPI setups.
