### PR TITLE
fix(desktop): preserve unreadable Deck drafts

### DIFF
--- a/changes/unreleased/desktop-deck-draft-recovery.md
+++ b/changes/unreleased/desktop-deck-draft-recovery.md
@@ -1,6 +1,6 @@
 category: fix
 issue: none
-pull: none
+pull: 443
 platforms: desktop
 user-facing: yes
 

--- a/changes/unreleased/desktop-deck-draft-recovery.md
+++ b/changes/unreleased/desktop-deck-draft-recovery.md
@@ -1,0 +1,7 @@
+category: fix
+issue: none
+pull: none
+platforms: desktop
+user-facing: yes
+
+Preserve encrypted Deck card drafts when desktop secure storage is temporarily unavailable.

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
@@ -295,9 +295,7 @@ internal class DesktopDeckCardDraftStore(
                 false
             }
         }
-        check(readableFiles >= overflow) {
-            "A new Deck draft cannot be saved while unreadable drafts fill the recovery limit."
-        }
+        if (readableFiles < overflow) throw DeckCardDraftCapacityException()
     }
 
     private fun ensurePrivateDirectory() {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
@@ -51,6 +51,8 @@ internal class DesktopDeckCardDraftStore(
         val encryptionKey = keyProvider.encryptionKey()
         if (file.exists()) {
             readAuthenticated(file, encryptionKey, persisted.key)
+        } else {
+            ensureCapacityForNewDraft(encryptionKey)
         }
         val plaintext = encodePlaintext(persisted, updatedAtEpochMillis)
         require(plaintext.size <= MAX_PLAINTEXT_BYTES) { "The Deck card draft is too large." }
@@ -67,11 +69,18 @@ internal class DesktopDeckCardDraftStore(
     }
 
     @Synchronized
-    fun clear(session: NextcloudSession, key: DeckCardDraftKey) {
+    fun clear(
+        session: NextcloudSession,
+        key: DeckCardDraftKey,
+        discardUnreadable: Boolean = false,
+    ) {
         val file = draftFile(session, key)
-        if (file.exists()) {
+        if (file.exists() && !discardUnreadable) {
             val encryptionKey = keyProvider.encryptionKey()
             readAuthenticated(file, encryptionKey, key)
+        }
+        check(!Files.isSymbolicLink(root.toPath())) {
+            "Desktop Deck draft storage must not be a symbolic link."
         }
         check(deleteFile(file) && deleteFile(quarantineFile(file))) {
             "The Deck card draft could not be cleared."
@@ -263,9 +272,28 @@ internal class DesktopDeckCardDraftStore(
         }
         val namesToPrune = DeckCardDraftRetention.keysToPrune(
             entries = entries,
-            maximumEntries = DeckCardDraftRetention.MAX_ENTRIES,
+            maximumEntries = (DeckCardDraftRetention.MAX_ENTRIES - (files.size - entries.size))
+                .coerceAtLeast(0),
         )
         files.filter { it.name in namesToPrune }.forEach(::deleteDraft)
+    }
+
+    private fun ensureCapacityForNewDraft(encryptionKey: ByteArray) {
+        val files = root.listFiles().orEmpty()
+            .filter { it.name.matches(DRAFT_FILE_PATTERN) }
+        val overflow = files.size + 1 - DeckCardDraftRetention.MAX_ENTRIES
+        if (overflow <= 0) return
+        val readableFiles = files.count { file ->
+            try {
+                readAuthenticated(file, encryptionKey)
+                true
+            } catch (_: DesktopDeckDraftRecoveryException) {
+                false
+            }
+        }
+        check(readableFiles >= overflow) {
+            "A new Deck draft cannot be saved while unreadable drafts fill the recovery limit."
+        }
     }
 
     private fun ensurePrivateDirectory() {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
@@ -39,18 +39,8 @@ internal class DesktopDeckCardDraftStore(
             return null
         }
         if (!file.exists()) return null
-        if (!file.isSafeRegularFile() || file.length() !in 1..MAX_ENVELOPE_BYTES) {
-            deleteInvalid(file)
-            return null
-        }
         val encryptionKey = keyProvider.encryptionKey()
-        return decode(file.readBytes(), file.name, encryptionKey)
-            ?.takeIf { it.draft.key == key }
-            ?.draft
-            ?: run {
-                deleteInvalid(file)
-                null
-            }
+        return readAuthenticated(file, encryptionKey, key).draft
     }
 
     @Synchronized
@@ -59,10 +49,17 @@ internal class DesktopDeckCardDraftStore(
         require(updatedAtEpochMillis >= 0L) { "The Deck draft timestamp is invalid." }
         val file = draftFile(session, persisted.key)
         val encryptionKey = keyProvider.encryptionKey()
+        if (file.exists()) {
+            readAuthenticated(file, encryptionKey, persisted.key)
+        }
         val plaintext = encodePlaintext(persisted, updatedAtEpochMillis)
         require(plaintext.size <= MAX_PLAINTEXT_BYTES) { "The Deck card draft is too large." }
         val envelope = encrypt(plaintext, file.name, encryptionKey)
         require(envelope.size.toLong() <= MAX_ENVELOPE_BYTES) { "The Deck card draft is too large." }
+        val verified = decode(envelope, file.name, encryptionKey)
+        check(verified.draft == persisted && verified.updatedAtEpochMillis == updatedAtEpochMillis) {
+            "The Deck card draft could not be verified."
+        }
         ensurePrivateDirectory()
         clearQuarantineBeforeSave(file)
         publish(file, envelope)
@@ -72,6 +69,10 @@ internal class DesktopDeckCardDraftStore(
     @Synchronized
     fun clear(session: NextcloudSession, key: DeckCardDraftKey) {
         val file = draftFile(session, key)
+        if (file.exists()) {
+            val encryptionKey = keyProvider.encryptionKey()
+            readAuthenticated(file, encryptionKey, key)
+        }
         check(deleteFile(file) && deleteFile(quarantineFile(file))) {
             "The Deck card draft could not be cleared."
         }
@@ -144,11 +145,34 @@ internal class DesktopDeckCardDraftStore(
         .toString()
         .encodeToByteArray()
 
+    private fun readAuthenticated(
+        file: File,
+        encryptionKey: ByteArray,
+        expectedKey: DeckCardDraftKey? = null,
+    ): StoredDeckCardDraft = try {
+        if (!file.isSafeRegularFile() || file.length() !in 1..MAX_ENVELOPE_BYTES) {
+            throw DesktopDeckDraftRecoveryException(
+                IllegalArgumentException("The Deck draft file is invalid."),
+            )
+        }
+        val stored = decode(file.readBytes(), file.name, encryptionKey)
+        if (expectedKey != null && stored.draft.key != expectedKey) {
+            throw DesktopDeckDraftRecoveryException(
+                IllegalArgumentException("The Deck draft resource identity does not match."),
+            )
+        }
+        stored
+    } catch (failure: DesktopDeckDraftRecoveryException) {
+        throw failure
+    } catch (failure: Exception) {
+        throw DesktopDeckDraftRecoveryException(failure)
+    }
+
     private fun decode(
         envelopeBytes: ByteArray,
         fileName: String,
         encryptionKey: ByteArray,
-    ): StoredDeckCardDraft? = runCatching {
+    ): StoredDeckCardDraft = try {
         require(encryptionKey.size == AES_KEY_BYTES) { "The Deck draft encryption key is invalid." }
         val envelope = JSONObject(envelopeBytes.decodeToString())
         require(envelope.getInt("version") == ENVELOPE_FORMAT_VERSION) {
@@ -197,7 +221,9 @@ internal class DesktopDeckCardDraftStore(
             ),
             updatedAtEpochMillis = updatedAtEpochMillis,
         )
-    }.getOrNull()
+    } catch (failure: Exception) {
+        throw DesktopDeckDraftRecoveryException(failure)
+    }
 
     private fun encrypt(
         plaintext: ByteArray,
@@ -225,28 +251,21 @@ internal class DesktopDeckCardDraftStore(
     private fun prune(encryptionKey: ByteArray) {
         val files = root.listFiles().orEmpty()
             .filter { it.name.matches(DRAFT_FILE_PATTERN) }
-        val malformed = linkedSetOf<File>()
         val entries = files.mapNotNull { file ->
-            val stored = if (
-                file.isSafeRegularFile() &&
-                file.length() in 1..MAX_ENVELOPE_BYTES
-            ) {
-                decode(file.readBytes(), file.name, encryptionKey)
-            } else {
+            val stored = try {
+                readAuthenticated(file, encryptionKey)
+            } catch (_: DesktopDeckDraftRecoveryException) {
+                // A keyring or filesystem failure can make valid ciphertext temporarily unreadable.
+                // Preserve it so a later app process can authenticate and recover the draft.
                 null
             }
-            if (stored == null) {
-                malformed += file
-                null
-            } else {
-                DeckCardDraftRetention.Entry(file.name, stored.updatedAtEpochMillis)
-            }
+            stored?.let { DeckCardDraftRetention.Entry(file.name, it.updatedAtEpochMillis) }
         }
         val namesToPrune = DeckCardDraftRetention.keysToPrune(
             entries = entries,
             maximumEntries = DeckCardDraftRetention.MAX_ENTRIES,
         )
-        (malformed + files.filter { it.name in namesToPrune }).forEach(::deleteInvalid)
+        files.filter { it.name in namesToPrune }.forEach(::deleteDraft)
     }
 
     private fun ensurePrivateDirectory() {
@@ -298,9 +317,9 @@ internal class DesktopDeckCardDraftStore(
         }
     }
 
-    private fun deleteInvalid(file: File) {
+    private fun deleteDraft(file: File) {
         check(deleteFile(file)) {
-            "An invalid Deck card draft could not be removed."
+            "An old Deck card draft could not be removed."
         }
     }
 
@@ -343,6 +362,10 @@ internal class DesktopDeckCardDraftStore(
 
 private fun deleteDeckDraftFile(file: File): Boolean =
     Files.deleteIfExists(file.toPath()) || !file.exists()
+
+internal class DesktopDeckDraftRecoveryException(
+    cause: Throwable,
+) : IllegalStateException("The saved Deck card draft could not be restored safely.", cause)
 
 internal fun desktopDeckLegacySecretRequired(
     root: File,

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStore.kt
@@ -2,10 +2,13 @@ package dev.obiente.nextcloudnative.app
 
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.channels.FileChannel
 import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.LinkOption
 import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.file.attribute.PosixFilePermission
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -29,13 +32,14 @@ internal class DesktopDeckCardDraftStore(
     private val nowEpochMillis: () -> Long = System::currentTimeMillis,
     private val random: SecureRandom = SecureRandom(),
     private val deleteFile: (File) -> Boolean = ::deleteDeckDraftFile,
+    private val syncDirectory: (File) -> Unit = ::syncDeckDraftDirectory,
 ) {
     @Synchronized
     fun load(session: NextcloudSession, key: DeckCardDraftKey): PersistedDeckCardDraft? {
         val file = draftFile(session, key)
         val quarantine = quarantineFile(file)
         if (quarantine.exists()) {
-            if (deleteFile(file)) deleteFile(quarantine)
+            if (deleteDurably(file)) deleteDurably(quarantine)
             return null
         }
         if (!file.exists()) return null
@@ -82,7 +86,7 @@ internal class DesktopDeckCardDraftStore(
         check(!Files.isSymbolicLink(root.toPath())) {
             "Desktop Deck draft storage must not be a symbolic link."
         }
-        check(deleteFile(file) && deleteFile(quarantineFile(file))) {
+        check(deleteDurably(file) && deleteDurably(quarantineFile(file))) {
             "The Deck card draft could not be cleared."
         }
     }
@@ -93,7 +97,7 @@ internal class DesktopDeckCardDraftStore(
         val quarantine = quarantineFile(file)
         ensurePrivateDirectory()
         publish(quarantine, SUBMITTED_MARKER_BYTES)
-        if (deleteFile(file)) deleteFile(quarantine)
+        if (deleteDurably(file)) deleteDurably(quarantine)
     }
 
     @Synchronized
@@ -107,7 +111,7 @@ internal class DesktopDeckCardDraftStore(
         }.filter { file ->
             file.name.matches(DRAFT_FILE_PATTERN) || file.name.matches(SUBMITTED_FILE_PATTERN)
         }
-        check(files.all(deleteFile)) { "Saved Deck card drafts could not be discarded." }
+        check(files.all(::deleteDurably)) { "Saved Deck card drafts could not be discarded." }
     }
 
     internal fun storageFileName(session: NextcloudSession, key: DeckCardDraftKey): String {
@@ -131,7 +135,7 @@ internal class DesktopDeckCardDraftStore(
     private fun clearQuarantineBeforeSave(draftFile: File) {
         val quarantine = quarantineFile(draftFile)
         if (!quarantine.exists()) return
-        check(deleteFile(draftFile) && deleteFile(quarantine)) {
+        check(deleteDurably(draftFile) && deleteDurably(quarantine)) {
             "The submitted Deck card draft quarantine could not be cleared."
         }
     }
@@ -340,15 +344,23 @@ internal class DesktopDeckCardDraftStore(
                 file,
                 setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
             )
+            syncDirectory(root)
         } finally {
             temporary.delete()
         }
     }
 
     private fun deleteDraft(file: File) {
-        check(deleteFile(file)) {
+        check(deleteDurably(file)) {
             "An old Deck card draft could not be removed."
         }
+    }
+
+    private fun deleteDurably(file: File): Boolean {
+        val existed = Files.exists(file.toPath(), LinkOption.NOFOLLOW_LINKS)
+        val deleted = deleteFile(file)
+        if (deleted && existed) syncDirectory(root)
+        return deleted
     }
 
     private fun File.isSafeRegularFile(): Boolean =
@@ -390,6 +402,13 @@ internal class DesktopDeckCardDraftStore(
 
 private fun deleteDeckDraftFile(file: File): Boolean =
     Files.deleteIfExists(file.toPath()) || !file.exists()
+
+private fun syncDeckDraftDirectory(directory: File) {
+    if (Files.getFileAttributeView(directory.toPath(), PosixFileAttributeView::class.java) == null) return
+    FileChannel.open(directory.toPath(), StandardOpenOption.READ).use { channel ->
+        channel.force(true)
+    }
+}
 
 internal class DesktopDeckDraftRecoveryException(
     cause: Throwable,
@@ -436,7 +455,15 @@ internal class PlatformDeckDraftKeyProvider(
             username = null,
             secret = encoded.encodeToByteArray(),
         )
-        return lookup() ?: generated
+        val persisted = lookup() ?: throw DesktopSecretStoreUnavailableException(
+            "The Deck draft encryption key could not be verified after saving.",
+        )
+        if (!MessageDigest.isEqual(generated, persisted)) {
+            throw DesktopSecretStoreUnavailableException(
+                "The Deck draft encryption key changed during secure storage verification.",
+            )
+        }
+        return generated
     }
 
     private fun lookup(): ByteArray? {

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt
@@ -3891,7 +3891,7 @@ class DesktopNextcloudServices(
         key: DeckCardDraftKey,
         discardUnreadable: Boolean,
     ) = withContext(Dispatchers.IO) {
-        deckCardDrafts.clear(session, key)
+        deckCardDrafts.clear(session, key, discardUnreadable)
     }
     override suspend fun quarantineSubmittedDeckCardDraft(
         session: NextcloudSession,

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
@@ -83,6 +83,56 @@ class DesktopDeckCardDraftStoreTest {
         }
 
     @Test
+    fun `explicit discard removes permanently unreadable ciphertext`() =
+        withStore { root, _, store ->
+            val session = session()
+            val damaged = persisted()
+            store.save(session, damaged)
+            val damagedFile = root.resolve(store.storageFileName(session, damaged.key))
+            damagedFile.writeText("not-an-envelope")
+
+            assertFailsWith<DesktopDeckDraftRecoveryException> {
+                store.load(session, damaged.key)
+            }
+
+            store.clear(session, damaged.key, discardUnreadable = true)
+
+            assertFalse(damagedFile.exists())
+        }
+
+    @Test
+    fun `unreadable drafts count toward the retention ceiling`() =
+        withStore { root, _, store ->
+            val session = session()
+            val damaged = persisted(cardId = 1L)
+            store.save(session, damaged)
+            root.resolve(store.storageFileName(session, damaged.key)).writeText("not-an-envelope")
+
+            (2L..(DeckCardDraftRetention.MAX_ENTRIES + 3L)).forEach { cardId ->
+                store.save(session, persisted(cardId = cardId))
+            }
+
+            assertEquals(DeckCardDraftRetention.MAX_ENTRIES, root.listFiles().orEmpty().size)
+            assertTrue(root.resolve(store.storageFileName(session, damaged.key)).exists())
+        }
+
+    @Test
+    fun `unreadable drafts cannot grow beyond the retention ceiling`() =
+        withStore { root, _, store ->
+            val session = session()
+            repeat(DeckCardDraftRetention.MAX_ENTRIES) { index ->
+                root.resolve("${DesktopDeckCardDraftStore.FILE_PREFIX}${index.toString(16).padStart(64, '0')}" +
+                    DesktopDeckCardDraftStore.FILE_SUFFIX).writeText("not-an-envelope")
+            }
+
+            assertFailsWith<IllegalStateException> {
+                store.save(session, persisted())
+            }
+
+            assertEquals(DeckCardDraftRetention.MAX_ENTRIES, root.listFiles().orEmpty().size)
+        }
+
+    @Test
     fun `retention keeps only the newest bounded draft set`() {
         val root = Files.createTempDirectory("desktop-deck-drafts").toFile()
         val key = ByteArray(DesktopDeckCardDraftStore.AES_KEY_BYTES) { it.toByte() }

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
@@ -126,7 +126,7 @@ class DesktopDeckCardDraftStoreTest {
                     DesktopDeckCardDraftStore.FILE_SUFFIX).writeText("not-an-envelope")
             }
 
-            assertFailsWith<IllegalStateException> {
+            assertFailsWith<DeckCardDraftCapacityException> {
                 store.save(session, persisted())
             }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
@@ -1,6 +1,7 @@
 package dev.obiente.nextcloudnative.app
 
 import java.nio.file.Files
+import java.util.Base64
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -297,6 +298,68 @@ class DesktopDeckCardDraftStoreTest {
     }
 
     @Test
+    fun `generated key is rejected when secure storage does not persist it`() {
+        var saves = 0
+        val secretStore = object : DesktopSecretStore {
+            override fun load(reference: DesktopSecretReference): ByteArray? = null
+
+            override fun save(
+                reference: DesktopSecretReference,
+                username: String?,
+                secret: ByteArray,
+            ) {
+                saves += 1
+            }
+
+            override fun clear(reference: DesktopSecretReference) = Unit
+        }
+        val provider = PlatformDeckDraftKeyProvider(
+            secretStore = secretStore,
+            legacySecretRequired = { false },
+        )
+
+        repeat(2) {
+            val failure = assertFailsWith<DesktopSecretStoreUnavailableException> {
+                provider.encryptionKey()
+            }
+            assertTrue(failure.message.orEmpty().contains("could not be verified"))
+        }
+
+        assertEquals(2, saves)
+    }
+
+    @Test
+    fun `generated key is rejected when secure storage readback changes it`() {
+        var saved = false
+        val replacement = Base64.getEncoder().encode(
+            ByteArray(DesktopDeckCardDraftStore.AES_KEY_BYTES) { 0x5a },
+        )
+        val secretStore = object : DesktopSecretStore {
+            override fun load(reference: DesktopSecretReference): ByteArray? =
+                replacement.copyOf().takeIf { saved }
+
+            override fun save(
+                reference: DesktopSecretReference,
+                username: String?,
+                secret: ByteArray,
+            ) {
+                saved = true
+            }
+
+            override fun clear(reference: DesktopSecretReference) = Unit
+        }
+
+        val failure = assertFailsWith<DesktopSecretStoreUnavailableException> {
+            PlatformDeckDraftKeyProvider(
+                secretStore = secretStore,
+                legacySecretRequired = { false },
+            ).encryptionKey()
+        }
+
+        assertTrue(failure.message.orEmpty().contains("changed during secure storage verification"))
+    }
+
+    @Test
     fun `clear removes only the requested account resource`() =
         withStore { root, _, store ->
             val session = session()
@@ -311,6 +374,34 @@ class DesktopDeckCardDraftStoreTest {
             assertEquals(second, store.load(session, second.key))
             assertEquals(1, root.listFiles().orEmpty().size)
         }
+
+    @Test
+    fun `publish and delete sync the draft directory entry`() {
+        val root = Files.createTempDirectory("desktop-deck-drafts-directory-sync").toFile()
+        val key = ByteArray(DesktopDeckCardDraftStore.AES_KEY_BYTES) { (it + 1).toByte() }
+        val session = session()
+        val persisted = persisted()
+        val syncedDraftPresence = mutableListOf<Boolean>()
+        try {
+            lateinit var draftFile: java.io.File
+            val store = DesktopDeckCardDraftStore(
+                root = root,
+                keyProvider = fixedKey(key),
+                syncDirectory = { directory ->
+                    assertEquals(root.canonicalFile, directory.canonicalFile)
+                    syncedDraftPresence += draftFile.exists()
+                },
+            )
+            draftFile = root.resolve(store.storageFileName(session, persisted.key))
+
+            store.save(session, persisted)
+            store.clear(session, persisted.key)
+
+            assertEquals(listOf(true, false), syncedDraftPresence)
+        } finally {
+            root.deleteRecursively()
+        }
+    }
 
     @Test
     fun `submitted draft quarantine blocks recovery when immediate deletion fails`() {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopDeckCardDraftStoreTest.kt
@@ -3,6 +3,7 @@ package dev.obiente.nextcloudnative.app
 import java.nio.file.Files
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -54,18 +55,30 @@ class DesktopDeckCardDraftStoreTest {
         }
 
     @Test
-    fun `corrupt ciphertext is discarded without affecting another draft`() =
+    fun `malformed ciphertext is preserved across load save clear and pruning`() =
         withStore { root, _, store ->
             val session = session()
             val damaged = persisted(cardId = 42L, title = "Damaged")
             val safe = persisted(cardId = 43L, title = "Safe")
             store.save(session, damaged)
-            store.save(session, safe)
             val damagedFile = root.resolve(store.storageFileName(session, damaged.key))
             damagedFile.writeText("""{"version":1,"nonce":"bad","ciphertext":"bad"}""")
+            val malformedBytes = damagedFile.readBytes()
 
-            assertNull(store.load(session, damaged.key))
-            assertFalse(damagedFile.exists())
+            assertFailsWith<DesktopDeckDraftRecoveryException> {
+                store.load(session, damaged.key)
+            }
+            assertFailsWith<DesktopDeckDraftRecoveryException> {
+                store.save(session, damaged.copy(draft = damaged.draft.copy(title = "Replacement")))
+            }
+            assertFailsWith<DesktopDeckDraftRecoveryException> {
+                store.clear(session, damaged.key)
+            }
+            assertContentEquals(malformedBytes, damagedFile.readBytes())
+
+            store.save(session, safe)
+
+            assertContentEquals(malformedBytes, damagedFile.readBytes())
             assertEquals(safe, store.load(session, safe.key))
         }
 
@@ -156,6 +169,84 @@ class DesktopDeckCardDraftStoreTest {
     }
 
     @Test
+    fun `transient secret store failure preserves draft through restart save and dismissal clear`() {
+        val root = Files.createTempDirectory("desktop-deck-drafts").toFile()
+        val secretStore = ToggleSecretStore()
+        val session = session()
+        val persisted = persisted()
+        try {
+            val initial = storeWithPlatformKey(root, secretStore)
+            initial.save(session, persisted)
+            val file = root.resolve(initial.storageFileName(session, persisted.key))
+            val originalBytes = file.readBytes()
+            secretStore.failure = DesktopSecretStoreUnavailableException(
+                "Synthetic locked keyring.",
+            )
+            val restarted = storeWithPlatformKey(root, secretStore)
+
+            assertFailsWith<DesktopSecretStoreUnavailableException> {
+                restarted.load(session, persisted.key)
+            }
+            assertFailsWith<DesktopSecretStoreUnavailableException> {
+                restarted.save(
+                    session,
+                    persisted.copy(draft = persisted.draft.copy(title = "Replacement")),
+                )
+            }
+            assertFailsWith<DesktopSecretStoreUnavailableException> {
+                restarted.clear(session, persisted.key)
+            }
+            assertContentEquals(originalBytes, file.readBytes())
+
+            secretStore.failure = null
+            assertEquals(
+                persisted,
+                storeWithPlatformKey(root, secretStore).load(session, persisted.key),
+            )
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `missing key is not replaced while an encrypted draft exists`() {
+        val root = Files.createTempDirectory("desktop-deck-drafts").toFile()
+        val secretStore = ToggleSecretStore()
+        val session = session()
+        val persisted = persisted()
+        try {
+            val firstStore = storeWithPlatformKey(root, secretStore)
+            firstStore.save(session, persisted)
+            val file = root.resolve(firstStore.storageFileName(session, persisted.key))
+            val originalBytes = file.readBytes()
+            secretStore.secret = null
+
+            val failure = assertFailsWith<DeckCardDraftResetRequiredException> {
+                storeWithPlatformKey(root, secretStore).save(
+                    session,
+                    persisted.copy(draft = persisted.draft.copy(title = "Replacement")),
+                )
+            }
+
+            assertTrue(failure.message.orEmpty().contains("encrypted drafts still exist"))
+            assertNull(secretStore.secret)
+            assertContentEquals(originalBytes, file.readBytes())
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `unreadable draft directory requires the existing secret`() {
+        val root = Files.createTempDirectory("desktop-deck-drafts").toFile()
+        try {
+            assertTrue(desktopDeckLegacySecretRequired(root) { null })
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
     fun `clear removes only the requested account resource`() =
         withStore { root, _, store ->
             val session = session()
@@ -235,6 +326,17 @@ class DesktopDeckCardDraftStoreTest {
     private fun fixedKey(key: ByteArray): DesktopDeckDraftKeyProvider =
         DesktopDeckDraftKeyProvider { key.copyOf() }
 
+    private fun storeWithPlatformKey(
+        root: java.io.File,
+        secretStore: ToggleSecretStore,
+    ): DesktopDeckCardDraftStore = DesktopDeckCardDraftStore(
+        root = root,
+        keyProvider = PlatformDeckDraftKeyProvider(
+            secretStore = secretStore,
+            legacySecretRequired = { desktopDeckLegacySecretRequired(root) },
+        ),
+    )
+
     private fun session(
         login: String = "alice",
         password: String = "secret",
@@ -259,4 +361,28 @@ class DesktopDeckCardDraftStoreTest {
             dueFieldsEdited = true,
         ),
     )
+
+    private class ToggleSecretStore : DesktopSecretStore {
+        var secret: ByteArray? = null
+        var failure: RuntimeException? = null
+
+        override fun load(reference: DesktopSecretReference): ByteArray? {
+            failure?.let { throw it }
+            return secret?.copyOf()
+        }
+
+        override fun save(
+            reference: DesktopSecretReference,
+            username: String?,
+            secret: ByteArray,
+        ) {
+            failure?.let { throw it }
+            this.secret = secret.copyOf()
+        }
+
+        override fun clear(reference: DesktopSecretReference) {
+            failure?.let { throw it }
+            secret = null
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- authenticate existing encrypted Deck drafts before loading, replacing, or clearing them
- preserve malformed or temporarily unreadable ciphertext during retention pruning
- refuse to generate a replacement encryption key while stored draft artifacts remain

## Validation

- `./gradlew --no-daemon --max-workers=1 -Dkotlin.incremental=false :ui:desktopTest --tests dev.obiente.nextcloudnative.app.DesktopDeckCardDraftStoreTest`
- `./gradlew --no-daemon --max-workers=1 -Dkotlin.incremental=false :ui:desktopTest :ui:createDistributable`
- `bash tools/check-repository.sh`

All commands passed on the dedicated Linux build host.

## Limits

The recovery paths use deterministic fake secure-storage failures. This does not prove behavior against every live desktop keyring or Windows Credential Manager implementation.