### PR TITLE
fix(windows): restore Cloud Files placeholders and Explorer browsing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,26 @@ UTF-8 letters and translations. Run
 Unicode ellipses, Unicode minus signs, no-break spaces, and invisible
 formatting characters.
 
+### Windows filesystem test prerequisites
+
+The full desktop suite and repository checks create disposable symbolic links
+for path-safety and Linux service fixtures. On Windows, the test process must
+have permission to create those links. Without that permission, Windows reports
+that a required privilege is not held, and Node.js reports `EPERM`. These are
+fixture setup failures, not successful safety checks.
+
+Run these checks from a terminal with the required symbolic-link privilege.
+Pass `--no-daemon` to Gradle so tests do not reuse a daemon started without that
+privilege. Keep the tests enabled: replacing links with ordinary files would bypass the
+behavior they verify. The Git Bash text-hygiene fixture converts its temporary
+paths for the native Windows scanner, including paths sent through stdin.
+
+The aggregate repository check also builds a Debian fixture with `dpkg-deb`.
+Run that check in Linux (including a configured WSL distribution or Linux
+container) with Rust, Node.js, Git, Python 3, jq, and Debian packaging tools
+available. Windows-only fixture checks can run from Git Bash; Node.js launches
+the manifest scripts through Bash using Windows-compatible paths.
+
 ### Isolated Android emulator tests
 
 The emulator helper gives each concurrent worktree a separate Android data

--- a/changes/unreleased/449-windows-placeholder-recovery.md
+++ b/changes/unreleased/449-windows-placeholder-recovery.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 449
+pull: none
+platforms: windows
+user-facing: yes
+
+Windows Cloud Files avoids corrupt metadata for short folder names, preserves local files during recovery, and fixes Explorer root browsing through correct callback identities and enumeration completion.

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -116,6 +116,37 @@ Explorer root under the checkout's ignored `target` directory. It checks saved
 registration ownership, rejection of a different requested path, and
 unregistration. It does not validate personal-account recovery or writeback.
 
