### PR TITLE
fix(packaging): use nati.ve for installed app names

### DIFF
--- a/PLATFORMS.md
+++ b/PLATFORMS.md
@@ -174,3 +174,20 @@ that operating system.
 
 The dependency order and acceptance gates are defined in
 [ROADMAP.md](ROADMAP.md), especially the platform productization milestone.
+
+## Installed display names
+
+Android's application label is `nati.ve`. Linux launcher and AppStream names are
+`nati.ve`, including the launcher rewritten into Debian packages. macOS packages
+use `nati.ve.app` and the `nati.ve` Dock name. Windows product and shortcut names
+are described in [Windows release packaging](docs/windows-release.md#installed-application-name).
+
+The Android application ID, Linux package and desktop-file IDs, persisted data
+paths, and Windows upgrade identity remain unchanged. These are compatibility
+identifiers, independent of the displayed brand. On macOS, remove the previous
+`NextcloudNative.app` after installing `nati.ve.app` to avoid keeping two app
+bundles; the DMG does not migrate an existing bundle automatically.
+
+These names describe source packaging configuration, not confirmation that a
+release containing it has been published. Check the
+[release artifacts](https://github.com/Obiente/native/releases) for availability.

--- a/changes/unreleased/451-platform-app-names.md
+++ b/changes/unreleased/451-platform-app-names.md
@@ -1,0 +1,7 @@
+category: fix
+issue: 451
+pull: none
+platforms: linux, macos, windows
+user-facing: yes
+
+Installed Windows product and shortcut names, Debian launcher names, and macOS application and Dock names now use nati.ve while retaining existing update and data identities.

--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -167,3 +167,18 @@ publicly trusted signing service is adopted, update the verifier, deep-sign
 project-owned executable content before packaging, sign the MSI last, retain
 RFC 3161 timestamps, and remove the unsigned-install disclosure only after the
 published artifact verifies successfully on a clean Windows installation.
+
+## Installed application name
+
+The MSI product name, launcher description, desktop shortcut, and Start menu
+shortcut are `nati.ve`.
+The package verifier checks both shortcuts as well as the product name. The
+packaging step applies display metadata before artifact verification and
+attestation. WinGet uses the branded MSI display name for installed-app matching.
+
+The `NextcloudNative.exe` launcher, installation directory, MSI upgrade UUID,
+and `Obiente.NextcloudNative` WinGet identifier remain stable so existing update,
+startup, and Explorer registrations keep resolving the same installation.
+Artifact filenames also retain the legacy Windows name. A newly built installer
+is required to update installed display metadata; replacing the app JAR alone
+does not rename existing shortcuts or the Windows installed-app entry.

--- a/tools/create-winget-manifests.ps1
+++ b/tools/create-winget-manifests.ps1
@@ -83,7 +83,7 @@ $publisher = Read-MsiProperty -Name "Manufacturer"
 $productCode = Read-MsiProperty -Name "ProductCode"
 $upgradeCode = Read-MsiProperty -Name "UpgradeCode"
 
-if ($productName -ne "NextcloudNative") {
+if ($productName -ne "nati.ve") {
     throw "Unexpected Windows product name: $productName"
 }
 if ($publisher -ne "Obiente") {

--- a/tools/enrich-deb-appstream.sh
+++ b/tools/enrich-deb-appstream.sh
@@ -54,6 +54,7 @@ mapfile -d '' desktop_entries < <(
 [[ "${#desktop_entries[@]}" -eq 1 ]]
 desktop_entry="${desktop_entries[0]}"
 sed -i \
+    -e 's|^Name=.*|Name=nati.ve|' \
     -e 's|^Comment=.*|Comment=One native client for your complete Nextcloud account|' \
     -e 's|^Categories=.*|Categories=Network;FileTransfer;Utility;|' \
     -e 's|^Icon=.*|Icon=dev.obiente.nextcloudnative|' \

--- a/tools/release-download-table.mjs
+++ b/tools/release-download-table.mjs
@@ -17,7 +17,7 @@ const packageRows = [
     ],
   },
   { platform: "Windows", formats: [{ label: "MSI (x86-64)", pattern: /^NextcloudNative-.*\.msi$/ }] },
-  { platform: "macOS preview", formats: [{ label: "DMG (Intel)", pattern: /^NextcloudNative-.*\.dmg$/ }] },
+  { platform: "macOS preview", formats: [{ label: "DMG (Intel)", pattern: /^(?:NextcloudNative|nati\.ve)-.*\.dmg$/ }] },
 ];
 
 function fail(message) {

--- a/tools/release-download-table.test.mjs
+++ b/tools/release-download-table.test.mjs
@@ -51,3 +51,12 @@ test("release download table replacement rejects a missing marker", () => {
     /do not contain a quick-download table/,
   );
 });
+
+test("release download table accepts branded macOS packages", () => {
+  const table = composeReleaseDownloadTable({
+    assetNames: ["nati.ve-1.2.3.dmg"],
+    repository: "Obiente/native",
+    tag: "v0.2.0-alpha.1",
+  });
+  assert.match(table, /\[DMG \(Intel\)\]\(https:\/\/github\.com\/Obiente\/native\/releases\/download\/v0\.2\.0-alpha\.1\/nati\.ve-1\.2\.3\.dmg\)/);
+});

--- a/tools/repackage-msi-with-uninstall-cleanup.ps1
+++ b/tools/repackage-msi-with-uninstall-cleanup.ps1
@@ -189,3 +189,5 @@ $rebuilt = @(Get-ChildItem -LiteralPath $PackageDirectory -Filter "*.msi" -File)
 if ($rebuilt.Count -ne 1) {
     throw "Expected exactly one rebuilt MSI package, found $($rebuilt.Count)."
 }
+
+& (Join-Path $PSScriptRoot "set-windows-package-display-name.ps1") -Package $rebuilt[0].FullName

--- a/tools/set-windows-package-display-name.ps1
+++ b/tools/set-windows-package-display-name.ps1
@@ -1,0 +1,52 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Package
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Change display metadata before signing/attestation without changing launcher or upgrade IDs.
+$installer = New-Object -ComObject WindowsInstaller.Installer
+$database = $installer.OpenDatabase((Resolve-Path -LiteralPath $Package).Path, 1)
+try {
+    $view = $database.OpenView('SELECT `Value` FROM `Property` WHERE `Property` = ''ProductName''')
+    try {
+        $view.Execute()
+        $row = $view.Fetch()
+        if ($null -eq $row -or $row.StringData(1) -ne "NextcloudNative") {
+            throw "Expected the unbranded jpackage product before applying display metadata."
+        }
+    } finally { $view.Close() }
+
+    $view = $database.OpenView('SELECT `Shortcut`, `Name` FROM `Shortcut`')
+    $shortcutIds = [System.Collections.Generic.List[string]]::new()
+    try {
+        $view.Execute()
+        while ($null -ne ($row = $view.Fetch())) {
+            if (($row.StringData(2) -split '\|')[-1] -ne "NextcloudNative") {
+                throw "Unexpected shortcut name in the generated Windows package."
+            }
+            $shortcutId = $row.StringData(1)
+            if ($shortcutId -notmatch '^[A-Za-z_][A-Za-z0-9_.]*$') {
+                throw "Unexpected MSI shortcut identity."
+            }
+            $shortcutIds.Add($shortcutId)
+        }
+    } finally { $view.Close() }
+    if ($shortcutIds.Count -ne 2) {
+        throw "Expected both desktop and Start menu shortcuts."
+    }
+    $queries = @('UPDATE `Property` SET `Value` = ''nati.ve'' WHERE `Property` = ''ProductName''')
+    foreach ($shortcutId in $shortcutIds) {
+        $queries += "UPDATE ``Shortcut`` SET ``Name`` = 'nati.ve' WHERE ``Shortcut`` = '$shortcutId'"
+    }
+    foreach ($query in $queries) {
+        $view = $database.OpenView($query)
+        try { $view.Execute() } finally { $view.Close() }
+    }
+    $database.Commit()
+} finally {
+    [System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($database) | Out-Null
+    [System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($installer) | Out-Null
+}

--- a/tools/test-linux-package-metadata.sh
+++ b/tools/test-linux-package-metadata.sh
@@ -110,7 +110,7 @@ EOF
 cat >"$deb_root/opt/nextcloudnative/lib/app/nextcloudnative-NextcloudNative.desktop" <<'EOF'
 [Desktop Entry]
 Type=Application
-Name=nati.ve
+Name=NextcloudNative
 Comment=Test package
 Categories=Network;
 Icon=nextcloudnative-NextcloudNative
@@ -123,6 +123,9 @@ bash "$project_root/tools/enrich-deb-appstream.sh" \
   "$rendered_metadata" \
   "$project_root/LICENSE" \
   "$project_root/website/public/icon-512.png" >/dev/null
+dpkg-deb --extract "$deb_directory/nextcloudnative_1.0.2971_amd64.deb" "$temporary/branded-deb"
+grep -Fxq 'Name=nati.ve' \
+  "$temporary/branded-deb/usr/share/applications/nextcloudnative-NextcloudNative.desktop"
 deb_dependencies="$(
   dpkg-deb --field "$deb_directory/nextcloudnative_1.0.2971_amd64.deb" Depends
 )"

--- a/tools/verify-windows-package.ps1
+++ b/tools/verify-windows-package.ps1
@@ -59,13 +59,17 @@ function Read-MsiProperty {
     }
 }
 
-function Read-MsiFileNames {
+function Read-MsiNames {
+    param(
+        [ValidateSet("File", "Shortcut")][string]$Table,
+        [ValidateSet("FileName", "Name")][string]$Column
+    )
     $view = $database.GetType().InvokeMember(
         "OpenView",
         "InvokeMethod",
         $null,
         $database,
-        @("SELECT ``FileName`` FROM ``File``")
+        @("SELECT ``$Column`` FROM ``$Table``")
     )
     try {
         $view.GetType().InvokeMember("Execute", "InvokeMethod", $null, $view, $null) | Out-Null
@@ -97,7 +101,7 @@ $productVersion = Read-MsiProperty -Name "ProductVersion"
 $manufacturer = Read-MsiProperty -Name "Manufacturer"
 $upgradeCode = Read-MsiProperty -Name "UpgradeCode"
 
-if ($productName -ne "NextcloudNative") {
+if ($productName -ne "nati.ve") {
     throw "Unexpected Windows product name: $productName"
 }
 if ($productVersion -ne $ExpectedVersion) {
@@ -111,11 +115,16 @@ if ($upgradeCode.ToUpperInvariant() -ne $expectedUpgradeCode) {
     throw "Unexpected Windows upgrade identity."
 }
 
-$packagedFiles = @(Read-MsiFileNames)
+$packagedFiles = @(Read-MsiNames -Table File -Column FileName)
 foreach ($requiredFile in @("NextcloudNativeShellRegistrar.exe", "NextcloudNative.ico")) {
     if ($requiredFile -notin $packagedFiles) {
         throw "The Windows MSI does not contain $requiredFile."
     }
+}
+
+$shortcuts = @(Read-MsiNames -Table Shortcut -Column Name)
+if ($shortcuts.Count -ne 2 -or @($shortcuts | Where-Object { $_ -ne "nati.ve" }).Count -ne 0) {
+    throw "The desktop and Start menu shortcuts must both be named nati.ve."
 }
 
 $signature = Get-AuthenticodeSignature -LiteralPath $package.FullName

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -257,9 +257,15 @@ compose.desktop {
         nativeDistributions {
             modules("jdk.security.auth")
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm)
-            packageName = "NextcloudNative"
+            // Preserve Windows/Linux launcher paths used by existing integrations.
+            packageName = if (System.getProperty("os.name").startsWith("Mac")) "nati.ve" else "NextcloudNative"
             packageVersion = ncDesktopPackageVersion
-            description = "One native client for your complete Nextcloud account"
+            // Windows uses the launcher description as its friendly process name.
+            description = if (System.getProperty("os.name").startsWith("Windows")) {
+                "nati.ve"
+            } else {
+                "One native client for your complete Nextcloud account"
+            }
             vendor = "Obiente"
             copyright = "Copyright 2026 Obiente"
             licenseFile.set(rootProject.file("LICENSE"))
@@ -278,6 +284,8 @@ compose.desktop {
                 upgradeUuid = "81237d85-c511-47a7-b8dc-c87a5f5c5823"
             }
             macOS {
+                packageName = "nati.ve"
+                dockName = "nati.ve"
                 packageVersion = ncMacosPackageVersion
             }
         }
@@ -320,6 +328,7 @@ val repackageRpmWithMetadata by tasks.registering(Exec::class) {
 val repackageMsiWithUninstallCleanup by tasks.registering(Exec::class) {
     dependsOn(stageWindowsShellAssets)
     inputs.file(rootProject.file("tools/repackage-msi-with-uninstall-cleanup.ps1"))
+    inputs.file(rootProject.file("tools/set-windows-package-display-name.ps1"))
     doNotTrackState("Rebuilds the packageMsi artifact with an uninstall cleanup action.")
     onlyIf {
         System.getProperty("os.name").startsWith("Windows", ignoreCase = true) &&

--- a/website/public/screenshots/capture-manifest.json
+++ b/website/public/screenshots/capture-manifest.json
@@ -422,7 +422,7 @@
         "gradle/wrapper/gradle-wrapper.properties": "aef287d114ce3153c3d535697a61928f5034990d570cbb2e93df549e9671483d",
         "settings.gradle.kts": "0acbe4b907815189abfedb2256c8659558e5a7e6995a3681a2bdfb05e335fd1a",
         "tools/marketing-capture-inputs.txt": "3c96e83e1ba2d715b1cda9cedf036fc97b78c3ca63b7fc930325ed536940c1f3",
-        "ui/build.gradle.kts": "43613c2ad7f2801f421f1d2638c0b1751c51377a2f897c70ae16a8efe1fe9e64",
+        "ui/build.gradle.kts": "2ecda1dd8c3ea78d3249c6c562cf8338a9a89f56dbd91d2db1af6b27eee8fb72",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/AccountSettingsScreen.kt": "7b93d571553fa8c364681f172edecde3109b45db9a4ff6f9f6fb12f8f6280a0e",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ActivityFilters.kt": "569265895b9442292c043f5ecbe2cdd55a9da6761a77b19b5f81fff34e999a10",
         "ui/src/commonMain/kotlin/dev/obiente/nextcloudnative/app/ActivityHistoryPresentation.kt": "88f25cd079f7d7fc1553f8969818740816e2788542b70377ea11f64201c44474",


### PR DESCRIPTION
Windows still displayed NextcloudNative in its installed-app entry and shortcuts, and Debian package enrichment left the generated launcher name unchanged. Use nati.ve for those names and the Windows launcher description. Configure macOS to produce nati.ve.app with a nati.ve Dock name and recognize the branded DMG in release download tables. Android and RPM launcher labels already use nati.ve.

The Windows executable path, installation directory, MSI upgrade UUID, WinGet identifier, Android application ID, and Linux package/desktop IDs remain unchanged. Display metadata is applied before verification and attestation.

Validation:
- Full Windows :ui:packageMsi build passed with JDK 21.
- Actual MSI product name and both shortcut names verified as nati.ve; existing upgrade UUID and shell assets verified.
- Actual launcher FileDescription verified as nati.ve.
- WinGet manifest generation passed using the rebuilt MSI.
- Release download-table and nightly-note tests, nightly packaging workflow checks, changelog validation, and Markdown link checks passed.
- Debian regression starts with a legacy launcher name and checks the extracted package for nati.ve. The complete repository hygiene check passed on the Ubuntu PR runner: https://github.com/Obiente/native/actions/runs/34005582182.
- macOS packaging configuration changed, but a macOS artifact was not built on this Windows host. Android production and development labels were inspected and are already branded.

Existing Windows installations need the new installer; a JAR-only patch cannot rename installed shortcuts. macOS users should remove the old NextcloudNative.app after installing nati.ve.app to avoid duplicate bundles. This PR does not publish a release or modify the locally installed application.

Closes #451.
