### PR TITLE
fix(offline): guard offline generations from stale workers

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineDownloadCompletion.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineDownloadCompletion.kt
@@ -1,0 +1,67 @@
+package dev.obiente.nextcloudnative
+
+import dev.obiente.nextcloudnative.app.FileOfflineJob
+import dev.obiente.nextcloudnative.app.FileOfflineJobOperation
+import dev.obiente.nextcloudnative.app.FileOfflineJobResult
+import dev.obiente.nextcloudnative.app.FileOfflineJobStatus
+import dev.obiente.nextcloudnative.app.FileOfflineKey
+import dev.obiente.nextcloudnative.app.FileOfflinePinRecord
+import dev.obiente.nextcloudnative.app.FileOfflineQueueState
+import dev.obiente.nextcloudnative.app.recordFileOfflineJobResult
+
+internal data class AndroidOfflineDownloadCommit(
+    val state: AndroidFileOfflinePersistedState,
+    val committed: Boolean,
+    val removableLocalRevisions: Set<String>,
+)
+
+/**
+ * Reconciles a published download with the authoritative queue generation. Only the exact running
+ * job may commit. Cleanup excludes every generation still owned by a record or pending job.
+ */
+internal fun commitAndroidFileOfflineDownload(
+    current: AndroidFileOfflinePersistedState,
+    startedJob: FileOfflineJob,
+    startedRecord: FileOfflinePinRecord,
+    downloadedLocalRevision: String,
+    remoteEtag: String,
+    nowEpochMillis: Long,
+): AndroidOfflineDownloadCommit {
+    require(startedJob.operation == FileOfflineJobOperation.Download)
+    require(startedJob.status == FileOfflineJobStatus.Running)
+    require(startedRecord.descriptor.key == startedJob.key)
+    require(downloadedLocalRevision.isNotBlank())
+    require(remoteEtag == startedJob.expectedRemoteEtag)
+    require(nowEpochMillis >= 0L)
+    val currentJob = current.queue.jobs.singleOrNull { it.id == startedJob.id }
+    val committed = currentJob == startedJob
+    val nextState = if (committed) {
+        current.copy(
+            queue = recordFileOfflineJobResult(
+                current.queue,
+                startedJob.id,
+                FileOfflineJobResult.Downloaded(downloadedLocalRevision, remoteEtag),
+                nowEpochMillis,
+            ),
+        )
+    } else {
+        current
+    }
+    val candidates = buildSet {
+        add(downloadedLocalRevision)
+        startedRecord.localRevision?.let(::add)
+    }
+    return AndroidOfflineDownloadCommit(
+        state = nextState,
+        committed = committed,
+        removableLocalRevisions = candidates - nextState.queue.retainedLocalRevisions(startedJob.key),
+    )
+}
+
+private fun FileOfflineQueueState.retainedLocalRevisions(key: FileOfflineKey): Set<String> = buildSet {
+    record(key)?.localRevision?.let(::add)
+    jobs.asSequence()
+        .filter { it.key == key }
+        .mapNotNull(FileOfflineJob::expectedLocalRevision)
+        .forEach(::add)
+}

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineRemoval.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineRemoval.kt
@@ -1,0 +1,50 @@
+package dev.obiente.nextcloudnative
+
+import dev.obiente.nextcloudnative.app.FileOfflineIntent
+import dev.obiente.nextcloudnative.app.FileOfflineJob
+import dev.obiente.nextcloudnative.app.FileOfflineJobOperation
+import dev.obiente.nextcloudnative.app.FileOfflineJobResult
+import dev.obiente.nextcloudnative.app.FileOfflineJobStatus
+import dev.obiente.nextcloudnative.app.recordFileOfflineJobResult
+
+internal data class AndroidOfflineRemovalCommit(
+    val state: AndroidFileOfflinePersistedState,
+    val outcome: AndroidOfflineExecutionOutcome,
+    val completedRemoval: Boolean,
+)
+
+/**
+ * Removes one offline generation only while the persisted removal intent still matches the worker
+ * claim. The caller must keep the queue lock held while this function and the following save run.
+ */
+internal fun commitAndroidFileOfflineRemoval(
+    current: AndroidFileOfflinePersistedState,
+    startedJob: FileOfflineJob,
+    nowEpochMillis: Long,
+    removeLocalGeneration: () -> Boolean,
+): AndroidOfflineRemovalCommit? {
+    require(startedJob.operation == FileOfflineJobOperation.RemoveLocal)
+    require(startedJob.status == FileOfflineJobStatus.Running)
+    require(nowEpochMillis >= 0L)
+    val currentJob = current.queue.jobs.singleOrNull { it.id == startedJob.id }
+    val currentRecord = current.queue.record(startedJob.key)
+    if (
+        currentJob != startedJob ||
+        currentRecord?.intent != FileOfflineIntent.OnlineOnly ||
+        currentRecord.localRevision != startedJob.expectedLocalRevision
+    ) {
+        return null
+    }
+    val completed = removeLocalGeneration()
+    val result = if (completed) {
+        FileOfflineJobResult.LocalRemoved
+    } else {
+        FileOfflineJobResult.RetryableFailure("Android could not remove the local copy yet.")
+    }
+    val nextQueue = recordFileOfflineJobResult(current.queue, startedJob.id, result, nowEpochMillis)
+    return AndroidOfflineRemovalCommit(
+        state = current.copy(queue = nextQueue),
+        outcome = if (completed) AndroidOfflineExecutionOutcome.Complete else AndroidOfflineExecutionOutcome.Retry,
+        completedRemoval = completed,
+    )
+}

