### PR TITLE
fix(android): preserve durable upload recovery

### DIFF
--- a/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidDurableMultipartUploads.kt
+++ b/androidApp/src/main/kotlin/dev/obiente/nextcloudnative/AndroidDurableMultipartUploads.kt
@@ -341,11 +341,16 @@ internal data class AndroidDurableUploadResource(
 }
 
 internal class AndroidDurableMultipartUploadStore(
-    context: Context,
-    preferenceName: String = PREFERENCES,
+    private val storage: AndroidDurableMultipartUploadEncryptedStorage,
+    private val cipher: AndroidDurableMultipartUploadCipher,
 ) {
-    private val preferences = context.applicationContext.getSharedPreferences(preferenceName, Context.MODE_PRIVATE)
-    private val cipher = SessionCipher()
+    constructor(
+        context: Context,
+        preferenceName: String = PREFERENCES,
+    ) : this(
+        storage = SharedPreferencesDurableMultipartUploadStorage(context, preferenceName),
+        cipher = SessionDurableMultipartUploadCipher(),
+    )
 
     fun add(job: AndroidDurableMultipartUploadJob) = synchronized(LOCK) {
         val current = readAll().toMutableList()
@@ -399,27 +404,44 @@ internal class AndroidDurableMultipartUploadStore(
     }
 
     private fun readAll(): List<AndroidDurableMultipartUploadJob> {
-        val encrypted = preferences.getString(KEY_JOBS, null) ?: return emptyList()
-        return runCatching {
+        val encrypted = try {
+            storage.read()
+        } catch (failure: Exception) {
+            throw AndroidDurableMultipartUploadRecoveryException(failure)
+        } ?: return emptyList()
+        return try {
             val array = JSONArray(cipher.decrypt(encrypted))
-            buildList {
-                repeat(array.length().coerceAtMost(MAX_STORED_UPLOADS)) { index ->
-                    runCatching { array.getJSONObject(index).toJob() }
-                        .getOrNull()
-                        ?.let(::add)
+            check(array.length() <= MAX_STORED_UPLOADS) {
+                "The durable upload queue contains too many rows."
+            }
+            val jobs = buildList {
+                repeat(array.length()) { index ->
+                    add(array.getJSONObject(index).toJob())
                 }
-            }.distinctBy(AndroidDurableMultipartUploadJob::id)
-        }.getOrElse { emptyList() }
+            }
+            check(jobs.distinctBy(AndroidDurableMultipartUploadJob::id).size == jobs.size) {
+                "The durable upload queue contains duplicate rows."
+            }
+            jobs
+        } catch (failure: Exception) {
+            throw AndroidDurableMultipartUploadRecoveryException(failure)
+        }
     }
 
     private fun writeAll(jobs: List<AndroidDurableMultipartUploadJob>) {
         val array = JSONArray()
         jobs.forEach { array.put(it.toJson()) }
-        check(
-            preferences.edit()
-                .putString(KEY_JOBS, cipher.encrypt(array.toString()))
-                .commit(),
-        ) { "The durable upload queue could not be saved." }
+        val encrypted = try {
+            cipher.encrypt(array.toString())
+        } catch (failure: Exception) {
+            throw IllegalStateException("The durable upload queue could not be saved.", failure)
+        }
+        val saved = try {
+            storage.write(encrypted)
+        } catch (failure: Exception) {
+            throw IllegalStateException("The durable upload queue could not be saved.", failure)
+        }
+        check(saved) { "The durable upload queue could not be saved." }
     }
 
     internal companion object {
@@ -431,6 +453,44 @@ internal class AndroidDurableMultipartUploadStore(
         const val MAX_ACTIVE_UPLOADS_PER_RESOURCE = 4
         const val MAX_STORED_UPLOADS = 64
     }
+}
+
+internal interface AndroidDurableMultipartUploadEncryptedStorage {
+    fun read(): String?
+    fun write(value: String): Boolean
+}
+
+internal interface AndroidDurableMultipartUploadCipher {
+    fun encrypt(value: String): String
+    fun decrypt(value: String): String
+}
+
+internal class AndroidDurableMultipartUploadRecoveryException(
+    cause: Exception,
+) : IllegalStateException(
+    "The saved background upload queue is unavailable. Its recovery data was left unchanged.",
+    cause,
+)
+
+private class SharedPreferencesDurableMultipartUploadStorage(
+    context: Context,
+    preferenceName: String,
+) : AndroidDurableMultipartUploadEncryptedStorage {
+    private val preferences = context.applicationContext.getSharedPreferences(preferenceName, Context.MODE_PRIVATE)
+
+    override fun read(): String? = preferences.getString(AndroidDurableMultipartUploadStore.KEY_JOBS, null)
+
+    override fun write(value: String): Boolean = preferences.edit()
+        .putString(AndroidDurableMultipartUploadStore.KEY_JOBS, value)
+        .commit()
+}
+
+private class SessionDurableMultipartUploadCipher : AndroidDurableMultipartUploadCipher {
+    private val cipher = SessionCipher()
+
+    override fun encrypt(value: String): String = cipher.encrypt(value)
+
+    override fun decrypt(value: String): String = cipher.decrypt(value)
 }
 
 internal fun requireCanAddDurableUpload(

--- a/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidDurableMultipartUploadPolicyTest.kt
+++ b/androidApp/src/test/kotlin/dev/obiente/nextcloudnative/AndroidDurableMultipartUploadPolicyTest.kt
@@ -6,13 +6,134 @@ import dev.obiente.nextcloudnative.app.NextcloudApiMethod
 import dev.obiente.nextcloudnative.app.NextcloudMultipartUploadRequest
 import dev.obiente.nextcloudnative.app.afterProcessRecovery
 import dev.obiente.nextcloudnative.app.localUploadFile
+import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.json.JSONArray
 
 class AndroidDurableMultipartUploadPolicyTest {
+    @Test
+    fun `encrypted queue read and decryption failures preserve recoverable jobs`() {
+        listOf("read", "decrypt").forEach { failureMode ->
+            val storage = FakeDurableUploadEncryptedStorage()
+            val cipher = FakeDurableUploadCipher()
+            val recoverable = fixtureJob(index = 1, account = ACCOUNT_A, cardId = 42)
+            AndroidDurableMultipartUploadStore(storage, cipher).add(recoverable)
+            val encryptedBeforeFailure = storage.value
+            if (failureMode == "read") storage.readFailure = IOException("synthetic read failure")
+            if (failureMode == "decrypt") cipher.decryptFailure = IOException("synthetic decrypt failure")
+
+            val restarted = AndroidDurableMultipartUploadStore(storage, cipher)
+            assertFailsWith<AndroidDurableMultipartUploadRecoveryException> { restarted.list() }
+            assertFailsWith<AndroidDurableMultipartUploadRecoveryException> {
+                restarted.add(fixtureJob(index = 2, account = ACCOUNT_A, cardId = 43))
+            }
+            assertEquals(encryptedBeforeFailure, storage.value)
+
+            storage.readFailure = null
+            cipher.decryptFailure = null
+            assertEquals(listOf(recoverable), AndroidDurableMultipartUploadStore(storage, cipher).list())
+        }
+    }
+
+    @Test
+    fun `corrupt encrypted queue is never replaced by a later write`() {
+        val storage = FakeDurableUploadEncryptedStorage(value = "not-json")
+        val cipher = FakeDurableUploadCipher()
+        val restarted = AndroidDurableMultipartUploadStore(storage, cipher)
+
+        assertFailsWith<AndroidDurableMultipartUploadRecoveryException> { restarted.list() }
+        assertFailsWith<AndroidDurableMultipartUploadRecoveryException> {
+            restarted.add(fixtureJob(index = 1, account = ACCOUNT_A, cardId = 42))
+        }
+
+        assertEquals("not-json", storage.value)
+    }
+
+    @Test
+    fun `one malformed row blocks queue rewrites without dropping valid rows`() {
+        val storage = FakeDurableUploadEncryptedStorage()
+        val cipher = FakeDurableUploadCipher()
+        val first = fixtureJob(index = 1, account = ACCOUNT_A, cardId = 42)
+        val second = fixtureJob(index = 2, account = ACCOUNT_A, cardId = 43)
+        AndroidDurableMultipartUploadStore(storage, cipher).apply {
+            add(first)
+            add(second)
+        }
+        val validSnapshot = requireNotNull(storage.value)
+        val malformed = JSONArray(validSnapshot).also { array ->
+            array.getJSONObject(1).remove("relativePath")
+        }.toString()
+        storage.value = malformed
+        val restarted = AndroidDurableMultipartUploadStore(storage, cipher)
+
+        assertFailsWith<AndroidDurableMultipartUploadRecoveryException> { restarted.list() }
+        assertFailsWith<AndroidDurableMultipartUploadRecoveryException> { restarted.remove(first.id) }
+        assertFailsWith<AndroidDurableMultipartUploadRecoveryException> {
+            restarted.transition(
+                first.id,
+                DurableUploadState.Queued,
+                DurableUploadState.Uploading,
+                null,
+            )
+        }
+        assertEquals(malformed, storage.value)
+
+        storage.value = validSnapshot
+        assertEquals(listOf(first, second), AndroidDurableMultipartUploadStore(storage, cipher).list())
+    }
+
+    @Test
+    fun `failed queue write leaves the previous restart snapshot readable`() {
+        val storage = FakeDurableUploadEncryptedStorage()
+        val cipher = FakeDurableUploadCipher()
+        val first = fixtureJob(index = 1, account = ACCOUNT_A, cardId = 42)
+        val second = fixtureJob(index = 2, account = ACCOUNT_A, cardId = 43)
+        AndroidDurableMultipartUploadStore(storage, cipher).add(first)
+        val snapshotBeforeWrite = storage.value
+        storage.failWrites = true
+
+        assertFailsWith<IllegalStateException> {
+            AndroidDurableMultipartUploadStore(storage, cipher).add(second)
+        }
+
+        assertEquals(snapshotBeforeWrite, storage.value)
+        storage.failWrites = false
+        assertEquals(listOf(first), AndroidDurableMultipartUploadStore(storage, cipher).list())
+    }
+
+    @Test
+    fun `duplicate and oversized queue snapshots block rewrites`() {
+        val storage = FakeDurableUploadEncryptedStorage()
+        val cipher = FakeDurableUploadCipher()
+        AndroidDurableMultipartUploadStore(storage, cipher).add(
+            fixtureJob(index = 1, account = ACCOUNT_A, cardId = 42),
+        )
+        val storedRow = JSONArray(requireNotNull(storage.value)).getJSONObject(0)
+        val invalidSnapshots = listOf(
+            JSONArray().put(storedRow).put(storedRow).toString(),
+            JSONArray().also { array ->
+                repeat(AndroidDurableMultipartUploadStore.MAX_STORED_UPLOADS + 1) {
+                    array.put(storedRow)
+                }
+            }.toString(),
+        )
+
+        invalidSnapshots.forEach { invalidSnapshot ->
+            storage.value = invalidSnapshot
+            val restarted = AndroidDurableMultipartUploadStore(storage, cipher)
+
+            assertFailsWith<AndroidDurableMultipartUploadRecoveryException> { restarted.list() }
+            assertFailsWith<AndroidDurableMultipartUploadRecoveryException> {
+                restarted.add(fixtureJob(index = 2, account = ACCOUNT_A, cardId = 43))
+            }
+            assertEquals(invalidSnapshot, storage.value)
+        }
+    }
+
     @Test
     fun `deck attachment resource binds board stack card and request path`() {
         val scope = DurableUploadScope("deck-attachment", "42")
@@ -188,5 +309,34 @@ class AndroidDurableMultipartUploadPolicyTest {
     private companion object {
         const val ACCOUNT_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         const val ACCOUNT_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    }
+}
+
+private class FakeDurableUploadEncryptedStorage(
+    var value: String? = null,
+) : AndroidDurableMultipartUploadEncryptedStorage {
+    var readFailure: IOException? = null
+    var failWrites: Boolean = false
+
+    override fun read(): String? {
+        readFailure?.let { throw it }
+        return value
+    }
+
+    override fun write(value: String): Boolean {
+        if (failWrites) return false
+        this.value = value
+        return true
+    }
+}
+
+private class FakeDurableUploadCipher : AndroidDurableMultipartUploadCipher {
+    var decryptFailure: IOException? = null
+
+    override fun encrypt(value: String): String = value
+
+    override fun decrypt(value: String): String {
+        decryptFailure?.let { throw it }
+        return value
     }
 }

--- a/changes/unreleased/440-durable-multipart-store-recovery.md
+++ b/changes/unreleased/440-durable-multipart-store-recovery.md
@@ -1,0 +1,7 @@
+category: fix
+issue: none
+pull: 440
+platforms: android
+user-facing: yes
+
+Keep queued background uploads intact when their encrypted recovery data cannot be decoded, instead of replacing the queue during a later update.


### PR DESCRIPTION
## Summary

- fail closed when the encrypted durable upload queue cannot be read or decrypted
- reject malformed, oversized, or duplicate rows as one recovery snapshot
- prevent add, remove, and transition writes from replacing undecodable recovery data

## Validation

- AndroidDurableMultipartUploadPolicyTest
- :androidApp:assembleDebug
- bash tools/check-repository.sh

## Evidence boundary

The deterministic tests use an injected in-memory encrypted store and cipher. Android assembly proves the SharedPreferences and AndroidKeyStore adapters compile, but this pass does not corrupt a live device keystore or execute a real background upload.