+## Short placeholder identity regression
+
+Root enumeration accepts the registered root context when Windows omits the item
+identity, only for a matching nonzero root file ID. Account and normalized path
+checks still apply. Enumeration reconciles existing children before completing
+the callback, avoiding duplicate placeholder submissions.
+
+Item identities use a version 3 envelope padded to at least 256 bytes, including
+the checksum. This is an application compatibility measure: short directory
+identities reproduced `0x8007016b` on a local Windows installation. It is not a
+documented CFAPI minimum. Readers accept versions 1, 2, and 3; the registered
+root context remains byte-identical version 2 so an upgrade does not replace a
+healthy registration. Older binaries cannot decode version 3 item identities.
+
+**Last reviewed: 2026-09-06.** Local Windows tests passed creation, directory listing, hydration,
+restart, and recovery from actual corrupt version 2 placeholders while preserving
+a synthetic local file. This evidence does not qualify personal-account
+writeback or a published upgrade; check the [releases](https://github.com/obiente/native/releases)
+for available artifacts. On a Windows NTFS test checkout, run:
+
+```powershell
+.\gradlew.bat :ui:createDistributable
+$env:NATIVE_WINDOWS_TEST_LAUNCHER = (Resolve-Path 'ui/build/compose/binaries/main/app/NextcloudNative/NextcloudNative.exe').Path
+.\gradlew.bat :ui:desktopTest --tests '*WindowsCloud*'
+```
+
+The opt-in native tests use the packaged registrar, disposable roots, and an
+in-memory backend that rejects server mutations. Without the launcher variable,
+these integration tests are skipped. The legacy-corruption case also skips on
+Windows versions where the old encoding no longer reproduces the failure.
+
 ## WinGet delivery
 
 `tools/create-winget-manifests.ps1` generates a three-file WinGet manifest from

--- a/tools/kotlin-file-size-baseline.txt
+++ b/tools/kotlin-file-size-baseline.txt
@@ -56,8 +56,8 @@ ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopFileSyncStore.k
 ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopNextcloudServices.kt|6289
 ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualRangeCache.kt|2762
 ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystem.kt|1731
-ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt|1086
-ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt|2480
+ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt|1085
+ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt|2373
 ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/DesktopVirtualRangeCacheTest.kt|2479
 ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/JvmSupportIntakeTest.kt|2890
 ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/LinuxVirtualFileSystemTest.kt|2149

--- a/tools/legacy-update-manifest-compatibility.test.mjs
+++ b/tools/legacy-update-manifest-compatibility.test.mjs
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import test from "node:test";
 
 const execFileAsync = promisify(execFile);
+const shellPath = (value) => process.platform === "win32" ? value.replaceAll("\\", "/") : value;
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repository = "Obiente/nc-native";
 const versionName = "0.1.0-alpha.2";
@@ -135,9 +136,10 @@ test("generated core manifests satisfy the oldest shipped strict schema", async 
     const environment = { ...process.env, GITHUB_REPOSITORY: repository };
 
     await execFileAsync(
-      path.join(repositoryRoot, "tools/create-android-update-manifest.sh"),
+      "bash",
       [
-        androidManifest,
+        shellPath(path.join(repositoryRoot, "tools/create-android-update-manifest.sh")),
+        shellPath(androidManifest),
         "prerelease-v1",
         tag,
         versionName,
@@ -156,15 +158,16 @@ test("generated core manifests satisfy the oldest shipped strict schema", async 
       writeFile(path.join(temporary, "NextcloudNative-1.0.3822.msi"), "msi fixture\n"),
     ]);
     await execFileAsync(
-      path.join(repositoryRoot, "tools/create-desktop-update-manifest.sh"),
+      "bash",
       [
-        desktopManifest,
+        shellPath(path.join(repositoryRoot, "tools/create-desktop-update-manifest.sh")),
+        shellPath(desktopManifest),
         "prerelease-v1",
         tag,
         versionName,
         String(versionCode),
         packageVersion,
-        temporary,
+        shellPath(temporary),
       ],
       { cwd: repositoryRoot, env: environment },
     );

--- a/tools/test-text-hygiene.sh
+++ b/tools/test-text-hygiene.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 temporary_directory="$(mktemp -d)"
+# MSYS converts command-line arguments for native executables, but not paths on stdin.
+# The scanner receives these fixture paths through its NUL-delimited input stream.
+if command -v cygpath >/dev/null 2>&1; then
+    temporary_directory="$(cygpath -m "$temporary_directory")"
+fi
 trap 'rm -rf -- "$temporary_directory"' EXIT
 
 rustc --edition=2021 --test \

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudCallbackIdentity.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudCallbackIdentity.kt
@@ -1,0 +1,24 @@
+package dev.obiente.nextcloudnative.app
+
+import com.sun.jna.Pointer
+
+/** Root enumeration may carry only the registration context, especially with WinRT registration. */
+internal fun CfCallbackInfo.windowsCloudCallbackIdentity(allowRootIdentity: Boolean): ByteArray? {
+    val itemIdentity = boundedCallbackIdentity(fileIdentity, fileIdentityLength)
+    if (itemIdentity != null) return itemIdentity
+    if (!allowRootIdentity || fileId == 0L || fileId != syncRootFileId) return null
+    val context = boundedCallbackIdentity(syncRootIdentity, syncRootIdentityLength) ?: return null
+    val root = WindowsCloudFileIdentityCodec.decode(context)
+    require(root.directory && root.path.isEmpty() && root.remoteRevision == "root") {
+        "The Cloud Files root callback context is not a root identity."
+    }
+    // The provider subsequently verifies account ownership and the exact normalized root path.
+    return context
+}
+
+private fun boundedCallbackIdentity(pointer: Pointer?, length: Int): ByteArray? {
+    require(length in 0..4096) { "The Cloud Files callback identity length is invalid." }
+    if (length == 0) return null
+    return requireNotNull(pointer) { "The Cloud Files callback identity pointer is missing." }
+        .getByteArray(0L, length)
+}

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFileIdentity.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFileIdentity.kt
@@ -1,0 +1,128 @@
+package dev.obiente.nextcloudnative.app
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.security.MessageDigest
+
+internal data class WindowsCloudFileIdentity(
+    val accountId: String,
+    val path: String,
+    val remoteRevision: String,
+    val size: Long,
+    val directory: Boolean,
+    val lastModifiedEpochMillis: Long? = null,
+) {
+    init {
+        require(accountId.isNotBlank() && accountId.length <= MAX_ACCOUNT_ID_LENGTH)
+        if (path.isNotEmpty()) FileOfflineKey(accountId, path)
+        require(remoteRevision.isNotBlank() && remoteRevision.length <= MAX_REVISION_LENGTH)
+        require(size >= 0L)
+        require(!directory || size == 0L)
+        require(lastModifiedEpochMillis == null || lastModifiedEpochMillis >= 0L)
+    }
+
+    private companion object {
+        const val MAX_ACCOUNT_ID_LENGTH = 256
+        const val MAX_REVISION_LENGTH = 1_024
+    }
+}
+
+/** Versioned, checksummed and strictly bounded identity persisted in Windows placeholders. */
+internal object WindowsCloudFileIdentityCodec {
+    fun encode(identity: WindowsCloudFileIdentity): ByteArray {
+        // Keep the registered root context byte-stable across upgrades. The padded envelope
+        // applies to item reparse metadata, not the separate sync-root registration contract.
+        val version = if (identity.directory && identity.path.isEmpty() && identity.remoteRevision == "root") 2 else VERSION
+        val payload = ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(MAGIC)
+                output.writeShort(version)
+                output.writeBoolean(identity.directory)
+                output.writeLong(identity.size)
+                output.writeLong(identity.lastModifiedEpochMillis ?: UNKNOWN_MODIFIED_TIME)
+                output.writeBoundedUtf8(identity.accountId, MAX_ACCOUNT_BYTES)
+                output.writeBoundedUtf8(identity.path, MAX_PATH_BYTES)
+                output.writeBoundedUtf8(identity.remoteRevision, MAX_REVISION_BYTES)
+                if (version >= 3) {
+                    val padding = (MINIMUM_PAYLOAD_BYTES - bytes.size()).coerceAtLeast(0)
+                    output.write(ByteArray(padding))
+                }
+            }
+            bytes.toByteArray()
+        }
+        require(payload.size + DIGEST_BYTES <= MAX_IDENTITY_BYTES) { "The Windows placeholder identity is too large." }
+        val digest = MessageDigest.getInstance("SHA-256").digest(payload)
+        return payload + digest
+    }
+
+    fun decode(bytes: ByteArray): WindowsCloudFileIdentity {
+        require(bytes.size in MIN_IDENTITY_BYTES..MAX_IDENTITY_BYTES) {
+            "The Windows placeholder identity has an invalid size."
+        }
+        val payload = bytes.copyOfRange(0, bytes.size - DIGEST_BYTES)
+        val expectedDigest = bytes.copyOfRange(bytes.size - DIGEST_BYTES, bytes.size)
+        require(MessageDigest.getInstance("SHA-256").digest(payload).contentEquals(expectedDigest)) {
+            "The Windows placeholder identity checksum is invalid."
+        }
+        return DataInputStream(ByteArrayInputStream(payload)).use { input ->
+            require(input.readInt() == MAGIC) { "The Windows placeholder identity type is invalid." }
+            val version = input.readUnsignedShort()
+            require(version in MINIMUM_SUPPORTED_VERSION..VERSION) {
+                "The Windows placeholder identity version is unsupported."
+            }
+            val directory = input.readBoolean()
+            val size = input.readLong()
+            val lastModifiedEpochMillis = if (version >= 2) {
+                input.readLong().takeUnless { it == UNKNOWN_MODIFIED_TIME }
+            } else {
+                null
+            }
+            val accountId = input.readBoundedUtf8(MAX_ACCOUNT_BYTES)
+            val path = input.readBoundedUtf8(MAX_PATH_BYTES)
+            val revision = input.readBoundedUtf8(MAX_REVISION_BYTES)
+            if (version >= 3) {
+                val consumed = payload.size - input.available()
+                val padding = (MINIMUM_PAYLOAD_BYTES - consumed).coerceAtLeast(0)
+                require(input.available() == padding) { "The Windows placeholder identity padding has an invalid size." }
+                repeat(padding) {
+                    require(input.readByte() == 0.toByte()) { "The Windows placeholder identity padding is invalid." }
+                }
+            }
+            require(input.available() == 0) { "The Windows placeholder identity has trailing data." }
+            WindowsCloudFileIdentity(accountId, path, revision, size, directory, lastModifiedEpochMillis)
+        }
+    }
+
+    private fun DataOutputStream.writeBoundedUtf8(value: String, maximumBytes: Int) {
+        val bytes = value.encodeToByteArray()
+        require(bytes.size <= maximumBytes)
+        writeShort(bytes.size)
+        write(bytes)
+    }
+
+    private fun DataInputStream.readBoundedUtf8(maximumBytes: Int): String {
+        val length = readUnsignedShort()
+        require(length <= maximumBytes && length <= available()) {
+            "The Windows placeholder identity field is invalid."
+        }
+        val bytes = ByteArray(length).also(::readFully)
+        return bytes.decodeToString(throwOnInvalidSequence = true)
+    }
+
+    private const val MAGIC = 0x4E434656 // NCFV
+    private const val VERSION = 3
+    // Short directory identities reproduced ERROR_FILE_SYSTEM_VIRTUALIZATION_METADATA_CORRUPT
+    // on Windows. A minimum 256-byte envelope passed the real CFAPI regression fixture.
+    // This is our compatibility padding, not a documented CFAPI minimum.
+    private const val MINIMUM_PAYLOAD_BYTES = 224
+    private const val MINIMUM_SUPPORTED_VERSION = 1
+    private const val UNKNOWN_MODIFIED_TIME = -1L
+    private const val DIGEST_BYTES = 32
+    private const val MAX_ACCOUNT_BYTES = 256
+    private const val MAX_PATH_BYTES = 3_072
+    private const val MAX_REVISION_BYTES = 1_024
+    private const val MAX_IDENTITY_BYTES = 4_096
+    private const val MIN_IDENTITY_BYTES = 4 + 2 + 1 + 8 + 2 + 2 + 2 + DIGEST_BYTES
+}

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesJna.kt
@@ -562,9 +562,9 @@ internal class JnaWindowsCloudFilesApi(
     }
 
     private fun dispatchCallback(callbacks: WindowsCloudFilesCallbacks, infoPointer: Pointer, parameters: Pointer) {
+        val type = requireNotNull(currentCallbackType.get()) { "The Cloud Files callback type was not bound." }
         val nativeInfo = CfCallbackInfo(infoPointer).apply { read() }
-        val identity = nativeInfo.fileIdentity?.takeIf { nativeInfo.fileIdentityLength > 0 }
-            ?.getByteArray(0L, nativeInfo.fileIdentityLength)
+        val identity = nativeInfo.windowsCloudCallbackIdentity(type == CF_CALLBACK_TYPE_FETCH_PLACEHOLDERS)
         val info = WindowsCloudCallbackInfo(
             connectionKey = nativeInfo.connectionKey,
             transferKey = nativeInfo.transferKey,
@@ -577,7 +577,6 @@ internal class JnaWindowsCloudFilesApi(
             fileSize = nativeInfo.fileSize,
             priorityHint = nativeInfo.priorityHint.toInt() and 0xff,
         )
-        val type = requireNotNull(currentCallbackType.get()) { "The Cloud Files callback type was not bound." }
         val union = PARAMETERS_UNION_OFFSET
         when (type) {
             CF_CALLBACK_TYPE_FETCH_DATA -> callbacks.fetchData(

--- a/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
+++ b/ui/src/desktopMain/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProvider.kt
@@ -1,9 +1,5 @@
 package dev.obiente.nextcloudnative.app
 
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.DataInputStream
-import java.io.DataOutputStream
 import java.io.File
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
@@ -11,7 +7,6 @@ import java.nio.file.LinkOption
 import java.nio.file.Path
 import java.nio.file.StandardWatchEventKinds
 import java.nio.file.WatchService
-import java.security.MessageDigest
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
@@ -28,107 +23,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
 private const val MAX_WINDOWS_CLOUD_FILES_RECOVERY_ROOT_ATTEMPTS = 16
-
-internal data class WindowsCloudFileIdentity(
-    val accountId: String,
-    val path: String,
-    val remoteRevision: String,
-    val size: Long,
-    val directory: Boolean,
-    val lastModifiedEpochMillis: Long? = null,
-) {
-    init {
-        require(accountId.isNotBlank() && accountId.length <= MAX_ACCOUNT_ID_LENGTH)
-        if (path.isNotEmpty()) FileOfflineKey(accountId, path)
-        require(remoteRevision.isNotBlank() && remoteRevision.length <= MAX_REVISION_LENGTH)
-        require(size >= 0L)
-        require(!directory || size == 0L)
-        require(lastModifiedEpochMillis == null || lastModifiedEpochMillis >= 0L)
-    }
-
-    private companion object {
-        const val MAX_ACCOUNT_ID_LENGTH = 256
-        const val MAX_REVISION_LENGTH = 1_024
-    }
-}
-
-/** Versioned, checksummed and strictly bounded identity persisted in Windows placeholders. */
-internal object WindowsCloudFileIdentityCodec {
-    fun encode(identity: WindowsCloudFileIdentity): ByteArray {
-        val payload = ByteArrayOutputStream().use { bytes ->
-            DataOutputStream(bytes).use { output ->
-                output.writeInt(MAGIC)
-                output.writeShort(VERSION)
-                output.writeBoolean(identity.directory)
-                output.writeLong(identity.size)
-                output.writeLong(identity.lastModifiedEpochMillis ?: UNKNOWN_MODIFIED_TIME)
-                output.writeBoundedUtf8(identity.accountId, MAX_ACCOUNT_BYTES)
-                output.writeBoundedUtf8(identity.path, MAX_PATH_BYTES)
-                output.writeBoundedUtf8(identity.remoteRevision, MAX_REVISION_BYTES)
-            }
-            bytes.toByteArray()
-        }
-        val digest = MessageDigest.getInstance("SHA-256").digest(payload)
-        return payload + digest
-    }
-
-    fun decode(bytes: ByteArray): WindowsCloudFileIdentity {
-        require(bytes.size in MIN_IDENTITY_BYTES..MAX_IDENTITY_BYTES) {
-            "The Windows placeholder identity has an invalid size."
-        }
-        val payload = bytes.copyOfRange(0, bytes.size - DIGEST_BYTES)
-        val expectedDigest = bytes.copyOfRange(bytes.size - DIGEST_BYTES, bytes.size)
-        require(MessageDigest.getInstance("SHA-256").digest(payload).contentEquals(expectedDigest)) {
-            "The Windows placeholder identity checksum is invalid."
-        }
-        return DataInputStream(ByteArrayInputStream(payload)).use { input ->
-            require(input.readInt() == MAGIC) { "The Windows placeholder identity type is invalid." }
-            val version = input.readUnsignedShort()
-            require(version in MINIMUM_SUPPORTED_VERSION..VERSION) {
-                "The Windows placeholder identity version is unsupported."
-            }
-            val directory = input.readBoolean()
-            val size = input.readLong()
-            val lastModifiedEpochMillis = if (version >= 2) {
-                input.readLong().takeUnless { it == UNKNOWN_MODIFIED_TIME }
-            } else {
-                null
-            }
-            val accountId = input.readBoundedUtf8(MAX_ACCOUNT_BYTES)
-            val path = input.readBoundedUtf8(MAX_PATH_BYTES)
-            val revision = input.readBoundedUtf8(MAX_REVISION_BYTES)
-            require(input.available() == 0) { "The Windows placeholder identity has trailing data." }
-            WindowsCloudFileIdentity(accountId, path, revision, size, directory, lastModifiedEpochMillis)
-        }
-    }
-
-    private fun DataOutputStream.writeBoundedUtf8(value: String, maximumBytes: Int) {
-        val bytes = value.encodeToByteArray()
-        require(bytes.size <= maximumBytes)
-        writeShort(bytes.size)
-        write(bytes)
-    }
-
-    private fun DataInputStream.readBoundedUtf8(maximumBytes: Int): String {
-        val length = readUnsignedShort()
-        require(length <= maximumBytes && length <= available()) {
-            "The Windows placeholder identity field is invalid."
-        }
-        val bytes = ByteArray(length).also(::readFully)
-        return bytes.decodeToString(throwOnInvalidSequence = true)
-    }
-
-    private const val MAGIC = 0x4E434656 // NCFV
-    private const val VERSION = 2
-    private const val MINIMUM_SUPPORTED_VERSION = 1
-    private const val UNKNOWN_MODIFIED_TIME = -1L
-    private const val DIGEST_BYTES = 32
-    private const val MAX_ACCOUNT_BYTES = 256
-    private const val MAX_PATH_BYTES = 3_072
-    private const val MAX_REVISION_BYTES = 1_024
-    private const val MAX_IDENTITY_BYTES = 4_096
-    private const val MIN_IDENTITY_BYTES = 4 + 2 + 1 + 8 + 2 + 2 + 2 + DIGEST_BYTES
-}
 
 internal data class WindowsCloudHydrationRange(val offset: Long, val length: Int) {
     init {
@@ -1021,13 +915,12 @@ internal class WindowsCloudFilesProvider(
                 }
                 if (cancellation.get()) return@execute
                 val directory = requireIdentity(info, expectDirectory = true)
-                // CFAPI permits returning entries beyond the requested pattern. Returning the complete
-                // directory lets this transfer safely mark on-demand population as finished.
-                val identities = backend.list(directory.path)
-                    .filter { !cancellation.get() }
-                identities.forEach { identity -> knownIdentities[identity.path] = identity }
-                val placeholders = identities.map(::placeholder)
-                if (!cancellation.get()) api.completePlaceholderFetch(info, placeholders)
+                // Reconcile existing children before completing the enumeration. Sending already
+                // present names through TRANSFER_PLACEHOLDERS can leave enumeration incomplete.
+                synchronized(namespaceMutationLock) {
+                    if (!cancellation.get()) populateDirectory(directory.path, localPath(directory))
+                }
+                if (!cancellation.get()) api.completePlaceholderFetch(info, emptyList())
             } catch (_: Throwable) {
                 if (!cancellation.get()) api.failPlaceholderFetch(info)
             } finally {

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudCallbackIdentityTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudCallbackIdentityTest.kt
@@ -1,0 +1,75 @@
+package dev.obiente.nextcloudnative.app
+
+import com.sun.jna.Memory
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class WindowsCloudCallbackIdentityTest {
+    private val root = WindowsCloudFileIdentity("a".repeat(64), "", "root", 0L, true)
+
+    @Test
+    fun rootEnumerationUsesVerifiedRegistrationContextWhenItemIdentityIsAbsent() {
+        val bytes = WindowsCloudFileIdentityCodec.encode(root)
+        Memory(256).use { structure ->
+            memory(bytes).use { context ->
+                val info = CfCallbackInfo(structure).apply {
+                    fileId = 42L
+                    syncRootFileId = 42L
+                    syncRootIdentity = context
+                    syncRootIdentityLength = bytes.size
+                }
+                assertContentEquals(bytes, info.windowsCloudCallbackIdentity(true))
+                assertNull(info.windowsCloudCallbackIdentity(false))
+                info.fileId = 43L
+                assertNull(info.windowsCloudCallbackIdentity(true))
+                info.fileId = 0L
+                info.syncRootFileId = 0L
+                assertNull(info.windowsCloudCallbackIdentity(true))
+            }
+        }
+    }
+
+    @Test
+    fun itemIdentityTakesPrecedenceAndDoesNotFallBackWhenMalformed() {
+        val bytes = WindowsCloudFileIdentityCodec.encode(root.copy(path = "Folder", remoteRevision = "v1"))
+        Memory(256).use { structure ->
+            memory(bytes).use { item ->
+                val info = CfCallbackInfo(structure).apply {
+                    fileIdentity = item
+                    fileIdentityLength = bytes.size
+                }
+                assertContentEquals(bytes, info.windowsCloudCallbackIdentity(true))
+                info.fileIdentityLength = 4097
+                assertFailsWith<IllegalArgumentException> { info.windowsCloudCallbackIdentity(true) }
+                info.fileIdentityLength = -1
+                assertFailsWith<IllegalArgumentException> { info.windowsCloudCallbackIdentity(true) }
+                info.fileIdentityLength = bytes.size
+                info.fileIdentity = null
+                assertFailsWith<IllegalArgumentException> { info.windowsCloudCallbackIdentity(true) }
+            }
+        }
+    }
+
+    @Test
+    fun rootFallbackRejectsInvalidOrNonRootContext() {
+        val valid = WindowsCloudFileIdentityCodec.encode(root)
+        val child = WindowsCloudFileIdentityCodec.encode(root.copy(path = "Folder"))
+        for (bytes in listOf(valid.copyOf().apply { this[lastIndex] = 0 }, child)) {
+            Memory(256).use { structure ->
+                memory(bytes).use { context ->
+                    val info = CfCallbackInfo(structure).apply {
+                        fileId = 42L
+                        syncRootFileId = 42L
+                        syncRootIdentity = context
+                        syncRootIdentityLength = bytes.size
+                    }
+                    assertFailsWith<IllegalArgumentException> { info.windowsCloudCallbackIdentity(true) }
+                }
+            }
+        }
+    }
+
+    private fun memory(bytes: ByteArray) = Memory(bytes.size.toLong()).apply { write(0, bytes, 0, bytes.size) }
+}

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFileIdentityTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFileIdentityTest.kt
@@ -1,0 +1,68 @@
+package dev.obiente.nextcloudnative.app
+
+import java.security.MessageDigest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class WindowsCloudFileIdentityTest {
+    private val shortDirectory = WindowsCloudFileIdentity("a".repeat(64), "Dir", "\"0123456789abc\"", 0L, true)
+
+    @Test
+    fun shortItemIdentitiesUseThePaddedEnvelope() {
+        for (nameLength in 1..32) {
+            val identity = shortDirectory.copy(path = "n".repeat(nameLength))
+            val encoded = WindowsCloudFileIdentityCodec.encode(identity)
+            assertEquals(256, encoded.size)
+            assertEquals(3, encoded[5].toInt())
+            assertEquals(identity, WindowsCloudFileIdentityCodec.decode(encoded))
+        }
+    }
+
+    @Test
+    fun longerIdentitiesRoundTripWithoutTruncation() {
+        val identity = shortDirectory.copy(path = "long-" + "n".repeat(240))
+        val encoded = WindowsCloudFileIdentityCodec.encode(identity)
+        assertTrue(encoded.size > 256)
+        assertEquals(identity, WindowsCloudFileIdentityCodec.decode(encoded))
+    }
+
+    @Test
+    fun paddingIsStrictlyValidatedEvenWithARecomputedChecksum() {
+        val payload = WindowsCloudFileIdentityCodec.encode(shortDirectory).dropLast(32).toByteArray()
+        val invalid = listOf(
+            payload.copyOf().apply { this[lastIndex] = 1 },
+            payload.copyOf(payload.size - 1),
+            payload + byteArrayOf(0),
+            payload.copyOf().apply { this[5] = 4 },
+        )
+        invalid.forEach { changed ->
+            assertFailsWith<IllegalArgumentException> {
+                WindowsCloudFileIdentityCodec.decode(changed.withChecksum())
+            }
+        }
+    }
+
+    @Test
+    fun legacyItemIdentitiesStillDecode() {
+        val encoded = WindowsCloudFileIdentityCodec.encode(shortDirectory)
+        val length = 29 + 64 + 3 + 15
+        val versionTwo = encoded.copyOfRange(0, length).apply { this[5] = 2 }
+        assertEquals(shortDirectory, WindowsCloudFileIdentityCodec.decode(versionTwo.withChecksum()))
+        val versionOne = (versionTwo.copyOfRange(0, 15) + versionTwo.copyOfRange(23, versionTwo.size))
+            .apply { this[5] = 1 }
+        assertEquals(shortDirectory, WindowsCloudFileIdentityCodec.decode(versionOne.withChecksum()))
+    }
+
+    @Test
+    fun registeredRootContextRemainsByteIdentical() {
+        val root = WindowsCloudFileIdentity("a".repeat(64), "", "root", 0L, true)
+        val expected = "4e4346560002010000000000000000ffffffffffffffff00406161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616100000004726f6f74cd1caa4b0547c9a4f510bddf5f7166b33d240914ed30eea742cb24f698f1fe6e"
+            .chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+        assertContentEquals(expected, WindowsCloudFileIdentityCodec.encode(root))
+    }
+
+    private fun ByteArray.withChecksum() = this + MessageDigest.getInstance("SHA-256").digest(this)
+}

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesBrandedIntegrationTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesBrandedIntegrationTest.kt
@@ -1,0 +1,168 @@
+package dev.obiente.nextcloudnative.app
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.junit.Assume.assumeTrue
+
+/** Opt-in tests of the packaged registrar and real CFAPI, using only synthetic content. */
+class WindowsCloudFilesBrandedIntegrationTest {
+    @Test
+    fun brandedRootPopulatesHydratesAndRestarts() = exerciseRoot(seedLegacy = false)
+
+    @Test
+    fun legacyShortIdentitiesRecoverWithoutLosingLocalFiles() = exerciseRoot(seedLegacy = true)
+
+    private fun exerciseRoot(seedLegacy: Boolean) {
+        val launcher = System.getenv("NATIVE_WINDOWS_TEST_LAUNCHER")
+        assumeTrue(isWindowsDesktop() && !launcher.isNullOrBlank())
+        val account = UUID.randomUUID().toString().replace("-", "").repeat(2)
+        val fixtureBase = System.getenv("NATIVE_WINDOWS_TEST_PARENT")?.let(Path::of) ?: Path.of("build")
+        val parent = Files.createTempDirectory(Files.createDirectories(fixtureBase.toAbsolutePath()), "cloud-fixture-")
+        val root = Files.createDirectory(parent.resolve("$account-v2"))
+        val backend = FixtureBackend(account)
+        val registrar = PackagedWindowsCloudShellRegistrar(
+                launcherPath = launcher,
+                recoveryRootsProvider = { emptyMap() },
+            ).also { assertTrue(it.available) }
+        val verifiedRegistrar = object : WindowsCloudShellRegistrar by registrar {
+            override fun register(root: Path, accountId: String, displayName: String, syncRootIdentity: ByteArray): WindowsShellRegistrationResult =
+                registrar.register(root, accountId, displayName, syncRootIdentity).also {
+                    assertEquals(WindowsShellRegistrationResult.Registered, it)
+                }
+        }
+        fun api() = JnaWindowsCloudFilesApi(
+            shellRegistrar = verifiedRegistrar,
+        )
+        var provider = WindowsCloudFilesProvider(root, backend, api())
+        try {
+            if (seedLegacy) {
+                root.resolve("local-edit.txt").toFile().writeText("preserved original")
+                val nativeSeedApi = api()
+                val seedApi = object : WindowsCloudFilesApi by nativeSeedApi {
+                    override fun createPlaceholders(baseDirectory: Path, placeholders: List<WindowsCloudPlaceholder>) {
+                        nativeSeedApi.createPlaceholders(baseDirectory, placeholders.map {
+                            it.copy(identity = legacyIdentity(it.identity))
+                        })
+                    }
+                }
+                provider.close()
+                provider = WindowsCloudFilesProvider(root, backend, seedApi)
+                val failure = runCatching { provider.start() }.exceptionOrNull()
+                provider.close()
+                // Windows versions that no longer reproduce this kernel failure do not need the
+                // migration probe; the normal native lifecycle test still applies there.
+                assumeTrue(failure != null)
+                assertEquals(0x8007016b.toInt(), assertIs<WindowsCloudFilesOperationException>(failure).hResult)
+                provider = WindowsCloudFilesProvider(root, backend, api())
+            }
+            provider.start()
+            provider.recoverAfterStartup(timeoutSeconds = 10L)
+            if (seedLegacy) {
+                val preserved = requireNotNull(provider.preservedRecoveryRoot)
+                assertEquals("preserved original", preserved.resolve("local-edit.txt").toFile().readText())
+            }
+            readFixture(root)
+            provider.close()
+            val nativeApi = api()
+            var injectCorruption = true
+            val recoveryApi = object : WindowsCloudFilesApi by nativeApi {
+                override fun updatePlaceholder(path: Path, placeholder: WindowsCloudPlaceholder, invalidateContent: Boolean, preserveSyncState: Boolean) {
+                    if (injectCorruption) {
+                        injectCorruption = false
+                        throw WindowsCloudFilesOperationException("open a synthetic corrupt placeholder", 0x8007016b.toInt())
+                    }
+                    nativeApi.updatePlaceholder(path, placeholder, invalidateContent, preserveSyncState)
+                }
+            }
+            provider = WindowsCloudFilesProvider(root, backend, recoveryApi)
+            provider.start()
+            provider.recoverAfterStartup(timeoutSeconds = 10L)
+            assertTrue(provider.preservedRecoveryRoot != null)
+            readFixture(root)
+            provider.close()
+            provider = WindowsCloudFilesProvider(root, backend, api())
+            provider.start()
+            provider.recoverAfterStartup(timeoutSeconds = 10L)
+            readFixture(root)
+        } finally {
+            provider.removeSyncRoot()
+            // Both paths were created exclusively by this test under its private fixture parent.
+            assertEquals(parent, root.parent)
+            parent.toFile().deleteRecursively()
+        }
+    }
+
+    private fun legacyIdentity(encoded: ByteArray): ByteArray {
+        val identity = WindowsCloudFileIdentityCodec.decode(encoded)
+        val length = 29 + identity.accountId.encodeToByteArray().size + identity.path.encodeToByteArray().size +
+            identity.remoteRevision.encodeToByteArray().size
+        val payload = encoded.copyOfRange(0, length).apply { this[5] = 2 }
+        return payload + MessageDigest.getInstance("SHA-256").digest(payload)
+    }
+
+    private fun readFixture(root: Path) {
+        val listing = ProcessBuilder("cmd.exe", "/d", "/c", "dir", "/b", root.toString())
+            .redirectErrorStream(true).start()
+        if (!listing.waitFor(15L, TimeUnit.SECONDS)) {
+            listing.destroyForcibly()
+            error("Synthetic root enumeration timed out")
+        }
+        val names = listing.inputStream.bufferedReader().readLines()
+        assertEquals(0, listing.exitValue(), "Synthetic root enumeration failed: $names")
+        assertTrue("Documents" in names)
+
+        val observer = ProcessBuilder("cmd.exe", "/d", "/c", "dir", "/s", "/b", root.toString())
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD).start()
+        val process = ProcessBuilder("cmd.exe", "/d", "/c", "type", root.resolve("Documents/readme.txt").toString())
+            .redirectErrorStream(true).start()
+        if (!process.waitFor(15L, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            error("Synthetic Cloud Files hydration timed out")
+        }
+        assertEquals(0, process.exitValue())
+        assertContentEquals("hello".encodeToByteArray(), process.inputStream.readBytes())
+        if (!observer.waitFor(15L, TimeUnit.SECONDS)) {
+            observer.destroyForcibly()
+            error("Concurrent synthetic folder browsing timed out")
+        }
+        assertEquals(0, observer.exitValue(), "Concurrent synthetic folder browsing failed")
+    }
+
+    private class FixtureBackend(override val accountId: String) : WindowsCloudFilesBackend {
+        override val displayName = "nati.ve disposable fixture"
+        private val entries = listOf(
+            WindowsCloudFileIdentity(accountId, "Documents", "\"0123456789abc\"", 0L, true, 1_700_000_000_000L),
+            WindowsCloudFileIdentity(accountId, "Documents/readme.txt", "file-v1", 5L, false, 1_700_000_000_000L),
+        ) + (1..40).map { index ->
+            WindowsCloudFileIdentity(accountId, "F$index", "\"0123456789abc\"", 0L, true, 1_700_000_000_000L)
+        } + listOf(".hidden", ".folder", "Folder with spaces", "Album (2026)").map { name ->
+            WindowsCloudFileIdentity(accountId, name, "\"0123456789abcdef0123456789abcdef\"", 0L, true, 1_700_000_000_000L)
+        } + listOf(0L, 5L, 4096L, 5_000_000_000L, 100_000_000_000L).mapIndexed { index, size ->
+            WindowsCloudFileIdentity(accountId, "File-$index.bin", "\"0123456789abcdef0123456789abcdef\"", size, false, 1_700_000_000_000L)
+        }
+        override fun resolve(path: String) = entries.firstOrNull { it.path == path }
+        override fun list(path: String) = entries.filter { it.path.substringBeforeLast('/', "") == path }
+        override fun open(identity: WindowsCloudFileIdentity) = object : WindowsCloudFileReadHandle {
+            override val size = 5L
+            override fun read(offset: Long, length: Int) = "hello".encodeToByteArray()
+                .copyOfRange(offset.toInt(), minOf(5, offset.toInt() + length))
+            override fun close() = Unit
+        }
+        override fun upload(path: String, localFile: File, expectedRemoteRevision: String?): WindowsCloudFileIdentity =
+            error("This read fixture must not upload")
+        override fun createDirectory(path: String): WindowsCloudFileIdentity = error("Unexpected directory mutation")
+        override fun delete(identity: WindowsCloudFileIdentity) = error("Unexpected deletion")
+        override fun move(identity: WindowsCloudFileIdentity, destinationPath: String): WindowsCloudFileIdentity =
+            error("Unexpected move")
+    }
+}

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudFilesProviderTest.kt
@@ -339,7 +339,7 @@ class WindowsCloudFilesProviderTest {
             assertFalse(startup.isAlive)
             startupFailure.get()?.let { throw it }
             assertTrue(api.awaitPlaceholderFetches())
-            assertEquals(listOf("Apps"), api.completedPlaceholders.map(WindowsCloudPlaceholder::name))
+            assertEquals(listOf("Apps"), api.createdPlaceholderBatches.flatten().map(WindowsCloudPlaceholder::name).distinct())
         } finally {
             releaseCreate.countDown()
             startup.join(TimeUnit.SECONDS.toMillis(5))
@@ -1329,7 +1329,7 @@ class WindowsCloudFilesProviderTest {
     }
 
     @Test
-    fun `patterned population still transfers the complete directory`() {
+    fun `patterned population still creates the complete directory`() {
         val root = createTempDirectory("windows-cloud-pattern-")
         val directory = WindowsCloudFileIdentity("account-01", "Apps", "\"directory\"", 0L, true)
         val text = WindowsCloudFileIdentity("account-01", "Apps/readme.txt", "\"text\"", 5L, false)
@@ -1344,7 +1344,7 @@ class WindowsCloudFilesProviderTest {
         provider.fetchPlaceholders(callbackInfo(root, directory), "*.txt")
 
         assertTrue(api.awaitPlaceholderFetches())
-        assertEquals(setOf("readme.txt", "photo.jpg"), api.completedPlaceholders.map { it.name }.toSet())
+        assertEquals(setOf("readme.txt", "photo.jpg"), api.createdPlaceholderBatches.flatten().map { it.name }.toSet())
         provider.close()
     }
 

--- a/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
+++ b/ui/src/desktopTest/kotlin/dev/obiente/nextcloudnative/app/WindowsCloudShellRegistrarTest.kt
@@ -22,7 +22,7 @@ class WindowsCloudShellRegistrarTest {
         val root = installation.resolve("Cloud root; still one argument").toPath().createDirectories()
         val accountId = "a5".repeat(32)
         var invocation = emptyList<String>()
-        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { command, timeout ->
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath, recoveryRootsProvider = { emptyMap() }) { command, timeout ->
             invocation = command
             assertEquals(30L, timeout)
             0
@@ -103,7 +103,7 @@ class WindowsCloudShellRegistrarTest {
         val installation = createTempDirectory("nextcloud-shell-missing").toFile()
         val launcher = installation.resolve("NextcloudNative.exe").apply { writeText("launcher") }
         var invoked = false
-        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { _, _ ->
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath, recoveryRootsProvider = { emptyMap() }) { _, _ ->
             invoked = true
             0
         }
@@ -125,7 +125,7 @@ class WindowsCloudShellRegistrarTest {
         val root = installation.resolve("Cloud root").toPath().createDirectories()
         val accountId = "b6".repeat(32)
         val invocations = mutableListOf<List<String>>()
-        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { command, _ ->
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath, recoveryRootsProvider = { emptyMap() }) { command, _ ->
             invocations += command
             if (command[1] == "register") WINDOWS_SHELL_OWNED_PATH_CONFLICT_EXIT_CODE else 0
         }
@@ -155,7 +155,7 @@ class WindowsCloudShellRegistrarTest {
         val root = installation.resolve("Cloud root").toPath().createDirectories()
         val accountId = "b7".repeat(32)
         var exitCode = WINDOWS_SHELL_REGISTRATION_NOT_FOUND_EXIT_CODE
-        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath) { _, _ -> exitCode }
+        val registrar = PackagedWindowsCloudShellRegistrar(launcher.absolutePath, recoveryRootsProvider = { emptyMap() }) { _, _ -> exitCode }
 
         assertEquals(WindowsShellUnregistrationResult.NotFound, registrar.unregister(root, accountId))
         exitCode = WINDOWS_SHELL_UNSAFE_CONFLICT_EXIT_CODE

--- a/website/content/guides/windows-cloud-files.md
+++ b/website/content/guides/windows-cloud-files.md
@@ -8,14 +8,14 @@ device: Desktop
 platforms: Windows
 durationMinutes: 9
 difficulty: Advanced
-lastUpdated: 2026-09-05
+lastUpdated: 2026-09-06
 captureScenarios: guide-windows-cloud-files-settings, guide-windows-cloud-files-storage, guide-windows-cloud-files-recovery
 prerequisites: A connected Windows x86-64 alpha installation, A disposable test folder in Nextcloud, Enough local storage to hydrate the files you open
 ---
 
 # Use Nextcloud files in Windows File Explorer
 
-**Last reviewed: 2026-09-05.** The software and published packages may have
+**Last reviewed: 2026-09-06.** The software and published packages may have
 changed since this review. Check the [current releases](https://github.com/obiente/native/releases)
 and [compatibility notes](/compatibility/) before using this guide with important data.
 
@@ -31,6 +31,8 @@ Open **Settings**, choose **Sync & storage**, then open **Virtual files**. Activ
 If activation fails, keep the failure message and retry only after checking that the app is the current installed version. The app keeps a failed automatic activation visible instead of retrying it on every settings refresh. Use the explicit activation action when you are ready to retry. Do not manually delete a registered sync root or copy provider metadata between accounts. Recovery handles stale registrations, legacy roots, and damaged Cloud Files metadata while preserving the existing local root and its data.
 
 An older build can report **Windows refused to safely unregister the branded Cloud Files root** during recovery. The source includes a fix for saved registrations whose provider identifier is empty: recovery verifies the saved account identity and path before proceeding. Check the release notes for a build containing this fix, then restart the installed app and retry activation. Do not delete the folder or edit the Windows registration to bypass the check. This recovery fix does not establish that all Windows sync or writeback scenarios are qualified.
+
+The source also includes a fix for **Could not open a Windows Cloud Files placeholder for update (HRESULT 0x8007016b)** when short folder identities produce damaged placeholder metadata. Recovery preserves the old local root and creates replacement placeholders. This fix has passed local Windows tests with disposable data, including recovery and opening files; check release notes for a published build containing it. Keep any preserved recovery folder until its local files have been reviewed. A related root-enumeration fix addresses Explorer reporting **The cloud operation was unsuccessful** even while the app reports **Connected**; connection status alone does not verify that browsing works.
 
 The storage view distinguishes **Not connected**, **Connected**, and
 **Edits need review**. An available integration is not proof that the provider


### PR DESCRIPTION
## Outcome

Fixes Windows Cloud Files activation failures for short directory identities and Explorer root browsing that fails while the app reports Connected.

- Pad version 3 item identities while retaining legacy readers and the byte-identical version 2 registration context.
- Accept validated root registration context for root enumeration callbacks, then reconcile children before completing enumeration.
- Add real CFAPI regression coverage for creation, browsing, hydration, preserved local files, recovery, and restart.
- Isolate registrar tests from saved account preferences and fix Windows portability of the text-scanner and Bash manifest fixtures. Document symbolic-link privileges and Linux packaging prerequisites.

Closes #449.

## Verification

- Full Windows desktop suite: 3,185 tests, zero failures/errors, 65 existing skips. All eight previously failing symlink-dependent tests passed with the required process privilege; no assertions were disabled.
- Windows Cloud Files tests: 103 tests, zero failures/skips, including real CFAPI registration, enumeration, hydration, and recovery fixtures.
- Windows distributable and MSI built; package verification passed (local unsigned package).
- Installed patch verified locally: root and subfolder browsing and an existing small-file read succeeded after restart. Preserved recovery folders were retained.
- Website locked dependency installation and full build passed, including tests, capture checks, client/SSR build, and 32 prerendered routes.
- Windows manifest compatibility test passed after launching Bash explicitly and normalizing shell paths. Native text-hygiene fixture passed after MSYS stdin path conversion.
- Full repository hygiene check passed on the Ubuntu PR runner, including the real Debian packaging fixture: [CI run](https://github.com/Obiente/native/actions/runs/34004137984).
- Kotlin architecture checks passed locally. Full PR build jobs are still running; their status is visible on this PR.

## Compatibility and risk

Tested on Windows 11 build 26200 with JDK 21. Version 3 item identities are not readable by older binaries; root registration bytes remain unchanged. Recovery preserves the previous local folder for review. This does not qualify every writeback, crash-recovery, or server-version scenario for general support.

The complete filesystem safety suite requires symbolic-link privileges on Windows; the assertions remain enabled. Local diagnostics, account data, and captures are excluded.

## Visual changes

Not applicable; this changes Cloud Files behavior and contributor guidance.