--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineRepository.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineRepository.kt
@@ -494,15 +494,8 @@ internal class AndroidFileOfflineRepository(context: Context) {
                 val revision = "sha256:${digest.digest().toHex()}"
                 val destination = contentFile(job.key, revision)
                 publishGeneration(temporary, destination)
-                val committed = finish(
-                    job.id,
-                    FileOfflineJobResult.Downloaded(revision, expectedEtag),
-                )
+                val committed = commitDownloadedGeneration(started, revision, expectedEtag)
                 if (committed) notifyOfflineChanged(session, job.key.relativePath)
-                if (!committed && !generationIsReferenced(job.key, revision)) destination.delete()
-                started.record.localRevision
-                    ?.takeIf { it != revision }
-                    ?.let { contentFile(job.key, it).delete() }
                 AndroidOfflineExecutionOutcome.Complete
             } catch (failure: Throwable) {
                 temporary.delete()
@@ -560,13 +553,19 @@ internal class AndroidFileOfflineRepository(context: Context) {
         val job = started.job
         val revision = requireNotNull(job.expectedLocalRevision)
         val file = contentFile(job.key, revision)
-        if (file.exists() && !file.delete()) {
-            return retry(job.id, "Android could not remove the local copy yet.")
+        val committed = synchronized(STATE_LOCK) {
+            val current = store.load()
+            commitAndroidFileOfflineRemoval(
+                current = current,
+                startedJob = job,
+                nowEpochMillis = System.currentTimeMillis(),
+                removeLocalGeneration = { !file.exists() || file.delete() },
+            )?.also { store.save(it.state) }
         }
-        if (finish(job.id, FileOfflineJobResult.LocalRemoved)) {
+        if (committed?.completedRemoval == true) {
             notifyOfflineChanged(session, job.key.relativePath)
         }
-        return AndroidOfflineExecutionOutcome.Complete
+        return committed?.outcome ?: AndroidOfflineExecutionOutcome.Complete
     }
 
     private fun notifyOfflineChanged(session: NextcloudSession, path: String) {
@@ -607,8 +606,24 @@ internal class AndroidFileOfflineRepository(context: Context) {
         true
     }
 
-    private fun generationIsReferenced(key: FileOfflineKey, revision: String): Boolean = synchronized(STATE_LOCK) {
-        store.load().queue.record(key)?.localRevision == revision
+    private fun commitDownloadedGeneration(
+        started: StartedJob,
+        revision: String,
+        remoteEtag: String,
+    ): Boolean = synchronized(STATE_LOCK) {
+        val commit = commitAndroidFileOfflineDownload(
+            current = store.load(),
+            startedJob = started.job,
+            startedRecord = started.record,
+            downloadedLocalRevision = revision,
+            remoteEtag = remoteEtag,
+            nowEpochMillis = System.currentTimeMillis(),
+        )
+        if (commit.committed) store.save(commit.state)
+        commit.removableLocalRevisions.forEach { removableRevision ->
+            contentFile(started.job.key, removableRevision).delete()
+        }
+        commit.committed
     }
 
     private fun enqueue(job: FileOfflineJob, accountId: String, userId: String) {

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineDownloadCompletionTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineDownloadCompletionTest.kt
@@ -1,0 +1,187 @@
+package dev.obiente.nextcloudnative
+
+import dev.obiente.nextcloudnative.app.FileOfflineDescriptor
+import dev.obiente.nextcloudnative.app.FileOfflineJob
+import dev.obiente.nextcloudnative.app.FileOfflineJobResult
+import dev.obiente.nextcloudnative.app.FileOfflineJobStatus
+import dev.obiente.nextcloudnative.app.FileOfflineKey
+import dev.obiente.nextcloudnative.app.FileOfflinePinRecord
+import dev.obiente.nextcloudnative.app.FileOfflineQueueState
+import dev.obiente.nextcloudnative.app.FileOfflineRequest
+import dev.obiente.nextcloudnative.app.markFileOfflineJobRunning
+import dev.obiente.nextcloudnative.app.planFileOfflineRequest
+import dev.obiente.nextcloudnative.app.recordFileOfflineJobResult
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AndroidFileOfflineDownloadCompletionTest {
+    @Test
+    fun supersededDownloadKeepsGenerationOwnedByNewerRefresh() {
+        val started = startedRefresh(SECOND_ETAG)
+        val newerRefresh = planFileOfflineRequest(
+            started.state,
+            pin(THIRD_ETAG, OLD_REVISION),
+            nowEpochMillis = 40L,
+        )
+
+        val commit = commitAndroidFileOfflineDownload(
+            current = AndroidFileOfflinePersistedState(queue = newerRefresh),
+            startedJob = started.job,
+            startedRecord = started.record,
+            downloadedLocalRevision = SUPERSEDED_REVISION,
+            remoteEtag = SECOND_ETAG,
+            nowEpochMillis = 50L,
+        )
+
+        assertFalse(commit.committed)
+        assertEquals(newerRefresh, commit.state.queue)
+        assertEquals(setOf(SUPERSEDED_REVISION), commit.removableLocalRevisions)
+        assertEquals(OLD_REVISION, newerRefresh.records.single().localRevision)
+        assertEquals(OLD_REVISION, newerRefresh.jobs.single().expectedLocalRevision)
+    }
+
+    @Test
+    fun failedNewerRefreshStillRetainsPreviousGeneration() {
+        val started = startedRefresh(SECOND_ETAG)
+        val newerRefresh = planFileOfflineRequest(
+            started.state,
+            pin(THIRD_ETAG, OLD_REVISION),
+            nowEpochMillis = 40L,
+        )
+        val newerRunning = markFileOfflineJobRunning(
+            newerRefresh,
+            newerRefresh.jobs.single().id,
+            nowEpochMillis = 41L,
+        )
+        val newerFailed = recordFileOfflineJobResult(
+            newerRunning,
+            newerRunning.jobs.single().id,
+            FileOfflineJobResult.RetryableFailure("Network unavailable"),
+            nowEpochMillis = 42L,
+        )
+
+        val commit = commitAndroidFileOfflineDownload(
+            current = AndroidFileOfflinePersistedState(queue = newerFailed),
+            startedJob = started.job,
+            startedRecord = started.record,
+            downloadedLocalRevision = SUPERSEDED_REVISION,
+            remoteEtag = SECOND_ETAG,
+            nowEpochMillis = 50L,
+        )
+
+        assertFalse(commit.committed)
+        assertEquals(setOf(SUPERSEDED_REVISION), commit.removableLocalRevisions)
+        assertEquals(OLD_REVISION, commit.state.queue.records.single().localRevision)
+        assertEquals(FileOfflineJobStatus.WaitingForNetwork, commit.state.queue.jobs.single().status)
+        assertEquals(OLD_REVISION, commit.state.queue.jobs.single().expectedLocalRevision)
+    }
+
+    @Test
+    fun currentCompletionCleansOnlyTheSupersededGeneration() {
+        val started = startedRefresh(SECOND_ETAG)
+
+        val commit = commitAndroidFileOfflineDownload(
+            current = AndroidFileOfflinePersistedState(queue = started.state),
+            startedJob = started.job,
+            startedRecord = started.record,
+            downloadedLocalRevision = CURRENT_REVISION,
+            remoteEtag = SECOND_ETAG,
+            nowEpochMillis = 40L,
+        )
+
+        assertTrue(commit.committed)
+        assertEquals(setOf(OLD_REVISION), commit.removableLocalRevisions)
+        assertEquals(CURRENT_REVISION, commit.state.queue.records.single().localRevision)
+        assertTrue(commit.state.queue.jobs.isEmpty())
+    }
+
+    @Test
+    fun persistedNewerRefreshRetainsItsGenerationAfterRestart() = withStore { store ->
+        val started = startedRefresh(SECOND_ETAG)
+        val newerRefresh = planFileOfflineRequest(
+            started.state,
+            pin(THIRD_ETAG, OLD_REVISION),
+            nowEpochMillis = 40L,
+        )
+        store.save(AndroidFileOfflinePersistedState(queue = newerRefresh))
+
+        val commit = commitAndroidFileOfflineDownload(
+            current = store.load(),
+            startedJob = started.job,
+            startedRecord = started.record,
+            downloadedLocalRevision = SUPERSEDED_REVISION,
+            remoteEtag = SECOND_ETAG,
+            nowEpochMillis = 50L,
+        )
+
+        assertFalse(commit.committed)
+        assertEquals(setOf(SUPERSEDED_REVISION), commit.removableLocalRevisions)
+        assertEquals(OLD_REVISION, commit.state.queue.records.single().localRevision)
+        assertEquals(OLD_REVISION, commit.state.queue.jobs.single().expectedLocalRevision)
+    }
+
+    private fun startedRefresh(etag: String): StartedRefresh {
+        val available = availableState()
+        val refresh = planFileOfflineRequest(
+            available,
+            pin(etag, OLD_REVISION),
+            nowEpochMillis = 30L,
+        )
+        val running = markFileOfflineJobRunning(refresh, refresh.jobs.single().id, nowEpochMillis = 31L)
+        return StartedRefresh(running, running.jobs.single(), running.records.single())
+    }
+
+    private fun availableState(): FileOfflineQueueState {
+        val queued = planFileOfflineRequest(
+            FileOfflineQueueState(),
+            pin(FIRST_ETAG, observedLocalRevision = null),
+            nowEpochMillis = 10L,
+        )
+        return recordFileOfflineJobResult(
+            queued,
+            queued.jobs.single().id,
+            FileOfflineJobResult.Downloaded(OLD_REVISION, FIRST_ETAG),
+            nowEpochMillis = 20L,
+        )
+    }
+
+    private fun pin(etag: String, observedLocalRevision: String?) = FileOfflineRequest.Pin(
+        descriptor = FileOfflineDescriptor(
+            key = KEY,
+            displayName = "vault.md",
+            remoteEtag = etag,
+            size = 42L,
+            mimeType = "text/markdown",
+        ),
+        observedLocalRevision = observedLocalRevision,
+    )
+
+    private fun withStore(block: (AndroidFileOfflineQueueStore) -> Unit) {
+        val directory = Files.createTempDirectory("ncn-offline-download-completion-").toFile()
+        try {
+            block(AndroidFileOfflineQueueStore.forTesting(File(directory, "queue.bin")))
+        } finally {
+            directory.deleteRecursively()
+        }
+    }
+
+    private data class StartedRefresh(
+        val state: FileOfflineQueueState,
+        val job: FileOfflineJob,
+        val record: FileOfflinePinRecord,
+    )
+
+    private companion object {
+        val KEY = FileOfflineKey("account-a", "Notes/vault.md")
+        const val FIRST_ETAG = "\"remote-1\""
+        const val SECOND_ETAG = "\"remote-2\""
+        const val THIRD_ETAG = "\"remote-3\""
+        const val OLD_REVISION = "sha256:old-generation"
+        const val SUPERSEDED_REVISION = "sha256:superseded-generation"
+        const val CURRENT_REVISION = "sha256:current-generation"
+    }
+}

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineRemovalTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidFileOfflineRemovalTest.kt
@@ -1,0 +1,137 @@
+package dev.obiente.nextcloudnative
+
+import dev.obiente.nextcloudnative.app.FileOfflineDescriptor
+import dev.obiente.nextcloudnative.app.FileOfflineIntent
+import dev.obiente.nextcloudnative.app.FileOfflineJobResult
+import dev.obiente.nextcloudnative.app.FileOfflineJobStatus
+import dev.obiente.nextcloudnative.app.FileOfflineKey
+import dev.obiente.nextcloudnative.app.FileOfflineQueueState
+import dev.obiente.nextcloudnative.app.FileOfflineRequest
+import dev.obiente.nextcloudnative.app.markFileOfflineJobRunning
+import dev.obiente.nextcloudnative.app.planFileOfflineRequest
+import dev.obiente.nextcloudnative.app.recordFileOfflineJobResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AndroidFileOfflineRemovalTest {
+    @Test
+    fun staleRemovalCannotDeleteGenerationAfterUserPinsFileAgain() {
+        val available = availableState()
+        val removal = planFileOfflineRequest(
+            available,
+            FileOfflineRequest.Unpin(KEY, observedLocalRevision = LOCAL_REVISION),
+            nowEpochMillis = 30L,
+        )
+        val running = markFileOfflineJobRunning(removal, removal.jobs.single().id, nowEpochMillis = 31L)
+        val startedJob = running.jobs.single()
+        val repinned = planFileOfflineRequest(
+            running,
+            pin(observedLocalRevision = LOCAL_REVISION),
+            nowEpochMillis = 32L,
+        )
+        var generationDeleted = false
+
+        val commit = commitAndroidFileOfflineRemoval(
+            current = AndroidFileOfflinePersistedState(queue = repinned),
+            startedJob = startedJob,
+            nowEpochMillis = 33L,
+            removeLocalGeneration = {
+                generationDeleted = true
+                true
+            },
+        )
+
+        assertNull(commit)
+        assertFalse(generationDeleted)
+        assertEquals(FileOfflineIntent.Pinned, repinned.records.single().intent)
+        assertEquals(LOCAL_REVISION, repinned.records.single().localRevision)
+        assertTrue(repinned.jobs.isEmpty())
+    }
+
+    @Test
+    fun currentRemovalDeletesGenerationAndCommitsQueueStateTogether() {
+        val available = availableState()
+        val removal = planFileOfflineRequest(
+            available,
+            FileOfflineRequest.Unpin(KEY, observedLocalRevision = LOCAL_REVISION),
+            nowEpochMillis = 30L,
+        )
+        val running = markFileOfflineJobRunning(removal, removal.jobs.single().id, nowEpochMillis = 31L)
+        var generationDeleted = false
+
+        val commit = requireNotNull(
+            commitAndroidFileOfflineRemoval(
+                current = AndroidFileOfflinePersistedState(queue = running),
+                startedJob = running.jobs.single(),
+                nowEpochMillis = 32L,
+                removeLocalGeneration = {
+                    generationDeleted = true
+                    true
+                },
+            ),
+        )
+
+        assertTrue(generationDeleted)
+        assertTrue(commit.completedRemoval)
+        assertEquals(AndroidOfflineExecutionOutcome.Complete, commit.outcome)
+        assertTrue(commit.state.queue.records.isEmpty())
+        assertTrue(commit.state.queue.jobs.isEmpty())
+    }
+
+    @Test
+    fun failedDeletionKeepsGenerationAndLeavesRemovalRetryable() {
+        val available = availableState()
+        val removal = planFileOfflineRequest(
+            available,
+            FileOfflineRequest.Unpin(KEY, observedLocalRevision = LOCAL_REVISION),
+            nowEpochMillis = 30L,
+        )
+        val running = markFileOfflineJobRunning(removal, removal.jobs.single().id, nowEpochMillis = 31L)
+
+        val commit = requireNotNull(
+            commitAndroidFileOfflineRemoval(
+                current = AndroidFileOfflinePersistedState(queue = running),
+                startedJob = running.jobs.single(),
+                nowEpochMillis = 32L,
+                removeLocalGeneration = { false },
+            ),
+        )
+
+        assertFalse(commit.completedRemoval)
+        assertEquals(AndroidOfflineExecutionOutcome.Retry, commit.outcome)
+        assertEquals(FileOfflineIntent.OnlineOnly, commit.state.queue.records.single().intent)
+        assertEquals(LOCAL_REVISION, commit.state.queue.records.single().localRevision)
+        assertEquals(FileOfflineJobStatus.WaitingForNetwork, commit.state.queue.jobs.single().status)
+        assertEquals(LOCAL_REVISION, commit.state.queue.jobs.single().expectedLocalRevision)
+    }
+
+    private fun availableState(): FileOfflineQueueState {
+        val queued = planFileOfflineRequest(FileOfflineQueueState(), pin(), nowEpochMillis = 10L)
+        return recordFileOfflineJobResult(
+            queued,
+            queued.jobs.single().id,
+            FileOfflineJobResult.Downloaded(LOCAL_REVISION, REMOTE_ETAG),
+            nowEpochMillis = 20L,
+        )
+    }
+
+    private fun pin(observedLocalRevision: String? = null) = FileOfflineRequest.Pin(
+        descriptor = FileOfflineDescriptor(
+            key = KEY,
+            displayName = "vault.md",
+            remoteEtag = REMOTE_ETAG,
+            size = 42L,
+            mimeType = "text/markdown",
+        ),
+        observedLocalRevision = observedLocalRevision,
+    )
+
+    private companion object {
+        val KEY = FileOfflineKey("account-a", "Notes/vault.md")
+        const val LOCAL_REVISION = "sha256:local-generation"
+        const val REMOTE_ETAG = "\"remote-1\""
+    }
+}

--- a/changes/unreleased/116-android-offline-download-generation-retention.md
+++ b/changes/unreleased/116-android-offline-download-generation-retention.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 116
-pull: none
+pull: 427
 platforms: android
 user-facing: yes
 

--- a/changes/unreleased/116-android-offline-download-generation-retention.md
+++ b/changes/unreleased/116-android-offline-download-generation-retention.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 116
+pull: none
+platforms: android
+user-facing: yes
+
+Keep the last valid offline generation when an older download finishes after a newer refresh supersedes it.

--- a/changes/unreleased/116-android-offline-removal-intent-race.md
+++ b/changes/unreleased/116-android-offline-removal-intent-race.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 116
-pull: none
+pull: 427
 platforms: android
 user-facing: yes
 

--- a/changes/unreleased/116-android-offline-removal-intent-race.md
+++ b/changes/unreleased/116-android-offline-removal-intent-race.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 116
+pull: none
+platforms: android
+user-facing: yes
+
+Keep the last valid offline copy when older removal or download workers finish after the pin or refresh state changed.


### PR DESCRIPTION
## What changed

- revalidate the persisted removal job, current pin intent, and expected generation before deleting an offline file
- keep a newly repinned file when an older removal worker resumes
- prevent a superseded download from deleting the last valid generation used by a newer refresh
- persist the authoritative generation before deleting old unreferenced content
- keep physical deletion failures retryable

## Validation

- focused `AndroidFileOfflineRemovalTest`
- focused `AndroidFileOfflineDownloadCompletionTest`
- `bash tools/check-kotlin-architecture.sh`
- `bash tools/check-repository.sh`

## Limits

This protects the Android offline pin queue. Broader transfer checkpoints, upload recovery, conflict presentation, and cancellation recovery remain separate work.

Advances #116
