### PR TITLE
fix: recover Windows sync roots with empty provider IDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,8 @@ jobs:
           steps.changes.outputs.windows == 'true'
         shell: pwsh
         run: |
+          cargo test --locked --bin nextcloud-native-shell-registrar
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           .\gradlew.bat --no-daemon `
             -PncDirectDesktopPackageUpdates=true `
             :ui:desktopTest :ui:packageMsi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ pretty_assertions = "1.4"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = [
     "Security_Cryptography",
+    "Security_Cryptography_Core",
     "Storage",
     "Storage_Provider",
     "Storage_Search",

--- a/changes/unreleased/windows-empty-provider-identity.md
+++ b/changes/unreleased/windows-empty-provider-identity.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 341
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows Cloud Files recovery verifies the complete account root identity when a saved provider GUID is empty, avoiding a false foreign-registration rejection while retaining path safety checks.

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -97,6 +97,9 @@ previous published package:
 - upgrade preserves account, sync, cache, and recovery state and starts only
   the new version;
 - account removal disconnects and unregisters its sync root;
+- recovery accepts an empty saved provider GUID only with the exact Windows
+  user, account root context, checksum, and permitted path; foreign identities
+  and damaged or unsupported context remain rejected;
 - uninstall leaves no active provider process or unusable registered sync
   root;
 - silent installation and uninstall work for package-manager validation.
@@ -104,6 +107,14 @@ previous published package:
 Explorer and writeback qualification uses disposable synthetic accounts. Do
 not use personal file trees or include server, account, path, or credential
 details in logs and public artifacts.
+
+Run `cargo test --locked --bin nextcloud-native-shell-registrar` for deterministic
+registration ownership coverage. On a Windows test checkout on NTFS, also run
+`cargo test --locked --bin nextcloud-native-shell-registrar persisted_root_can_be_owned_and_unregistered -- --ignored`.
+That explicit integration test creates and removes only its disposable empty
+Explorer root under the checkout's ignored `target` directory. It checks saved
+registration ownership, rejection of a different requested path, and
+unregistration. It does not validate personal-account recovery or writeback.
 
 ## WinGet delivery
 

--- a/src/bin/nextcloud-native-shell-registrar.rs
+++ b/src/bin/nextcloud-native-shell-registrar.rs
@@ -348,6 +348,7 @@ mod platform {
     use std::ffi::{OsStr, OsString};
     use std::mem::size_of;
     use std::path::{Path, PathBuf};
+    use windows::Security::Cryptography::Core::HashAlgorithmProvider;
     use windows::Security::Cryptography::CryptographicBuffer;
     use windows::Storage::Provider::{
         StorageProviderHardlinkPolicy, StorageProviderHydrationPolicy,
@@ -471,6 +472,61 @@ mod platform {
     }
     const PROVIDER_GUID: GUID = GUID::from_u128(0x6d456713_7d9a_4a39_90ce_127998de42d7);
 
+    // Match the complete root identity written by WindowsCloudFileIdentityCodec, including its
+    // checksum. Only its two known root encodings qualify; arbitrary placeholder context does not.
+    fn root_identity_context(
+        account_id: &str,
+        version: u16,
+    ) -> WindowsResult<windows::Storage::Streams::IBuffer> {
+        let mut payload = Vec::from(*b"NCFV");
+        payload.extend_from_slice(&version.to_be_bytes());
+        payload.push(1); // directory
+        payload.extend_from_slice(&0_i64.to_be_bytes());
+        if version == 2 {
+            payload.extend_from_slice(&(-1_i64).to_be_bytes()); // unknown modification time
+        }
+        payload.extend_from_slice(&(account_id.len() as u16).to_be_bytes());
+        payload.extend_from_slice(account_id.as_bytes());
+        payload.extend_from_slice(&[0, 0, 0, 4]); // empty path, four-byte revision
+        payload.extend_from_slice(b"root");
+        let algorithm = HashAlgorithmProvider::OpenAlgorithm(&HSTRING::from("SHA256"))?;
+        let digest = algorithm.HashData(&CryptographicBuffer::CreateFromByteArray(&payload)?)?;
+        let mut checksum = windows::core::Array::new();
+        CryptographicBuffer::CopyToByteArray(&digest, &mut checksum)?;
+        payload.extend_from_slice(&checksum);
+        CryptographicBuffer::CreateFromByteArray(&payload)
+    }
+
+    fn registration_is_owned(existing: &StorageProviderSyncRootInfo) -> WindowsResult<bool> {
+        let id = existing.Id()?;
+        let id_value = id.to_string();
+        let Some(account_id) = account_id_from_sync_root_id(&id_value) else {
+            return Ok(false);
+        };
+        // Include the current Windows SID, not just the provider prefix and account suffix.
+        if id != sync_root_id(account_id)? {
+            return Ok(false);
+        }
+        match existing.ProviderId()? {
+            provider if provider == PROVIDER_GUID => Ok(true),
+            provider if provider == GUID::zeroed() => {
+                // Windows can return an empty GUID for a persisted branded registration. Require
+                // the exact account-scoped root context before applying the usual path checks.
+                let context = existing.Context()?;
+                for version in [1, 2] {
+                    let expected = root_identity_context(account_id, version)?;
+                    if context.Length()? == expected.Length()?
+                        && CryptographicBuffer::Compare(&context, &expected)?
+                    {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            _ => Ok(false),
+        }
+    }
+
     struct OwnedHandle(HANDLE);
 
     impl Drop for OwnedHandle {
@@ -592,7 +648,7 @@ mod platform {
         let mut current_registration_is_ready = false;
         match StorageProviderSyncRootManager::GetSyncRootInformationForId(&id) {
             Ok(existing) => {
-                let provider_owned = existing.ProviderId()? == PROVIDER_GUID;
+                let provider_owned = registration_is_owned(&existing)?;
                 let current_state = if provider_owned {
                     current_registration_state(
                         &existing,
@@ -629,15 +685,12 @@ mod platform {
             let Ok(existing_id) = existing.Id() else {
                 continue;
             };
-            let Ok(existing_provider_id) = existing.ProviderId() else {
-                continue;
-            };
             // The exact current ID was handled above with its path recovery checks. Never make a
             // second, less-informed decision about that registration from the enumeration view.
             if existing_id == id {
                 continue;
             }
-            let provider_owned = existing_provider_id == PROVIDER_GUID;
+            let provider_owned = registration_is_owned(&existing).unwrap_or(false);
             let cleanup_state = if provider_owned {
                 non_current_registration_state(&existing, &existing_id, &root, &recoverable_roots)
             } else {
@@ -707,7 +760,7 @@ mod platform {
             }
             Err(failure) => return Err(failure.into()),
         };
-        if existing.ProviderId()? != PROVIDER_GUID {
+        if !registration_is_owned(&existing)? {
             return Err(Box::new(UnsafeRegistrationConflict));
         }
         match existing.Path().and_then(|folder| folder.Path()) {
@@ -808,6 +861,164 @@ mod platform {
                 unregister(root, account_id)
             }
             _ => Err("unsupported command".into()),
+        }
+    }
+    #[cfg(test)]
+    mod ownership_tests {
+        use super::*;
+
+        fn registration(
+            account: &str,
+            provider: GUID,
+            version: u16,
+        ) -> StorageProviderSyncRootInfo {
+            let info = StorageProviderSyncRootInfo::new().unwrap();
+            info.SetId(&sync_root_id(account).unwrap()).unwrap();
+            info.SetProviderId(provider).unwrap();
+            info.SetContext(&root_identity_context(account, version).unwrap())
+                .unwrap();
+            info
+        }
+
+        #[test]
+        fn accepts_known_root_context_for_an_empty_provider_guid() {
+            let _apartment = WinRtApartment::initialize().unwrap();
+            for version in [1, 2] {
+                let info = registration(&"a".repeat(64), GUID::zeroed(), version);
+                assert!(registration_is_owned(&info).unwrap());
+            }
+            let info = registration(&"a".repeat(64), PROVIDER_GUID, 2);
+            assert!(registration_is_owned(&info).unwrap());
+        }
+
+        #[test]
+        fn root_context_matches_jvm_codec_golden_vectors() {
+            let _apartment = WinRtApartment::initialize().unwrap();
+            let vectors = [
+                (
+                    1,
+                    "4e434656000101000000000000000000406161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000004726f6f74da093d34d47512a77176207d7a1a99bc4e2195d4b108d1df5a760bd1af0db2ff",
+                ),
+                (
+                    2,
+                    "4e4346560002010000000000000000ffffffffffffffff00406161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000004726f6f74cd1caa4b0547c9a4f510bddf5f7166b33d240914ed30eea742cb24f698f1fe6e",
+                ),
+            ];
+            for (version, expected) in vectors {
+                let context = root_identity_context(&"a".repeat(64), version).unwrap();
+                assert_eq!(
+                    CryptographicBuffer::EncodeToHexString(&context).unwrap(),
+                    HSTRING::from(expected)
+                );
+            }
+        }
+
+        #[test]
+        fn rejects_foreign_provider_account_sid_and_namespace() {
+            let _apartment = WinRtApartment::initialize().unwrap();
+            let account = "a".repeat(64);
+            let info = registration(&account, GUID::from_u128(1), 2);
+            assert!(!registration_is_owned(&info).unwrap());
+            info.SetProviderId(GUID::zeroed()).unwrap();
+            info.SetId(&sync_root_id(&"b".repeat(64)).unwrap()).unwrap();
+            assert!(!registration_is_owned(&info).unwrap());
+            for id in [
+                format!("Obiente.NextcloudNative!S-1-5-0!{account}"),
+                format!("Other.Provider!S-1-5-0!{account}"),
+                "Obiente.NextcloudNative!invalid".to_owned(),
+            ] {
+                info.SetId(&HSTRING::from(id)).unwrap();
+                assert!(!registration_is_owned(&info).unwrap());
+            }
+        }
+
+        #[test]
+        fn rejects_missing_malformed_oversized_and_tampered_context() {
+            let _apartment = WinRtApartment::initialize().unwrap();
+            let info = registration(&"a".repeat(64), GUID::zeroed(), 2);
+            let mut original = windows::core::Array::new();
+            CryptographicBuffer::CopyToByteArray(&info.Context().unwrap(), &mut original).unwrap();
+            let mut cases = vec![vec![], vec![0], vec![0; 4097], original[..128].to_vec()];
+            // Check checksum damage, unsupported version, file identity and a non-root revision.
+            for index in [128, 5, 6, 96] {
+                let mut changed = original.to_vec();
+                changed[index] ^= 1;
+                cases.push(changed);
+            }
+            for bytes in cases {
+                info.SetContext(&CryptographicBuffer::CreateFromByteArray(&bytes).unwrap())
+                    .unwrap();
+                assert!(!registration_is_owned(&info).unwrap());
+            }
+        }
+
+        #[test]
+        #[ignore = "Creates a disposable Explorer root; explicit Windows integration test"]
+        fn persisted_root_can_be_owned_and_unregistered() {
+            let _apartment = WinRtApartment::initialize().unwrap();
+            let account = format!(
+                "{:064x}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            );
+            let root = std::env::current_dir()
+                .unwrap()
+                .join("target")
+                .join(format!("native-shell-test-{account}"));
+            std::fs::create_dir(&root).unwrap();
+            let id = sync_root_id(&account).unwrap();
+            struct Cleanup(HSTRING, PathBuf);
+            impl Drop for Cleanup {
+                fn drop(&mut self) {
+                    let _ = StorageProviderSyncRootManager::Unregister(&self.0);
+                    let _ = std::fs::remove_dir(&self.1);
+                }
+            }
+            let _cleanup = Cleanup(id.clone(), root.clone());
+            let info = registration(&account, PROVIDER_GUID, 2);
+            info.SetPath(
+                &StorageFolder::GetFolderFromPathAsync(&HSTRING::from(root.as_path()))
+                    .unwrap()
+                    .join()
+                    .unwrap(),
+            )
+            .unwrap();
+            info.SetDisplayNameResource(&HSTRING::from("nati.ve disposable test"))
+                .unwrap();
+            info.SetIconResource(&HSTRING::from("shell32.dll,3"))
+                .unwrap();
+            info.SetHydrationPolicy(StorageProviderHydrationPolicy::Progressive)
+                .unwrap();
+            info.SetHydrationPolicyModifier(
+                StorageProviderHydrationPolicyModifier::AutoDehydrationAllowed,
+            )
+            .unwrap();
+            info.SetPopulationPolicy(StorageProviderPopulationPolicy::Full)
+                .unwrap();
+            info.SetInSyncPolicy(
+                StorageProviderInSyncPolicy::FileCreationTime
+                    | StorageProviderInSyncPolicy::FileLastWriteTime
+                    | StorageProviderInSyncPolicy::DirectoryCreationTime
+                    | StorageProviderInSyncPolicy::DirectoryLastWriteTime,
+            )
+            .unwrap();
+            info.SetHardlinkPolicy(StorageProviderHardlinkPolicy::None)
+                .unwrap();
+            info.SetShowSiblingsAsGroup(false).unwrap();
+            info.SetVersion(&HSTRING::from(env!("CARGO_PKG_VERSION")))
+                .unwrap();
+            info.SetAllowPinning(true).unwrap();
+            StorageProviderSyncRootManager::Register(&info).unwrap();
+            let persisted =
+                StorageProviderSyncRootManager::GetSyncRootInformationForId(&id).unwrap();
+            assert!(registration_is_owned(&persisted).unwrap());
+            assert!(unregister(root.with_extension("different"), account.clone()).is_err());
+            assert!(StorageProviderSyncRootManager::GetSyncRootInformationForId(&id).is_ok());
+            unregister(root.clone(), account).unwrap();
+            assert!(root.is_dir());
+            assert!(StorageProviderSyncRootManager::GetSyncRootInformationForId(&id).is_err());
         }
     }
 }

--- a/website/content/guides/windows-cloud-files.md
+++ b/website/content/guides/windows-cloud-files.md
@@ -8,14 +8,14 @@ device: Desktop
 platforms: Windows
 durationMinutes: 9
 difficulty: Advanced
-lastUpdated: 2026-08-30
+lastUpdated: 2026-09-05
 captureScenarios: guide-windows-cloud-files-settings, guide-windows-cloud-files-storage, guide-windows-cloud-files-recovery
 prerequisites: A connected Windows x86-64 alpha installation, A disposable test folder in Nextcloud, Enough local storage to hydrate the files you open
 ---
 
 # Use Nextcloud files in Windows File Explorer
 
-**Last reviewed: 2026-08-30.** The software and published packages may have
+**Last reviewed: 2026-09-05.** The software and published packages may have
 changed since this review. Check the [current releases](https://github.com/obiente/native/releases)
 and [compatibility notes](/compatibility/) before using this guide with important data.
 
@@ -29,6 +29,8 @@ On Windows, nati.ve integrates with the Cloud Files API so remote content can ap
 Open **Settings**, choose **Sync & storage**, then open **Virtual files**. Activate the system provider if it is not already active. When registration succeeds, the location is reported as **nati.ve in File Explorer**. The root is account-scoped, and signing out disconnects the provider for that account.
 
 If activation fails, keep the failure message and retry only after checking that the app is the current installed version. The app keeps a failed automatic activation visible instead of retrying it on every settings refresh. Use the explicit activation action when you are ready to retry. Do not manually delete a registered sync root or copy provider metadata between accounts. Recovery handles stale registrations, legacy roots, and damaged Cloud Files metadata while preserving the existing local root and its data.
+
+An older build can report **Windows refused to safely unregister the branded Cloud Files root** during recovery. The source includes a fix for saved registrations whose provider identifier is empty: recovery verifies the saved account identity and path before proceeding. Check the release notes for a build containing this fix, then restart the installed app and retry activation. Do not delete the folder or edit the Windows registration to bypass the check. This recovery fix does not establish that all Windows sync or writeback scenarios are qualified.
 
 The storage view distinguishes **Not connected**, **Connected**, and
 **Edits need review**. An available integration is not proof that the provider


### PR DESCRIPTION
## Outcome

Fix Windows Cloud Files activation failing with "Windows refused to safely unregister the branded Cloud Files root" when Windows returns an empty provider GUID for a saved nati.ve registration.

The registrar now recognizes this case only when the provider namespace, current Windows SID, account, and complete checksummed root context match. Existing path checks still apply; foreign provider GUIDs and mismatched or malformed context remain rejected. Apply the same ownership check to registration, stale-registration handling, and unregistration. Add Windows CI coverage and update the recovery guide.

Related to #341.

## Verification

- [x] Relevant checks pass or their limitations are listed below.
- [ ] `bash tools/check-repository.sh` passes.
- [x] A new `changes/unreleased/` fragment records the change.
- [x] No credentials, private server data, machine-local paths, or generated output are included.

Passed on Windows x86-64:

- `cargo test --locked` and focused registrar tests.
- `cargo test --locked --bin nextcloud-native-shell-registrar persisted_root_can_be_owned_and_unregistered -- --ignored`: disposable NTFS root registration, ownership readback, rejection of a different requested path, and unregistration.
- `:ui:desktopTest --tests *WindowsCloud*`: 93 tests passed.
- `:ui:createDistributable` and `:ui:packageMsi`; `tools/verify-windows-package.ps1` validated the unsigned test MSI at version 0.1.0.
- Rust formatting, Kotlin architecture, changelog validation, local Markdown links, and capture-asset validation.
- Website client and SSR builds and prerendering of 32 routes, run separately from the blocked aggregate test gate.

Limits:

- The repository and aggregate website gates stop at existing symlink fixtures because this Windows environment denies symlink creation. These tests were not weakened or skipped to obtain a passing gate.
- Clippy completes with an existing `uninlined_format_args` warning in `src/dynamic_compiler.rs`; strict warnings-as-errors remains blocked by that warning.
- The live Windows integration test is opt-in because it creates a disposable Explorer registration. Deterministic ownership tests run in Windows CI.

## Compatibility and risk

Validated locally on Windows x86-64 with NTFS. No Nextcloud server/app version was exercised: this change addresses local Windows registration ownership. The fallback accepts only the known v1/v2 root encodings and retains the existing path and recovery policies. End-to-end recovery of an existing account's corrupt file tree and writeback were not performed. The test MSI is not a published release or an installed upgrade.

## Visual changes

Not applicable.
