### PR TITLE
fix(packaging): support Debian 12 library names

### DIFF
--- a/changes/unreleased/417-debian-12-package-compatibility.md
+++ b/changes/unreleased/417-debian-12-package-compatibility.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 417
+pull: 419
+platforms: linux
+user-facing: yes
+
+Linux DEB packages now install on Debian 12 and Debian 13 by accepting the library package names available on either release.

--- a/tools/enrich-deb-appstream.sh
+++ b/tools/enrich-deb-appstream.sh
@@ -26,6 +26,15 @@ install -D -m 0644 "$metadata" \
     "$root/usr/share/metainfo/dev.obiente.nextcloudnative.metainfo.xml"
 install -D -m 0644 "$license" "$root/usr/share/doc/nextcloudnative/copyright"
 control="$root/DEBIAN/control"
+add_legacy_runtime_alternative() {
+    local current_package="$1"
+    local legacy_package="$2"
+    sed -i -E \
+        "/^Depends:/ s/(^Depends: |, )(${current_package}([[:space:]]*\\([^)]*\\))?)(,|$)/\\1\\2 | ${legacy_package}\\4/" \
+        "$control"
+}
+add_legacy_runtime_alternative libasound2t64 libasound2
+add_legacy_runtime_alternative libpng16-16t64 libpng16-16
 if ! grep -q '^Depends:' "$control"; then
     sed -i '/^Description:/i Depends: libsecret-tools' "$control"
 elif ! sed -n '/^Depends:/p' "$control" |
@@ -65,7 +74,20 @@ install -D -m 0644 "$icon" \
 )
 dpkg-deb --build --root-owner-group "$root" "$rebuilt"
 mv -- "$rebuilt" "${packages[0]}"
-dpkg-deb --field "${packages[0]}" Depends |
+dependencies="$(dpkg-deb --field "${packages[0]}" Depends)"
+printf '%s\n' "$dependencies" |
     tr ',' '\n' |
     sed 's/^[[:space:]]*//; s/[[:space:]]*$//' |
     grep -Eq '^libsecret-tools([[:space:](]|$)'
+verify_legacy_runtime_alternative() {
+    local current_package="$1"
+    local legacy_package="$2"
+    if grep -Eq "(^|,)[[:space:]]*${current_package}([[:space:](,]|$)" <<<"$dependencies"; then
+        tr ',' '\n' <<<"$dependencies" |
+            sed 's/^[[:space:]]*//; s/[[:space:]]*$//' |
+            grep -Eq \
+                "^${current_package}([[:space:]]*\\([^)]*\\))?[[:space:]]*\\|[[:space:]]*${legacy_package}$"
+    fi
+}
+verify_legacy_runtime_alternative libasound2t64 libasound2
+verify_legacy_runtime_alternative libpng16-16t64 libpng16-16

--- a/tools/test-linux-package-metadata.sh
+++ b/tools/test-linux-package-metadata.sh
@@ -93,6 +93,43 @@ assert "nightly-20260801-1830-run406-03ebaf9d" in " ".join(release.itertext())
 assert "verified" not in " ".join(release.itertext()).lower()
 PY
 
+deb_root="$temporary/deb-root"
+deb_directory="$temporary/deb-package"
+mkdir -p \
+  "$deb_root/DEBIAN" \
+  "$deb_root/opt/nextcloudnative/lib/app" \
+  "$deb_directory"
+cat >"$deb_root/DEBIAN/control" <<'EOF'
+Package: nextcloudnative
+Version: 1.0.2971
+Architecture: amd64
+Maintainer: Obiente
+Depends: libasound2t64, libc6, libpng16-16t64
+Description: Nextcloud Native test package
+EOF
+cat >"$deb_root/opt/nextcloudnative/lib/app/nextcloudnative-NextcloudNative.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=Nextcloud Native
+Comment=Test package
+Categories=Network;
+Icon=nextcloudnative-NextcloudNative
+Exec=/opt/nextcloudnative/bin/NextcloudNative
+EOF
+dpkg-deb --build --root-owner-group \
+  "$deb_root" "$deb_directory/nextcloudnative_1.0.2971_amd64.deb" >/dev/null
+bash "$project_root/tools/enrich-deb-appstream.sh" \
+  "$deb_directory" \
+  "$rendered_metadata" \
+  "$project_root/LICENSE" \
+  "$project_root/website/public/icon-512.png" >/dev/null
+deb_dependencies="$(
+  dpkg-deb --field "$deb_directory/nextcloudnative_1.0.2971_amd64.deb" Depends
+)"
+grep -Fq 'libasound2t64 | libasound2' <<<"$deb_dependencies"
+grep -Fq 'libpng16-16t64 | libpng16-16' <<<"$deb_dependencies"
+grep -Fq 'libsecret-tools' <<<"$deb_dependencies"
+
 printf '%s\n' \
   '#!/usr/bin/env bash' \
   'set -euo pipefail' \


### PR DESCRIPTION
## Outcome

- rewrite generated DEB dependencies as `libasound2t64 | libasound2`
- rewrite `libpng16-16t64` as `libpng16-16t64 | libpng16-16`
- preserve `libsecret-tools`
- add a package-building regression fixture that verifies all three dependency groups

The released binary uses stable runtime SONAMEs while Debian 12 and Debian 13 expose them under different package names. This keeps the Debian 13 dependencies preferred and lets Debian 12 systems select their available packages.

Refs #417

## Compatibility references

- https://packages.debian.org/bookworm/libasound2
- https://packages.debian.org/trixie/libasound2t64
- https://packages.debian.org/bookworm/libpng16-16
- https://packages.debian.org/trixie/libpng16-16t64

## Validation

- `bash tools/test-linux-package-metadata.sh`
- `bash tools/check-repository.sh`

Both completed successfully. The current nightly DEB was also rebuilt with the alternative dependency groups and its resulting control metadata was inspected.
