### PR TITLE
fix(sync): preserve upload checkpoint recovery evidence

### DIFF
--- a/changes/unreleased/113-upload-checkpoint-recovery.md
+++ b/changes/unreleased/113-upload-checkpoint-recovery.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 113
+pull: none
+platforms: android, desktop
+user-facing: yes
+
+Superseded resumable uploads now retain durable size, content hash, and publication state during cleanup, so an ambiguous server result cannot mistake an already published directory replacement for an abandoned stage.

--- a/changes/unreleased/113-upload-checkpoint-recovery.md
+++ b/changes/unreleased/113-upload-checkpoint-recovery.md
@@ -1,7 +1,7 @@
 category: fix
 issue: 113
 pull: 431
-platforms: android, desktop
+platforms: desktop
 user-facing: yes
 
 Superseded resumable uploads now retain durable size, content hash, and publication state during cleanup, so an ambiguous server result cannot mistake an already published directory replacement for an abandoned stage.

--- a/changes/unreleased/113-upload-checkpoint-recovery.md
+++ b/changes/unreleased/113-upload-checkpoint-recovery.md
@@ -1,6 +1,6 @@
 category: fix
 issue: 113
-pull: none
+pull: 431
 platforms: android, desktop
 user-facing: yes
 

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTypeReplacement.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncRemoteTypeReplacement.kt
@@ -143,7 +143,9 @@ internal fun DesktopFileSyncRemoteTree.reconcilePublishedReplacement(
     val expectedBackupEtag = ownedReplacementBackupEtags[uploadId] ?: return null
     val destination = resolvePhysical(relativePath, shouldContinue) ?: return null
     if (destination.isDirectory) return null
-    if (expectedSizeBytes == null || expectedContentHash == null) return false
+    // Older checkpoints predate durable size/hash evidence. Let the caller fall back to the
+    // recorded stage ETag so it can restore the protected directory without trusting the file.
+    if (expectedSizeBytes == null || expectedContentHash == null) return null
     if (destination.entry.size != expectedSizeBytes) {
         return discardReplacementBackup(relativePath, uploadId, assembledStageEtag = null, shouldContinue)
     }

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncUploadExecution.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncUploadExecution.kt
@@ -130,12 +130,20 @@ internal fun executeDesktopFileSyncUpload(
     val expectedDirectoryEtag = requireNotNull(expectedRemoteEtag)
     val transferPlan = nextcloudUploadTransferPlan(source.length())
     if (transferPlan is NextcloudUploadTransferPlan.Chunked) {
-        val recoveringPublication = checkpoint?.let {
-            it.commitInFlight && it.localRevision == exactLocal.revision && it.transferPlan == transferPlan
-        } == true
+        val matchingCheckpoint = checkpoint?.takeIf {
+            it.localRevision == exactLocal.revision && it.contentRevision == exactLocal.revision &&
+                it.contentHash == exactLocal.contentHash && it.transferPlan == transferPlan
+        }
+        if (checkpoint != null && matchingCheckpoint == null) {
+            check(
+                remote.resumableUploadRemote(shouldContinue, expectedDirectoryEtag)
+                    .discardCheckpointUpload(checkpoint, relativePath),
+            ) { "An unverified upload stage still requires recovery." }
+        }
+        val recoveringPublication = matchingCheckpoint?.commitInFlight == true
         if (!recoveringPublication) remote.requireDirectoryGeneration(relativePath, expectedDirectoryEtag)
         return resumeDesktopFileSyncUpload(
-            source, relativePath, exactLocal, expectedDirectoryEtag, checkpoint,
+            source, relativePath, exactLocal, expectedDirectoryEtag, matchingCheckpoint,
             persistCheckpoint, remote, shouldContinue,
             replacingDirectoryEtag = expectedDirectoryEtag,
         )

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncCleanupCancellationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncCleanupCancellationTest.kt
@@ -99,6 +99,7 @@ class DesktopFileSyncCleanupCancellationTest {
                         """.trimIndent(),
                     ).build(),
             )
+            server.enqueue(MockResponse.Builder().code(412).build())
             val directory = Files.createTempDirectory("desktop-sync-cleanup-block-").toFile()
             val localRoot = directory.resolve("local").apply { mkdirs() }
             val session = NextcloudSession(server.url("/").toString(), "alice", "secret")
@@ -134,7 +135,7 @@ class DesktopFileSyncCleanupCancellationTest {
 
                 assertIs<FileSyncCenterActionResult.Rejected>(result)
                 assertEquals(FileSyncRejectionScope.Preflight, result.scope)
-                assertEquals(2, server.requestCount)
+                assertEquals(3, server.requestCount)
                 assertEquals(listOf(cleanup), store.loadPair(pair.id).coordinator.pairs.single().pendingUploadCleanups)
             } finally {
                 directory.deleteRecursively()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncReplacementPublicationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncReplacementPublicationTest.kt
@@ -157,6 +157,46 @@ class DesktopFileSyncReplacementPublicationTest {
     }
 
     @Test
+    fun `legacy checkpoint restores its directory backup using the recorded stage etag`() {
+        val uploadId = "01234567-89ab-cdef-0123-456789abcdef"
+        val requests = mutableListOf<Request>()
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            requests += chain.request()
+            when (chain.request().method) {
+                "PROPFIND" -> response(chain.request(), 207, publishedListing(uploadId, sizeBytes = 5))
+                "DELETE" -> response(chain.request(), if (".upload" in chain.request().url.encodedPath) 404 else 204)
+                "MOVE" -> response(chain.request(), 201)
+                else -> error("Legacy recovery must not ${chain.request().method} either generation")
+            }
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            "alice",
+            "Vault",
+            client,
+            ownedUploadIds = setOf(uploadId),
+            ownedUploadPaths = mapOf(uploadId to "archive.bin"),
+            ownedReplacementBackupEtags = mapOf(uploadId to "directory-etag"),
+        )
+
+        val cleaned = tree.resumableUploadRemote(shouldContinue = { true }).discardOwnedUpload(
+            uploadId = uploadId,
+            relativePath = "archive.bin",
+            assembledStageEtag = "published-etag",
+            expectedStageSizeBytes = null,
+            expectedStageContentHash = null,
+            publicationInFlight = true,
+        )
+
+        assertTrue(cleaned)
+        assertTrue(requests.any { it.method == "DELETE" && it.url.encodedPath.endsWith("/archive.bin") })
+        val restore = requests.single { it.method == "MOVE" }
+        assertTrue(restore.url.encodedPath.endsWith(".nextcloud-native-backup-$uploadId"))
+        assertTrue(restore.header("Destination").orEmpty().endsWith("/archive.bin"))
+        assertTrue(requests.none { it.method == "GET" })
+    }
+
+    @Test
     fun `recovery scan traverses an owned backup at its physical path`() {
         val uploadId = "01234567-89ab-cdef-0123-456789abcdef"
         val requestedPaths = mutableListOf<String>()

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncReplacementPublicationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncReplacementPublicationTest.kt
@@ -1,8 +1,10 @@
 package dev.obiente.nextcloudnative.app
 
+import java.io.RandomAccessFile
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
@@ -183,6 +185,82 @@ class DesktopFileSyncReplacementPublicationTest {
         assertEquals(listOf("archive.bin", "archive.bin/kept.txt"), scanned.map { it.entry.relativePath })
         assertTrue(requestedPaths.last().endsWith(".nextcloud-native-backup-$uploadId"))
         assertTrue(requestedPaths.none { it.endsWith("/archive.bin") })
+    }
+
+    @Test
+    fun `superseded published replacement is reconciled before directory preflight`() {
+        val uploadId = "01234567-89ab-cdef-0123-456789abcdef"
+        val oldPayload = ByteArray(21 * 1024 * 1024) { 1 }
+        val oldHash = hashExactJvmFileSyncContent(oldPayload.inputStream(), oldPayload.size.toLong())
+        val requests = mutableListOf<Request>()
+        val client = OkHttpClient.Builder().addInterceptor { chain ->
+            requests += chain.request()
+            when (chain.request().method) {
+                "GET" -> response(chain.request(), 200, oldPayload)
+                "PROPFIND" -> response(chain.request(), 207, publishedListing(uploadId, oldPayload.size.toLong()))
+                "DELETE" -> response(chain.request(), 204)
+                else -> error("Superseded recovery must not ${chain.request().method} a new upload")
+            }
+        }.build()
+        val tree = DesktopFileSyncRemoteTree(
+            NextcloudSession("https://cloud.example.test", "alice", "secret"),
+            "alice",
+            "Vault",
+            client,
+            ownedUploadIds = setOf(uploadId),
+            ownedStageEtags = mapOf(uploadId to "stage-etag"),
+            ownedUploadPaths = mapOf(uploadId to "archive.bin"),
+            ownedReplacementBackupEtags = mapOf(uploadId to "directory-etag"),
+        )
+        val source = Files.createTempFile("nextcloud-sync-superseded-replacement", ".tmp").toFile()
+        RandomAccessFile(source, "rw").use { it.setLength(oldPayload.size.toLong()) }
+        val newHash = source.inputStream().buffered().use { input ->
+            hashExactJvmFileSyncContent(input, source.length())
+        }
+        val plan = nextcloudUploadTransferPlan(source.length()) as NextcloudUploadTransferPlan.Chunked
+        val checkpoint = newFileSyncUploadCheckpoint(
+            uploadId,
+            "local-1",
+            plan,
+            contentHash = oldHash,
+        ).copy(
+            uploadedChunks = plan.chunkCount,
+            commitInFlight = true,
+            assembledStageEtag = "stage-etag",
+        )
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                executeDesktopFileSyncUpload(
+                    source = source,
+                    relativePath = "archive.bin",
+                    exactLocal = LocalSyncEntry(
+                        "archive.bin",
+                        SyncEntryKind.File,
+                        "local-2",
+                        source.length(),
+                        contentHash = newHash,
+                    ),
+                    expectedRemoteEtag = "directory-etag",
+                    checkpoint = checkpoint,
+                    replacingType = true,
+                    persistCheckpoint = {},
+                    retainCleanup = {},
+                    completeCleanup = {},
+                    remote = tree,
+                    shouldContinue = { true },
+                )
+            }
+
+            assertEquals(
+                listOf("DELETE", "PROPFIND", "GET", "PROPFIND", "PROPFIND", "DELETE", "PROPFIND"),
+                requests.map { it.method },
+            )
+            assertTrue(requests.none { it.method == "PUT" || it.method == "MOVE" })
+            assertTrue(requests[5].url.encodedPath.endsWith(".nextcloud-native-backup-$uploadId"))
+            assertTrue(requests.last().url.encodedPath.endsWith("/archive.bin"))
+        } finally {
+            assertTrue(source.delete())
+        }
     }
 
     private fun stagedListing(uploadId: String?, sizeBytes: Long): String =

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncReplacementPublicationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncReplacementPublicationTest.kt
@@ -257,7 +257,7 @@ class DesktopFileSyncReplacementPublicationTest {
             )
             assertTrue(requests.none { it.method == "PUT" || it.method == "MOVE" })
             assertTrue(requests[5].url.encodedPath.endsWith(".nextcloud-native-backup-$uploadId"))
-            assertTrue(requests.last().url.encodedPath.endsWith("/archive.bin"))
+            assertEquals(requests[1].url.encodedPath, requests.last().url.encodedPath)
         } finally {
             assertTrue(source.delete())
         }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmResumableNextcloudUploadTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmResumableNextcloudUploadTest.kt
@@ -131,6 +131,130 @@ class JvmResumableNextcloudUploadTest {
     }
 
     @Test
+    fun `superseded ambiguous publication is reconciled with its durable generation evidence`() {
+        val source = sparseFile(25L * 1024L * 1024L)
+        val plan = nextcloudUploadTransferPlan(source.length()) as NextcloudUploadTransferPlan.Chunked
+        val oldHash = "sha256:" + "11".repeat(32)
+        val checkpoint = newFileSyncUploadCheckpoint(
+            UPLOAD_ID,
+            "local-1",
+            plan,
+            contentRevision = "content-1",
+            contentHash = oldHash,
+        ).copy(
+            uploadedChunks = plan.chunkCount,
+            commitInFlight = true,
+            assembledStageEtag = "published-stage",
+        )
+        val remote = RecordingUploadRemote(collectionCreated = true)
+        val persisted = mutableListOf<FileSyncUploadCheckpoint>()
+        try {
+            jvmResumableNextcloudUpload(
+                source, "archive.bin", "local-2", "directory-etag", checkpoint,
+                newUploadId = { "fedcba98-7654-3210-fedc-ba9876543210" },
+                persistCheckpoint = persisted::add,
+                remote = remote,
+                contentRevision = "content-2",
+                contentHash = "sha256:" + "22".repeat(32),
+            )
+
+            assertEquals(
+                listOf(
+                    DiscardedUpload(
+                        assembledStageEtag = "published-stage",
+                        expectedStageSizeBytes = checkpoint.sizeBytes,
+                        expectedStageContentHash = oldHash,
+                        publicationInFlight = true,
+                    ),
+                ),
+                remote.discardedUploads,
+            )
+            assertEquals("fedcba98-7654-3210-fedc-ba9876543210", persisted.first().uploadId)
+        } finally {
+            source.delete()
+        }
+    }
+
+    @Test
+    fun `superseded ambiguous assembly is discarded only with its durable content evidence`() {
+        val source = sparseFile(25L * 1024L * 1024L)
+        val plan = nextcloudUploadTransferPlan(source.length()) as NextcloudUploadTransferPlan.Chunked
+        val oldHash = "sha256:" + "33".repeat(32)
+        val checkpoint = newFileSyncUploadCheckpoint(
+            UPLOAD_ID,
+            "local-1",
+            plan,
+            contentHash = oldHash,
+        ).copy(
+            uploadedChunks = plan.chunkCount,
+            commitInFlight = true,
+        )
+        val remote = RecordingUploadRemote(collectionCreated = true)
+        try {
+            jvmResumableNextcloudUpload(
+                source, "large.bin", "local-2", null, checkpoint,
+                newUploadId = { "fedcba98-7654-3210-fedc-ba9876543210" },
+                persistCheckpoint = {},
+                remote = remote,
+                contentHash = "sha256:" + "44".repeat(32),
+            )
+
+            assertEquals(
+                listOf(
+                    DiscardedUpload(
+                        assembledStageEtag = null,
+                        expectedStageSizeBytes = checkpoint.sizeBytes,
+                        expectedStageContentHash = oldHash,
+                        publicationInFlight = false,
+                    ),
+                ),
+                remote.discardedUploads,
+            )
+        } finally {
+            source.delete()
+        }
+    }
+
+    @Test
+    fun `failed superseded checkpoint cleanup blocks a replacement upload`() {
+        val source = sparseFile(25L * 1024L * 1024L)
+        val plan = nextcloudUploadTransferPlan(source.length()) as NextcloudUploadTransferPlan.Chunked
+        val checkpoint = newFileSyncUploadCheckpoint(
+            UPLOAD_ID,
+            "local-1",
+            plan,
+            contentHash = "sha256:" + "55".repeat(32),
+        ).copy(
+            uploadedChunks = plan.chunkCount,
+            commitInFlight = true,
+        )
+        val remote = RecordingUploadRemote(collectionCreated = true, cleanupComplete = false)
+        var allocatedReplacement = false
+        val persisted = mutableListOf<FileSyncUploadCheckpoint>()
+        try {
+            assertFailsWith<IllegalStateException> {
+                jvmResumableNextcloudUpload(
+                    source, "large.bin", "local-2", null, checkpoint,
+                    newUploadId = {
+                        allocatedReplacement = true
+                        "fedcba98-7654-3210-fedc-ba9876543210"
+                    },
+                    persistCheckpoint = persisted::add,
+                    remote = remote,
+                    contentHash = "sha256:" + "66".repeat(32),
+                )
+            }
+
+            assertFalse(allocatedReplacement)
+            assertTrue(persisted.isEmpty())
+            assertTrue(remote.uploadedChunkNumbers.isEmpty())
+            assertEquals(1, remote.discardedUploads.size)
+        } finally {
+            source.delete()
+        }
+    }
+
+    @Test
     fun `expired collection resets progress before any bytes are skipped`() {
         val source = sparseFile(25L * 1024L * 1024L)
         val plan = nextcloudUploadTransferPlan(source.length()) as NextcloudUploadTransferPlan.Chunked
@@ -480,6 +604,7 @@ class JvmResumableNextcloudUploadTest {
     ) : JvmResumableNextcloudUploadRemote {
         val uploadedChunkNumbers = mutableListOf<Int>()
         val discardedStageEtags = mutableListOf<String?>()
+        val discardedUploads = mutableListOf<DiscardedUpload>()
         val finalizationEvents = mutableListOf<String>()
         var discardCount = 0
         var resolvePublishedCount = 0
@@ -589,9 +714,22 @@ class JvmResumableNextcloudUploadTest {
         ): Boolean {
             discardCount += 1
             discardedStageEtags += assembledStageEtag
+            discardedUploads += DiscardedUpload(
+                assembledStageEtag,
+                expectedStageSizeBytes,
+                expectedStageContentHash,
+                publicationInFlight,
+            )
             return cleanupComplete
         }
     }
+
+    private data class DiscardedUpload(
+        val assembledStageEtag: String?,
+        val expectedStageSizeBytes: Long?,
+        val expectedStageContentHash: String?,
+        val publicationInFlight: Boolean,
+    )
 
     private companion object {
         const val UPLOAD_ID = "01234567-89ab-cdef-0123-456789abcdef"

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt
@@ -2219,7 +2219,9 @@ class JvmSupportIntakeTest {
             val submission = launch(Dispatchers.Default) {
                 fixture.intake.submit("A refresh failed.", "nightly", emptyList())
             }
-            val upload = requireNotNull(fixture.server.takeRequest(2, TimeUnit.SECONDS))
+            val upload = requireNotNull(
+                fixture.server.takeRequest(WINDOWS_REQUEST_START_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+            )
             assertTrue(fixture.intake.cancel())
             submission.join()
 

--- a/ui/src/jvmMain/kotlin/dev/obiente/nextcloudnative/app/JvmResumableNextcloudUpload.kt
+++ b/ui/src/jvmMain/kotlin/dev/obiente/nextcloudnative/app/JvmResumableNextcloudUpload.kt
@@ -161,6 +161,18 @@ fun cleanupJvmFileSyncOwnedUploads(
     return JvmFileSyncUploadCleanupResult(updated, unresolved)
 }
 
+private fun JvmResumableNextcloudUploadRemote.discardCheckpointUpload(
+    checkpoint: FileSyncUploadCheckpoint,
+    relativePath: String,
+): Boolean = discardOwnedUpload(
+    uploadId = checkpoint.uploadId,
+    relativePath = relativePath,
+    assembledStageEtag = checkpoint.assembledStageEtag,
+    expectedStageSizeBytes = checkpoint.contentHash?.let { checkpoint.sizeBytes },
+    expectedStageContentHash = checkpoint.contentHash,
+    publicationInFlight = checkpoint.commitInFlight && checkpoint.assembledStageEtag != null,
+)
+
 /**
  * Runs the same crash-safe chunk state machine for every JVM platform.
  *
@@ -253,7 +265,7 @@ fun jvmResumableNextcloudUpload(
     }
     if (plan is NextcloudUploadTransferPlan.Direct) {
         checkpoint?.let {
-            check(remote.discardOwnedUpload(it.uploadId, relativePath, it.assembledStageEtag)) {
+            check(remote.discardCheckpointUpload(it, relativePath)) {
                 "An unverified upload stage still requires recovery."
             }
         }
@@ -270,7 +282,7 @@ fun jvmResumableNextcloudUpload(
 
     val resumable = matchingCheckpoint?.takeIf { !it.commitInFlight }
     if (checkpoint != null && resumable == null) {
-        check(remote.discardOwnedUpload(checkpoint.uploadId, relativePath, checkpoint.assembledStageEtag)) {
+        check(remote.discardCheckpointUpload(checkpoint, relativePath)) {
             "An unverified upload stage still requires recovery."
         }
     }

--- a/ui/src/jvmMain/kotlin/dev/obiente/nextcloudnative/app/JvmResumableNextcloudUpload.kt
+++ b/ui/src/jvmMain/kotlin/dev/obiente/nextcloudnative/app/JvmResumableNextcloudUpload.kt
@@ -161,7 +161,7 @@ fun cleanupJvmFileSyncOwnedUploads(
     return JvmFileSyncUploadCleanupResult(updated, unresolved)
 }
 
-private fun JvmResumableNextcloudUploadRemote.discardCheckpointUpload(
+internal fun JvmResumableNextcloudUploadRemote.discardCheckpointUpload(
     checkpoint: FileSyncUploadCheckpoint,
     relativePath: String,
 ): Boolean = discardOwnedUpload(


### PR DESCRIPTION
## Summary

- carry a superseded upload checkpoint's recorded stage ETag into cleanup
- use the checkpoint's durable size and content hash to reconcile an unrecorded assembled stage
- preserve publication-in-flight state so cleanup cannot mistake an already published directory replacement for an abandoned upload
- refuse to allocate a replacement upload while the previous generation remains unresolved

Advances #113.

## Validation

- focused `JvmResumableNextcloudUploadTest` on the dedicated build host
- Android debug Kotlin compilation on the dedicated build host
- Kotlin architecture checks
- full repository hygiene checks

## Limits

- this slice hardens superseded checkpoint cleanup; it does not add the remaining Android download-publication recovery work
- no live Nextcloud end-to-end run was performed
